### PR TITLE
chore: Remove outdated OVN references from codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Firewalld network isolation:
 - **Restricted Mode**: Allows gateway, blocks RFC1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) and metadata (169.254.0.0/16), allows all else
 - **Allowlist Mode**: Allows gateway, allows specific IPs from resolved domains, blocks RFC1918 and metadata, default deny all else
 - **Cleanup**: Rules are removed when container stops/deletes using container IP as identifier
-- **No OVN Required**: Works with standard Incus bridge networks (incusbr0), no special routing needed
+- **Standard Bridge Networks**: Works with standard Incus bridge networks (incusbr0), no special routing needed
 
 Docker/nested container support:
 - **Automatic Configuration**: All containers automatically receive Docker support flags on launch

--- a/tests/network/test_allowlist.py
+++ b/tests/network/test_allowlist.py
@@ -367,7 +367,7 @@ def test_allowlist_blocks_public_ips_not_in_list(coi_binary, workspace_dir, clea
     """
     Test that allowlist mode blocks public IPs not in the allowlist.
 
-    Verifies that OVN's implicit default-deny blocks non-allowed public IPs.
+    Verifies that firewalld's implicit default-deny blocks non-allowed public IPs.
     """
     # Create temporary config with only DNS
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:

--- a/tests/network/test_network_host_isolation.py
+++ b/tests/network/test_network_host_isolation.py
@@ -87,7 +87,7 @@ mode = "restricted"
             )
 
             # Verify it's blocked by ACL (can be timeout, connection refused, or unreachable)
-            # OVN ACLs can reject traffic immediately (connection refused) or via timeout
+            # Firewall rules can reject traffic immediately (connection refused) or via timeout
             error_output = (result.stdout + result.stderr).lower()
             assert (
                 "timeout" in error_output
@@ -177,7 +177,7 @@ refresh_interval_minutes = 30
             )
 
             # Verify it's blocked by ACL (can be timeout, connection refused, or unreachable)
-            # OVN ACLs can reject traffic immediately (connection refused) or via timeout
+            # Firewall rules can reject traffic immediately (connection refused) or via timeout
             error_output = (result.stdout + result.stderr).lower()
             assert (
                 "timeout" in error_output
@@ -251,7 +251,7 @@ mode = "restricted"
         assert result.returncode == 0, f"Failed to get container info: {result.stderr}"
 
         container_info = json.loads(result.stdout)[0]
-        # Get eth0 IP address (OVN network IP, not Docker bridge IP)
+        # Get eth0 IP address (container network IP, not Docker bridge IP)
         eth0_addresses = container_info["state"]["network"]["eth0"]["addresses"]
         ipv4_addresses = [addr["address"] for addr in eth0_addresses if addr["family"] == "inet"]
         assert ipv4_addresses, f"No IPv4 address found for container {container_name}"

--- a/tests/network/test_network_restricted_comprehensive.py
+++ b/tests/network/test_network_restricted_comprehensive.py
@@ -233,7 +233,7 @@ def test_restricted_blocks_metadata(coi_binary, workspace_dir, cleanup_container
     Verifies that containers cannot access the cloud metadata service.
 
     Note: In cloud environments (Azure CI), a real metadata service may exist
-    that cannot be blocked by OVN ACLs. This test is skipped in such environments.
+    that cannot be blocked by firewall rules. This test is skipped in such environments.
     """
     # Create temporary config with RESTRICTED mode
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
@@ -295,7 +295,7 @@ mode = "restricted"
         )
 
         # In RESTRICTED mode, either outcome is acceptable:
-        # - Success (returncode == 0): Cloud environment where OVN ACLs cannot block
+        # - Success (returncode == 0): Cloud environment where firewall rules cannot block
         #   the cloud provider's own metadata service (expected behavior in cloud CI)
         # - Failure: Local environment where metadata service doesn't exist or is blocked
         # Both are valid depending on the environment
@@ -389,7 +389,7 @@ def test_restricted_allows_gateway(coi_binary, workspace_dir, cleanup_containers
     """
     Test that RESTRICTED mode allows access to the gateway.
 
-    Verifies that containers can reach the OVN gateway IP despite RFC1918 blocking.
+    Verifies that containers can reach the gateway IP despite RFC1918 blocking.
     Note: This test is informational - gateway connectivity is complex to verify.
     """
     # Create temporary config with RESTRICTED mode

--- a/tests/shell/ephemeral/new_session_with_poweroff_ephemeral.py
+++ b/tests/shell/ephemeral/new_session_with_poweroff_ephemeral.py
@@ -107,7 +107,7 @@ def test_ephemeral_session_with_shutdown(coi_binary, cleanup_containers, workspa
     except Exception:
         child.close(force=True)
 
-    # Step 5: Wait for container to be deleted (60s to account for OVN network teardown)
+    # Step 5: Wait for container to be deleted (60s to account for network teardown)
     container_deleted = wait_for_specific_container_deletion(container_name, timeout=60)
 
     # Step 6: Verify cleanup messages

--- a/tests/shell/ephemeral/new_session_with_resume_ephemeral.py
+++ b/tests/shell/ephemeral/new_session_with_resume_ephemeral.py
@@ -109,7 +109,7 @@ def test_ephemeral_session_with_resume(coi_binary, cleanup_containers, workspace
     except Exception:
         child.close(force=True)
 
-    # Wait for container deletion (60s to account for cleanup detection + OVN teardown)
+    # Wait for container deletion (60s to account for cleanup detection + network teardown)
     # The wait function polls, so no need for a sleep before waiting
     container_deleted = wait_for_specific_container_deletion(container_name, timeout=60)
     assert container_deleted, (
@@ -170,7 +170,7 @@ def test_ephemeral_session_with_resume(coi_binary, cleanup_containers, workspace
     except Exception:
         child2.close(force=True)
 
-    # Wait for second container to be deleted (60s to account for cleanup detection + OVN teardown)
+    # Wait for second container to be deleted (60s to account for cleanup detection + network teardown)
     container_name2 = calculate_container_name(workspace_dir, 1)
     deleted = wait_for_specific_container_deletion(container_name2, timeout=60)
 


### PR DESCRIPTION
## Summary

Remove all outdated OVN (Open Virtual Network) references from the codebase and replace them with accurate references to the current firewalld-based implementation.

The codebase migrated from OVN to firewalld in v0.6.0, but several comments and documentation still referenced the old OVN system, which could cause confusion.

## Changes

- **CHANGELOG.md**: Changed "No OVN Required" → "Standard Bridge Networks"
- **Test comments**: Updated all references from:
  - "OVN ACLs" → "firewall rules"
  - "OVN teardown" → "network teardown"  
  - "OVN network IP" → "container network IP"
  - "OVN's default-deny" → "firewalld's default-deny"
  - "OVN gateway IP" → "gateway IP"

## Files Modified

- `CHANGELOG.md`
- `tests/network/test_allowlist.py`
- `tests/network/test_network_host_isolation.py`
- `tests/network/test_network_restricted_comprehensive.py`
- `tests/shell/ephemeral/new_session_with_poweroff_ephemeral.py`
- `tests/shell/ephemeral/new_session_with_resume_ephemeral.py`

## Impact

This is a documentation/comment-only change with no functional impact. It ensures that all documentation accurately reflects the current firewalld-based network isolation implementation.

## Note

Historical CHANGELOG entries (lines 26, 71, 75) that document the migration from OVN to firewalld in v0.6.0 were intentionally preserved as they provide accurate historical context.