### PR TITLE
fix: resolve hardcoded /workspace paths for preserve_workspace_path

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -128,11 +128,14 @@ func attachToContainer(containerName string) error {
 	// Get TERM with fallback (same as shell command)
 	termEnv := terminal.SanitizeTerm(os.Getenv("TERM"))
 
+	// Get workspace path from container's device config
+	workspacePath := mgr.GetWorkspacePath()
+
 	// Execute as code user with proper environment setup
 	user := container.CodeUID
 	opts := container.ExecCommandOptions{
 		User:        &user,
-		Cwd:         "/workspace",
+		Cwd:         workspacePath,
 		Interactive: true,
 		Env: map[string]string{
 			"TERM": termEnv,
@@ -166,11 +169,14 @@ func attachToContainerWithBash(containerName string) error {
 	// Use container manager for proper user/environment handling
 	mgr := container.NewManager(containerName)
 
+	// Get workspace path from container's device config
+	workspacePath := mgr.GetWorkspacePath()
+
 	// Execute bash as code user
 	user := container.CodeUID
 	opts := container.ExecCommandOptions{
 		User:        &user,
-		Cwd:         "/workspace",
+		Cwd:         workspacePath,
 		Interactive: true,
 	}
 

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -165,6 +165,11 @@ Examples:
 			envVars, _ := cmd.Flags().GetStringArray("env")
 			cwd, _ := cmd.Flags().GetString("cwd")
 
+			// Auto-detect workspace path if --cwd not explicitly set
+			if !cmd.Flags().Changed("cwd") {
+				cwd = mgr.GetWorkspacePath()
+			}
+
 			// Parse env vars
 			env := make(map[string]string)
 			for _, e := range envVars {
@@ -229,6 +234,11 @@ Examples:
 		groupFlag, _ := cmd.Flags().GetInt("group")
 		envVars, _ := cmd.Flags().GetStringArray("env")
 		cwd, _ := cmd.Flags().GetString("cwd")
+
+		// Auto-detect workspace path if --cwd not explicitly set
+		if !cmd.Flags().Changed("cwd") {
+			cwd = mgr.GetWorkspacePath()
+		}
 
 		// Parse env vars
 		env := make(map[string]string)
@@ -399,7 +409,7 @@ func init() {
 	containerExecCmd.Flags().Int("user", 0, "User ID to run as")
 	containerExecCmd.Flags().Int("group", 0, "Group ID to run as")
 	containerExecCmd.Flags().StringArray("env", []string{}, "Environment variable (KEY=VALUE)")
-	containerExecCmd.Flags().String("cwd", "/workspace", "Working directory")
+	containerExecCmd.Flags().String("cwd", "", "Working directory (auto-detects from container if not set)")
 	containerExecCmd.Flags().Bool("capture", false, "Capture output as JSON")
 	containerExecCmd.Flags().String("format", "json", "Output format when using --capture: json or raw")
 	containerExecCmd.Flags().BoolP("tty", "t", false, "Allocate a pseudo-terminal (PTY)")

--- a/internal/container/workspace_path_integration_test.go
+++ b/internal/container/workspace_path_integration_test.go
@@ -1,0 +1,224 @@
+package container
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestGetWorkspacePath_DefaultMount verifies that GetWorkspacePath returns the correct
+// path when workspace is mounted at /workspace (the default).
+func TestGetWorkspacePath_DefaultMount(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-workspace-default"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	// Remove any leftover container from a previous run
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	// Mount workspace at default /workspace path
+	tmpDir := t.TempDir()
+	if err := mgr.MountDisk("workspace", tmpDir, "/workspace", true, false); err != nil {
+		t.Fatalf("Failed to mount workspace: %v", err)
+	}
+
+	// Get workspace path - should return /workspace
+	workspacePath := mgr.GetWorkspacePath()
+	if workspacePath != "/workspace" {
+		t.Errorf("GetWorkspacePath() = %q, want %q", workspacePath, "/workspace")
+	}
+
+	// Verify we can execute a command in the workspace
+	output, err := mgr.ExecArgsCapture([]string{"pwd"}, ExecCommandOptions{Cwd: workspacePath})
+	if err != nil {
+		t.Fatalf("Failed to run pwd: %v", err)
+	}
+
+	got := strings.TrimSpace(output)
+	if got != "/workspace" {
+		t.Errorf("pwd in workspace = %q, want %q", got, "/workspace")
+	}
+}
+
+// TestGetWorkspacePath_CustomMount verifies that GetWorkspacePath returns the correct
+// path when workspace is mounted at a custom path (preserve_workspace_path scenario).
+func TestGetWorkspacePath_CustomMount(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-workspace-custom"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	// Remove any leftover container from a previous run
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	// Create the custom path directory inside container first
+	customPath := "/home/code/myproject"
+	_, err = mgr.ExecArgsCapture([]string{"mkdir", "-p", customPath}, ExecCommandOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create custom path directory: %v", err)
+	}
+
+	// Mount workspace at custom path (preserving host path)
+	tmpDir := t.TempDir()
+	if err := mgr.MountDisk("workspace", tmpDir, customPath, true, false); err != nil {
+		t.Fatalf("Failed to mount workspace: %v", err)
+	}
+
+	// Get workspace path - should return custom path
+	workspacePath := mgr.GetWorkspacePath()
+	if workspacePath != customPath {
+		t.Errorf("GetWorkspacePath() = %q, want %q", workspacePath, customPath)
+	}
+
+	// Verify we can execute a command in the workspace
+	output, err := mgr.ExecArgsCapture([]string{"pwd"}, ExecCommandOptions{Cwd: workspacePath})
+	if err != nil {
+		t.Fatalf("Failed to run pwd: %v", err)
+	}
+
+	got := strings.TrimSpace(output)
+	if got != customPath {
+		t.Errorf("pwd in workspace = %q, want %q", got, customPath)
+	}
+}
+
+// TestGetWorkspacePath_NoWorkspaceDevice verifies that GetWorkspacePath returns
+// the fallback /workspace when no workspace device is mounted.
+func TestGetWorkspacePath_NoWorkspaceDevice(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-workspace-no-device"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	// Remove any leftover container from a previous run
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	// Don't mount any workspace device
+	// GetWorkspacePath should return fallback /workspace
+	workspacePath := mgr.GetWorkspacePath()
+	if workspacePath != "/workspace" {
+		t.Errorf("GetWorkspacePath() = %q, want fallback %q", workspacePath, "/workspace")
+	}
+}
+
+// TestExecWithAutoDetectedWorkspace verifies that ExecArgsCapture uses the
+// auto-detected workspace path when Cwd is empty.
+func TestExecWithAutoDetectedWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-exec-autodetect"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	// Remove any leftover container from a previous run
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	// Create a custom path
+	customPath := "/home/code/testproject"
+	_, err = mgr.ExecArgsCapture([]string{"mkdir", "-p", customPath}, ExecCommandOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create custom path directory: %v", err)
+	}
+
+	// Mount workspace at custom path
+	tmpDir := t.TempDir()
+	if err := mgr.MountDisk("workspace", tmpDir, customPath, true, false); err != nil {
+		t.Fatalf("Failed to mount workspace: %v", err)
+	}
+
+	// Exec with Cwd set to the workspace path (simulating auto-detection from caller)
+	workspacePath := mgr.GetWorkspacePath()
+	output, err := mgr.ExecArgsCapture([]string{"pwd"}, ExecCommandOptions{Cwd: workspacePath})
+	if err != nil {
+		t.Fatalf("Failed to run pwd: %v", err)
+	}
+
+	got := strings.TrimSpace(output)
+	if got != customPath {
+		t.Errorf("pwd with auto-detected workspace = %q, want %q", got, customPath)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GetWorkspacePath()` to container manager to auto-detect workspace mount path from container device configuration
- Update `coi attach` to use `GetWorkspacePath()` instead of hardcoded `/workspace`
- Update `coi run` to respect `preserve_workspace_path` config with system directory validation
- Update `coi container exec` to auto-detect workspace path when `--cwd` not explicitly set
- Add comprehensive integration tests for workspace path detection

## Test plan
- [x] Integration tests pass for GetWorkspacePath with default mount
- [x] Integration tests pass for GetWorkspacePath with custom mount
- [x] Integration tests pass for GetWorkspacePath fallback (no workspace device)
- [x] Integration tests pass for exec with auto-detected workspace
- [x] Build passes
- [x] Unit tests pass

Fixes issues where attach, run, and container exec commands would fail or use wrong directory when `preserve_workspace_path` was enabled.