### PR TITLE
docs: Add macOS/Colima --network=open guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Enhancements
 
+- [Enhancement] **macOS/Colima documentation and UX improvements** - Updated README with clearer instructions for running COI on macOS via Colima/Lima VMs. Added explicit guidance that `--network=open` is required since Colima/Lima VMs don't include firewalld by default. Documented how to set open network mode as default in config file. Added more detailed setup steps including Colima VM resource allocation and complete installation flow inside the VM. Added warning message when running in open mode without firewalld available to inform users about lack of network isolation.
 - [Enhancement] **Update Claude CLI installation to native method** - Replaced deprecated npm installation (`npm install -g @anthropic-ai/claude-code`) with the official native installer (`curl -fsSL https://claude.ai/install.sh | bash`). Anthropic moved away from npm releases as of 2025, making the native installation method the recommended approach. The installer runs as the `code` user and installs to `~/.local/bin/claude` with a global symlink at `/usr/local/bin/claude`. Added verification to ensure the binary exists before creating symlink, preventing broken installations. Users must rebuild the base image with `coi build --force` to get the updated installation method. (#82)
 ### Technical Details
 
@@ -45,6 +46,7 @@ Colima/Lima detection:
 - **Fallback check**: Verifies if running as `lima` user (Lima VM default user)
 - **Logging**: Clearly indicates when auto-detection activates vs manual configuration
 - **Override**: Manual `disable_shift = true` config takes precedence over auto-detection
+- **Network mode**: Colima/Lima VMs don't include firewalld, so `--network=open` must be used. The open mode works without firewalld - it skips firewall rule setup entirely and allows unrestricted network access
 
 This prevents the error: `Error: Failed to start device "workspace": Required idmapping abilities not available` when running COI inside Colima/Lima VMs on macOS.
 

--- a/README.md
+++ b/README.md
@@ -268,17 +268,47 @@ COI can run on macOS by using Incus inside a [Colima](https://github.com/abiosof
 2. **COI detects the environment** - Checks for virtiofs mounts in `/proc/mounts` and the `lima` user
 3. **UID shifting is auto-disabled** - COI automatically disables Incus's `shift=true` option to avoid conflicts with VM-level mapping
 
+### Network Mode on macOS
+
+**Important:** Network isolation modes (`restricted`, `allowlist`) require firewalld, which is not available in Colima/Lima VMs by default. Use `--network=open` for unrestricted network access:
+
+```bash
+# Inside Colima/Lima VM
+coi shell --network=open
+```
+
+Or set it as default in your config:
+
+```toml
+# ~/.config/coi/config.toml
+[network]
+mode = "open"
+```
+
 ### Setup
 
 ```bash
 # Install Colima (example)
 brew install colima
 
-# Start Colima VM
-colima start
+# Start Colima VM with sufficient resources
+colima start --cpu 4 --memory 8 --disk 50
 
-# Inside the VM, install Incus and COI following normal Linux instructions
-# COI will automatically detect it's running in Colima/Lima
+# SSH into the VM
+colima ssh
+
+# Inside the VM, install Incus
+sudo apt update && sudo apt install -y incus
+sudo incus admin init --auto
+sudo usermod -aG incus-admin $USER
+newgrp incus-admin
+
+# Install COI
+curl -fsSL https://raw.githubusercontent.com/mensfeld/code-on-incus/master/install.sh | bash
+
+# Build image and start a session
+coi build
+coi shell --network=open
 ```
 
 **Manual Override**: In rare cases where auto-detection doesn't work, you can manually configure:

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -71,6 +71,9 @@ func (m *Manager) SetupForContainer(ctx context.Context, containerName string) e
 			if err := EnsureOpenModeRules(containerIP); err != nil {
 				log.Printf("Warning: could not add open mode rules: %v", err)
 			}
+		} else {
+			log.Println("Warning: firewalld not available - container has unrestricted network access")
+			log.Println("         Network isolation (restricted/allowlist modes) requires firewalld")
 		}
 		return nil
 


### PR DESCRIPTION
## Summary

- Document that `--network=open` is required for macOS users running COI via Colima/Lima VMs
- These VMs don't include firewalld, so network isolation modes (restricted/allowlist) fail
- Open mode works without firewalld - it skips firewall setup entirely
- **Added warning** when running open mode without firewalld available

## Changes

**README.md:**
- Add "Network Mode on macOS" section explaining the requirement
- Show how to set open mode as default in config file
- Expand Colima setup instructions with complete installation flow

**CHANGELOG.md:**
- Add enhancement entry for documentation improvements
- Add technical detail about network mode in Colima/Lima section

**internal/network/manager.go:**
- Add warning log when firewalld is not available in open mode
- Informs users that network isolation modes require firewalld

## Test plan

- [x] Verified code already supports this (manager.go:62-75 returns nil for open mode without firewalld)
- [x] Warning is logged when firewalld unavailable
- [ ] Documentation review