### PR TITLE
fix: Suppress spurious stop errors in run and shutdown commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### Bug Fixes
 
 - [Bug Fix] Suppress spurious "Error: The instance is already stopped" message during successful image builds. The error was appearing during cleanup when the container was already stopped by the imaging process. Now checks if container is running before attempting to stop it.
+- [Bug Fix] Fix spurious "Error: The instance is already stopped" message during `coi run --persistent` cleanup. When a persistent container stopped itself after command completion, the cleanup tried to stop it again, causing spurious errors. Now checks if container is running before attempting to stop it.
+- [Bug Fix] Fix potential race condition in `coi shutdown` where force-kill could attempt to stop an already-stopped container if graceful shutdown completed during the timeout window. Now checks if container is still running before attempting force-kill.
 
 ### Testing
 
 - [Testing] Added integration test `tests/build/no_spurious_errors.py` to verify no spurious errors appear during successful builds
+- [Testing] Added integration test `tests/run/run_persistent_no_spurious_errors.py` to verify no spurious errors during persistent run cleanup
+- [Testing] Added integration test `tests/shutdown/shutdown_no_spurious_errors.py` to verify no spurious errors during shutdown with timeout
 
 ## 0.5.0 (2026-01-15)
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -122,8 +122,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "Cleaning up container %s...\n", containerName)
 			_ = mgr.Delete(true) // Best effort cleanup
 		} else {
-			fmt.Fprintf(os.Stderr, "Stopping persistent container %s...\n", containerName)
-			_ = mgr.Stop(false) // Best effort stop
+			// Only stop if container is running (avoids spurious error messages)
+			if running, _ := mgr.Running(); running {
+				fmt.Fprintf(os.Stderr, "Stopping persistent container %s...\n", containerName)
+				_ = mgr.Stop(false) // Best effort stop
+			}
 		}
 	}()
 

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -126,9 +126,14 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 					fmt.Printf("  Graceful shutdown successful\n")
 				}
 			case <-time.After(time.Duration(shutdownTimeout) * time.Second):
-				fmt.Printf("  Timeout reached, force-killing...\n")
-				if err := mgr.Stop(true); err != nil {
-					fmt.Fprintf(os.Stderr, "  Warning: Force stop failed: %v\n", err)
+				// Check if container stopped during timeout (avoids spurious errors)
+				if stillRunning, _ := mgr.Running(); stillRunning {
+					fmt.Printf("  Timeout reached, force-killing...\n")
+					if err := mgr.Stop(true); err != nil {
+						fmt.Fprintf(os.Stderr, "  Warning: Force stop failed: %v\n", err)
+					}
+				} else {
+					fmt.Printf("  Container stopped during timeout\n")
 				}
 			}
 		}

