### PR TITLE
Fix flaky allowlist network blocking tests

### DIFF
--- a/tests/network/test_allowlist.py
+++ b/tests/network/test_allowlist.py
@@ -176,7 +176,8 @@ refresh_interval_minutes = 30
         )
 
         # Wait for firewall rules to be fully applied (CI timing issue)
-        time.sleep(2)
+        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
+        time.sleep(5)
 
         # Test: curl blocked domain (should fail)
         result = subprocess.run(

--- a/tests/network/test_network_allowlist_comprehensive.py
+++ b/tests/network/test_network_allowlist_comprehensive.py
@@ -175,7 +175,8 @@ refresh_interval_minutes = 30
         )
 
         # Wait for firewall rules to be fully applied (CI timing issue)
-        time.sleep(2)
+        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
+        time.sleep(5)
 
         # Test: curl example.com (NOT in allowlist, should fail)
         result = subprocess.run(
@@ -276,6 +277,10 @@ refresh_interval_minutes = 30
                 break
 
         assert container_name, f"Could not find container name in output: {output}"
+
+        # Wait for firewall rules to be fully applied (CI timing issue)
+        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
+        time.sleep(5)
 
         # Test: attempt connection to 10.0.0.1 (even though in allowlist)
         result = subprocess.run(
@@ -457,6 +462,10 @@ refresh_interval_minutes = 30
                 break
 
         assert container_name, f"Could not find container name in output: {output}"
+
+        # Wait for firewall rules to be fully applied (CI timing issue)
+        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
+        time.sleep(5)
 
         # Test: nslookup query to Quad9 DNS 9.9.9.9 (NOT in allowlist, should fail)
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- Adds missing `time.sleep(5)` before network blocking tests to wait for firewalld rules to fully propagate
- Increases existing sleep delays from 2s to 5s for consistency with other network tests

## Root Cause
The `test_allowlist_blocks_non_allowed_dns` test was failing intermittently because it ran immediately after container startup without waiting for firewalld rules to fully propagate. In CI environments (especially GitHub Actions), firewalld rule propagation can be slow, causing traffic to 9.9.9.9 (Quad9 DNS) to succeed when it should have been blocked by the allowlist mode.

Other similar tests in the same file already had `time.sleep(2)` with the comment "Wait for firewall rules to be fully applied (CI timing issue)", but this was missing from `test_allowlist_blocks_non_allowed_dns` and `test_allowlist_blocks_rfc1918_always`.

## Changes
- `test_allowlist_blocks_non_allowed_dns`: Added 5s sleep before testing
- `test_allowlist_blocks_rfc1918_always`: Added 5s sleep before testing
- `test_allowlist_blocks_non_allowed`: Increased sleep from 2s to 5s

## Test plan
- [ ] CI network tests pass consistently
- [ ] The specific test `test_allowlist_blocks_non_allowed_dns` no longer fails intermittently