### PR TITLE
fix: protected paths work with preserve_workspace_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Bug Fixes
 
+- [Bug Fix] **Protected paths work with preserve_workspace_path** - Fixed protected paths (`.git/hooks`, `.vscode`, etc.) not being mounted at the correct location when `preserve_workspace_path` was enabled. The security mounts were hardcoded to use `/workspace` instead of the dynamic container workspace path. Also added validation to prevent mounting workspace over critical system directories (`/etc`, `/bin`, `/usr`, etc.) and updated all CLI code paths to use the dynamic workspace path. Includes integration tests for protected paths with `preserve_workspace_path`.
+
 - [Bug Fix] **Large write detection test timeout handling** - Fixed the large write detection integration test timing out on slow CI systems. The test now handles `TimeoutExpired` exceptions gracefully and still verifies threat detection by checking audit logs. Reduced subprocess timeout and added proper cleanup on timeout scenarios.
 
 - [Bug Fix] **NFT monitoring rules now cleaned up on container kill** - Fixed NFT monitoring rules not being removed when containers are killed via `coi kill` or auto-killed by the security responder (e.g., when metadata endpoint access is detected). Added `CleanupNFTMonitoringRules()` to the network package and integrated it into both kill paths: `coi kill` command and the responder's `killContainer()` method. The cleanup gracefully handles cases where no rules exist (monitoring wasn't enabled) or the nftables chain doesn't exist.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -209,10 +209,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		// Protect security-sensitive paths by mounting read-only (security feature)
