### PR TITLE
Refactor: Define version as constant and bump to 0.3.0

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// Version is the current version of coi
+	Version = "0.3.0"
+)
+
 var (
 	// Global flags
 	workspace       string
@@ -38,7 +43,7 @@ Examples:
   coi images                   # List available images
   coi list                     # List active sessions
 `,
-	Version: "0.2.0",
+	Version: Version,
 	// When called without subcommand, run shell command
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Execute shell command with the same args
@@ -110,7 +115,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("claude-on-incus (coi) v0.2.0")
+		fmt.Printf("claude-on-incus (coi) v%s\n", Version)
 		fmt.Println("https://github.com/mensfeld/claude-on-incus")
 	},
 }


### PR DESCRIPTION
## Summary

Refactors version management to use a constant instead of hardcoded strings, and bumps version from 0.2.0 to 0.3.0.

## Changes

1. **Added Version constant**
   - Defined at package level: `const Version = "0.3.0"`
   - Single source of truth for version number

2. **Updated all version references**
   - `rootCmd.Version` now uses `Version` constant
   - `versionCmd` output uses `Version` with `fmt.Printf`

3. **Bumped version to 0.3.0**
   - Reflects completed features in 0.3.0 release:
     - Machine-readable output formats (`--format=json`, `--format=raw`)
     - Power management wrapper scripts
     - CLI-agnostic refactoring (Phase 1)

## Benefits

- ✅ **Single source of truth** - version defined in one place
- ✅ **Easy to update** - change constant value affects all outputs
- ✅ **Prevents mismatches** - impossible to have version inconsistencies
- ✅ **More maintainable** - clearer intent and easier code maintenance

## Tests

✅ **Version tests are version-agnostic**:
- `tests/version/version_format_validation.py` - checks format with regex `v\d+\.\d+\.\d+`
- `tests/version/version_no_network_required.py` - checks for presence of "v" but not specific version

Both tests will pass with 0.3.0 without any changes needed.

## Test Output

```bash
$ ./coi version
claude-on-incus (coi) v0.3.0
https://github.com/mensfeld/claude-on-incus

$ ./coi --version
coi version 0.3.0
```

## Future Updates

To update the version in the future, simply change the `Version` constant in `internal/cli/root.go`:
```go
const (
    Version = "0.4.0"  // Change here only
)
```