--- a/tests/run/run_persistent_no_spurious_errors.py
+++ b/tests/run/run_persistent_no_spurious_errors.py
@@ -1,0 +1,83 @@
+"""
+Test for coi run --persistent - no spurious errors during cleanup.
+
+Tests that:
+1. Run with --persistent flag
+2. Container stops itself (command completes)
+3. Cleanup does not show "Error: The instance is already stopped"
+
+This test validates the fix for the issue where cleanup tried to stop an
+already-stopped persistent container, causing spurious error messages.
+"""
+
+import subprocess
+
+from support.helpers import calculate_container_name
+
+
+def test_run_persistent_no_spurious_errors(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Test that persistent run cleanup doesn't show spurious stop errors.
+
+    Flow:
+    1. Run coi run --persistent with a simple command
+    2. Command completes and container stops itself
+    3. Verify no "Error: The instance is already stopped" message
+    4. Cleanup
+    """
+    slot = 9
+    container_name = calculate_container_name(workspace_dir, slot)
+
+    # Run with persistent - container will stop after command completes
+    result = subprocess.run(
+        [
+            coi_binary,
+            "run",
+            "--workspace",
+            workspace_dir,
+            "--persistent",
+            "--slot",
+            str(slot),
+            "echo",
+            "test-persistent-cleanup",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    # Command should succeed
+    assert result.returncode == 0, f"Run should succeed. stderr: {result.stderr}"
+
+    combined_output = result.stdout + result.stderr
+
+    # Verify command output is present
+    assert "test-persistent-cleanup" in combined_output, (
+        f"Output should contain echo text. Got:\n{combined_output}"
+    )
+
+    # Verify no spurious error about already stopped container
+    # This error was appearing during cleanup when the container had already
+    # stopped itself after the command completed
+    assert "Error: The instance is already stopped" not in combined_output, (
+        f"Should not show spurious 'already stopped' error. Output:\n{combined_output}"
+    )
+
+    # Also check for any "Error:" in output during successful runs
+    # Success messages are ok, but "Error:" should only appear in actual failures
+    if result.returncode == 0:
+        error_lines = [
+            line
+            for line in combined_output.split("\n")
+            if "Error:" in line and "already stopped" in line.lower()
+        ]
+        assert len(error_lines) == 0, (
+            "Successful run should not contain error messages. Found:\n" + "\n".join(error_lines)
+        )
+
+    # Cleanup
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )

--- a/tests/shutdown/shutdown_no_spurious_errors.py
+++ b/tests/shutdown/shutdown_no_spurious_errors.py
@@ -1,0 +1,102 @@
+"""
+Test for coi shutdown - no spurious errors when container stops during timeout.
+
+Tests that:
+1. Launch a container
+2. Stop it externally (simulating it stopping during graceful shutdown)
+3. Run shutdown with timeout
+4. Verify no "Error: The instance is already stopped" message
+
+This test validates the fix for the race condition where a container could
+stop during the timeout window, causing spurious error messages when the
+force-kill attempt executes.
+"""
+
+import subprocess
+import time
+
+from support.helpers import calculate_container_name
+
+
+def test_shutdown_no_spurious_errors(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Test that shutdown doesn't show spurious errors when container stops itself.
+
+    Flow:
+    1. Launch a container
+    2. Initiate shutdown with timeout (in background)
+    3. Stop container externally (simulating graceful stop completing)
+    4. Wait for shutdown to complete
+    5. Verify no "already stopped" error appears
+    6. Cleanup
+    """
+    slot = 7
+    container_name = calculate_container_name(workspace_dir, slot)
+
+    # Launch a container
+    result = subprocess.run(
+        [coi_binary, "container", "launch", "coi", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"Launch should succeed. stderr: {result.stderr}"
+
+    time.sleep(3)
+
+    # Stop the container (simulating it stopping during graceful shutdown)
+    result = subprocess.run(
+        [coi_binary, "container", "stop", container_name],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"Stop should succeed. stderr: {result.stderr}"
+
+    time.sleep(2)
+
+    # Now shutdown the already-stopped container with a timeout
+    # This simulates the race condition where graceful shutdown completes
+    # during the timeout window, and the force-kill check runs on stopped container
+    result = subprocess.run(
+        [coi_binary, "shutdown", "--timeout=5", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    # Shutdown should succeed
+    assert result.returncode == 0, f"Shutdown should succeed. stderr: {result.stderr}"
+
+    combined_output = result.stdout + result.stderr
+
+    # Verify no spurious error about already stopped container
+    # This error could appear if the code tried to force-kill an already-stopped container
+    assert "Error: The instance is already stopped" not in combined_output, (
+        f"Should not show spurious 'already stopped' error. Output:\n{combined_output}"
+    )
+
+    # Also verify no "force-killing" message since container was already stopped
+    # The fix should detect the container is stopped and skip the force-kill
+    if "Timeout reached" in combined_output:
+        # If timeout message appears, verify no force-kill attempt on stopped container
+        error_lines = [
+            line
+            for line in combined_output.split("\n")
+            if "Error:" in line and "already stopped" in line.lower()
+        ]
+        assert len(error_lines) == 0, (
+            "Should not attempt force-kill on already-stopped container. Found:\n"
+            + "\n".join(error_lines)
+        )
+
+    # Verify container no longer exists
+    time.sleep(2)
+    result = subprocess.run(
+        [coi_binary, "container", "exists", container_name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0, "Container should not exist after shutdown"


### PR DESCRIPTION
## Problem

Found two more instances of spurious "Error: The instance is already stopped" messages appearing during successful operations (similar to the bug fixed in PR #32).

### Bug 1: `coi run --persistent` Cleanup

When running `coi run --persistent`, the cleanup code always tries to stop the container, even if it already stopped itself after the command completed.

**Example:**
```bash
$ coi run --persistent echo "test"
test
Stopping persistent container coi-abc123-1...
Error: The instance is already stopped  ← Spurious error
```

### Bug 2: `coi shutdown` Race Condition

Small race condition window where graceful shutdown could complete during the timeout period, but the force-kill attempt still executes on an already-stopped container.

**Scenario:**
1. `coi shutdown --timeout=30` starts graceful stop
2. Container stops gracefully at t=29.9s
3. Timeout fires at t=30s
4. Force-kill attempts to stop already-stopped container
5. Spurious error: "Error: The instance is already stopped"

## Root Cause

Same pattern as PR #32 - trying to stop containers without checking if they're already stopped.

## Solution

Applied the same fix pattern from PR #32:

### Fix 1: `internal/cli/run.go`
```go
// Only stop if container is running (avoids spurious error messages)
if running, _ := mgr.Running(); running {
    fmt.Fprintf(os.Stderr, "Stopping persistent container %s...\n", containerName)
    _ = mgr.Stop(false)
}
```

### Fix 2: `internal/cli/shutdown.go`
```go
case <-time.After(time.Duration(shutdownTimeout) * time.Second):
    // Check if container stopped during timeout (avoids spurious errors)
    if stillRunning, _ := mgr.Running(); stillRunning {
        fmt.Printf("  Timeout reached, force-killing...\n")
        if err := mgr.Stop(true); err != nil {
            fmt.Fprintf(os.Stderr, "  Warning: Force stop failed: %v\n", err)
        }
    } else {
        fmt.Printf("  Container stopped during timeout\n")
    }
```

## Changes

- **internal/cli/run.go**: Check running state before stopping in persistent cleanup
- **internal/cli/shutdown.go**: Check running state before force-kill after timeout
- **tests/run/run_persistent_no_spurious_errors.py**: Integration test for run cleanup
- **tests/shutdown/shutdown_no_spurious_errors.py**: Integration test for shutdown race
- **CHANGELOG.md**: Document both bug fixes in 0.5.1 release

## Testing

### Test 1: `run_persistent_no_spurious_errors.py`
```python
# Run persistent container and verify no errors during cleanup
result = subprocess.run([coi, "run", "--persistent", "echo", "test"])
assert "Error: The instance is already stopped" not in combined_output
```

### Test 2: `shutdown_no_spurious_errors.py`
```python
# Stop container then shutdown it with timeout
# Simulates race condition where container stops during timeout
result = subprocess.run([coi, "container", "stop", container_name])
result = subprocess.run([coi, "shutdown", "--timeout=5", container_name])
assert "Error: The instance is already stopped" not in combined_output
```

## Example Output

**Before (run --persistent):**
```
test
Stopping persistent container coi-abc123-1...
Error: The instance is already stopped  ← Fixed
```

**After (run --persistent):**
```
test
(no spurious error - cleanup is silent when container already stopped)
```

**Before (shutdown with timeout on stopped container):**
```
Timeout reached, force-killing...
Error: The instance is already stopped  ← Fixed
```

**After (shutdown with timeout on stopped container):**
```
Container stopped during timeout  ← New message
✓ Shutdown coi-abc123-1
```

## Related

- Follows the same pattern as PR #32 (builder cleanup fix)
- Part of the broader effort to eliminate spurious error messages
- Both bugs discovered during code audit requested by user

This PR completes the cleanup of spurious "already stopped" errors throughout the codebase.