+		// Note: coi run always uses /workspace as the container path
 		if !writableGitHooks && !cfg.Security.DisableProtection {
 			protectedPaths := cfg.Security.GetEffectiveProtectedPaths()
 			if len(protectedPaths) > 0 {
-				if err := session.SetupSecurityMounts(mgr, absWorkspace, protectedPaths, useShift); err != nil {
+				if err := session.SetupSecurityMounts(mgr, absWorkspace, "/workspace", protectedPaths, useShift); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: Failed to setup security mounts: %v\n", err)
 				} else {
 					// Log which paths were actually protected

--- a/internal/session/security.go
+++ b/internal/session/security.go
@@ -12,14 +12,16 @@ import (
 // SetupSecurityMounts mounts protected paths as read-only for security.
 // This prevents containers from modifying files that could execute automatically
 // on the host (git hooks, IDE configs, etc.).
+// containerWorkspacePath is the path where the workspace is mounted inside the container
+// (either /workspace or the preserved host path).
 // Returns nil if no paths need protection.
-func SetupSecurityMounts(mgr *container.Manager, workspacePath string, protectedPaths []string, useShift bool) error {
+func SetupSecurityMounts(mgr *container.Manager, workspacePath, containerWorkspacePath string, protectedPaths []string, useShift bool) error {
 	if len(protectedPaths) == 0 {
 		return nil
 	}
 
 	for _, relPath := range protectedPaths {
-		if err := setupProtectedPath(mgr, workspacePath, relPath, useShift); err != nil {
+		if err := setupProtectedPath(mgr, workspacePath, containerWorkspacePath, relPath, useShift); err != nil {
 			// Log warning but continue with other paths
 			// Some paths may not exist and that's OK
 			if !os.IsNotExist(err) {
@@ -32,9 +34,9 @@ func SetupSecurityMounts(mgr *container.Manager, workspacePath string, protected
 }
 
 // setupProtectedPath mounts a single path as read-only
-func setupProtectedPath(mgr *container.Manager, workspacePath, relPath string, useShift bool) error {
+func setupProtectedPath(mgr *container.Manager, workspacePath, containerWorkspacePath, relPath string, useShift bool) error {
 	hostPath := filepath.Join(workspacePath, relPath)
-	containerPath := filepath.Join("/workspace", relPath)
+	containerPath := filepath.Join(containerWorkspacePath, relPath)
 
 	// For .git paths, check if .git itself is valid FIRST (not a symlink or file)
 	// This must happen before we try to create .git/hooks
@@ -111,7 +113,8 @@ func pathToDeviceName(path string) string {
 // It mounts .git/hooks as read-only for security.
 // Deprecated: Use SetupSecurityMounts with config.Security.GetEffectiveProtectedPaths() instead
 func SetupGitHooksMount(mgr *container.Manager, workspacePath string, useShift bool) error {
-	return SetupSecurityMounts(mgr, workspacePath, []string{".git/hooks"}, useShift)
+	// Use /workspace as the default container path for backwards compatibility
+	return SetupSecurityMounts(mgr, workspacePath, "/workspace", []string{".git/hooks"}, useShift)
 }
 
 // GetProtectedPathsForLogging returns a human-readable list of protected paths

--- a/internal/session/security_test.go
+++ b/internal/session/security_test.go
@@ -76,12 +76,12 @@ func TestSetupSecurityMounts_EmptyPaths(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Empty paths should return nil
-	err = SetupSecurityMounts(nil, tmpDir, []string{}, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", []string{}, false)
 	if err != nil {
 		t.Errorf("Expected nil error for empty paths, got: %v", err)
 	}
 
-	err = SetupSecurityMounts(nil, tmpDir, nil, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", nil, false)
 	if err != nil {
 		t.Errorf("Expected nil error for nil paths, got: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestSetupSecurityMounts_NonExistentPaths(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Non-existent paths should be silently skipped (except .git/hooks which is created)
-	err = SetupSecurityMounts(nil, tmpDir, []string{".vscode", ".husky"}, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", []string{".vscode", ".husky"}, false)
 	if err != nil {
 		t.Errorf("Expected nil error for non-existent paths, got: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestSetupSecurityMounts_SymlinkRejection(t *testing.T) {
 	}
 
 	// Should return error for symlinked paths
-	err = SetupSecurityMounts(nil, tmpDir, []string{".vscode"}, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", []string{".vscode"}, false)
 	if err == nil {
 		t.Error("Expected error for symlinked path, got nil")
 	}
@@ -147,7 +147,7 @@ func TestSetupSecurityMounts_GitSymlinkSkipped(t *testing.T) {
 	}
 
 	// Should skip .git/hooks when .git is a symlink (no error, just skip)
-	err = SetupSecurityMounts(nil, tmpDir, []string{".git/hooks"}, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", []string{".git/hooks"}, false)
 	if err != nil {
 		t.Errorf("Expected nil error when .git is symlink, got: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestSetupSecurityMounts_GitFileSkipped(t *testing.T) {
 	}
 
 	// Should skip .git/hooks when .git is a file (no error, just skip)
-	err = SetupSecurityMounts(nil, tmpDir, []string{".git/hooks"}, false)
+	err = SetupSecurityMounts(nil, tmpDir, "/workspace", []string{".git/hooks"}, false)
 	if err != nil {
 		t.Errorf("Expected nil error when .git is file, got: %v", err)
 	}

--- a/tests/config/preserve_workspace_path_protected_paths.py
+++ b/tests/config/preserve_workspace_path_protected_paths.py
@@ -1,0 +1,206 @@
+"""
+Test for preserve_workspace_path with protected paths.
+
+Tests that:
+1. When preserve_workspace_path is enabled, protected paths (.git/hooks) are
+   mounted read-only at the correct location (not /workspace/.git/hooks but
+   at the preserved path)
+2. This verifies the critical bug fix where SetupSecurityMounts was hardcoded
+   to use /workspace instead of the dynamic container workspace path
+"""
+
+import os
+import subprocess
+import time
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_text_in_monitor,
+    with_live_screen,
+)
+
+
+def test_protected_paths_work_with_preserve_workspace_path(
+    coi_binary, cleanup_containers, workspace_dir
+):
+    """
+    Test that protected paths (.git/hooks) are read-only when preserve_workspace_path is enabled.
+
+    This test verifies the fix for the bug where SetupSecurityMounts hardcoded
+    /workspace as the container path, causing protected paths to be mounted at
+    the wrong location when preserve_workspace_path was enabled.
+
+    Flow:
+    1. Create a git repo in workspace with a hook file
+    2. Enable preserve_workspace_path
+    3. Start coi shell
+    4. Try to modify .git/hooks from inside container
+    5. Verify modification is blocked (read-only)
+    """
+    env = {"COI_USE_DUMMY": "1"}
+
+    # Create .coi.toml with preserve_workspace_path enabled
+    config_path = os.path.join(workspace_dir, ".coi.toml")
+    with open(config_path, "w") as f:
+        f.write(
+            """
+[paths]
+preserve_workspace_path = true
+"""
+        )
+
+    # Initialize a git repo and create a hook
+    subprocess.run(["git", "init"], cwd=workspace_dir, capture_output=True, check=True)
+    hooks_dir = os.path.join(workspace_dir, ".git", "hooks")
+    os.makedirs(hooks_dir, exist_ok=True)
+    hook_file = os.path.join(hooks_dir, "pre-commit")
+    with open(hook_file, "w") as f:
+        f.write("#!/bin/bash\necho 'Original hook'\n")
+    os.chmod(hook_file, 0o755)
+
+    # Start shell
+    child = spawn_coi(
+        coi_binary,
+        ["shell"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    # Exit CLI to bash
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
+    time.sleep(2)
+
+    # Try to write to .git/hooks - should fail because it's read-only
+    # The hook should be at {workspace_dir}/.git/hooks/pre-commit (preserved path)
+    # not at /workspace/.git/hooks/pre-commit
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+
+        # First verify we're at the correct path
+        child.send("pwd")
+        time.sleep(0.3)
+        child.send("\x0d")
+        found = wait_for_text_in_monitor(monitor, workspace_dir, timeout=10)
+        assert found, f"Should be at {workspace_dir}"
+
+        # Verify the hook file exists at the preserved path
+        child.send(f"cat {workspace_dir}/.git/hooks/pre-commit")
+        time.sleep(0.3)
+        child.send("\x0d")
+        found = wait_for_text_in_monitor(monitor, "Original hook", timeout=10)
+        assert found, "Hook file should exist and be readable at preserved path"
+
+        # Try to modify the hook - should fail with read-only error
+        child.send(f"echo 'Modified' >> {workspace_dir}/.git/hooks/pre-commit 2>&1")
+        time.sleep(0.3)
+        child.send("\x0d")
+        # Look for "Read-only" error message
+        found = wait_for_text_in_monitor(monitor, "Read-only", timeout=10)
+        assert found, "Writing to .git/hooks should fail with Read-only error"
+
+    # Verify the hook was NOT modified on host
+    with open(hook_file) as f:
+        content = f.read()
+    assert "Modified" not in content, "Hook should not have been modified"
+    assert "Original hook" in content, "Hook should still have original content"
+
+    # Cleanup
+    child.send("sudo poweroff")
+    time.sleep(0.3)
+    child.send("\x0d")
+
+    try:
+        child.expect(EOF, timeout=60)
+    except TIMEOUT:
+        pass
+
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+
+
+def test_protected_paths_default_workspace(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Test that protected paths work correctly with default /workspace path.
+
+    This is a baseline test to ensure the fix doesn't break the default behavior.
+    """
+    env = {"COI_USE_DUMMY": "1"}
+
+    # Initialize a git repo and create a hook
+    subprocess.run(["git", "init"], cwd=workspace_dir, capture_output=True, check=True)
+    hooks_dir = os.path.join(workspace_dir, ".git", "hooks")
+    os.makedirs(hooks_dir, exist_ok=True)
+    hook_file = os.path.join(hooks_dir, "pre-commit")
+    with open(hook_file, "w") as f:
+        f.write("#!/bin/bash\necho 'Original hook'\n")
+    os.chmod(hook_file, 0o755)
+
+    # Start shell (default config, no preserve_workspace_path)
+    child = spawn_coi(
+        coi_binary,
+        ["shell"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    # Exit CLI to bash
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
+    time.sleep(2)
+
+    # Try to write to .git/hooks at /workspace - should fail
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+
+        # Verify we're at /workspace
+        child.send("pwd")
+        time.sleep(0.3)
+        child.send("\x0d")
+        found = wait_for_text_in_monitor(monitor, "/workspace", timeout=10)
+        assert found, "Should be at /workspace"
+
+        # Verify the hook file exists
+        child.send("cat /workspace/.git/hooks/pre-commit")
+        time.sleep(0.3)
+        child.send("\x0d")
+        found = wait_for_text_in_monitor(monitor, "Original hook", timeout=10)
+        assert found, "Hook file should exist and be readable"
+
+        # Try to modify the hook - should fail with read-only error
+        child.send("echo 'Modified' >> /workspace/.git/hooks/pre-commit 2>&1")
+        time.sleep(0.3)
+        child.send("\x0d")
+        found = wait_for_text_in_monitor(monitor, "Read-only", timeout=10)
+        assert found, "Writing to .git/hooks should fail with Read-only error"
+
+    # Cleanup
+    child.send("sudo poweroff")
+    time.sleep(0.3)
+    child.send("\x0d")
+
+    try:
+        child.expect(EOF, timeout=60)
+    except TIMEOUT:
+        pass
+
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)


### PR DESCRIPTION
## Summary

Fix critical bugs in `preserve_workspace_path` feature reported by Copilot review on PR #146:

1. **Protected paths mounted at wrong location** - `SetupSecurityMounts` was hardcoded to use `/workspace` instead of the dynamic container workspace path. When `preserve_workspace_path=true`, protected paths like `.git/hooks` would be mounted at `/workspace/.git/hooks` instead of the preserved host path.

2. **System directory validation** - Added validation to prevent mounting workspace over critical system directories (`/etc`, `/bin`, `/usr`, `/root`, `/sys`, `/proc`, `/dev`, `/lib`).

3. **Dynamic workspace path in CLI** - Updated all CLI code (`shell.go`, `run.go`) to use `result.ContainerWorkspacePath` instead of hardcoded `/workspace`.

## Changes

- Add `ContainerWorkspacePath` field to `SetupResult` struct
- Update `SetupSecurityMounts` signature to accept container workspace path
- Add system directory validation with warning fallback
- Update all tmux and exec calls in `shell.go` to use dynamic path
- Update unit tests for new function signature

## Test plan

- [x] Unit tests updated and passing
- [x] Integration test: protected paths are read-only at preserved host path
- [x] Integration test: protected paths work at default `/workspace` path

Fixes issues from Copilot review on #146