### PR TITLE
feat: add context.Context support to Incus command execution

### DIFF
--- a/internal/container/context_integration_test.go
+++ b/internal/container/context_integration_test.go
@@ -1,0 +1,149 @@
+package container
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestIncusOutputContext_Cancellation verifies that IncusOutputContext returns
+// promptly when its context is cancelled, rather than blocking for the full
+// duration of the underlying command.
+func TestIncusOutputContext_Cancellation(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-ctx-output"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	// Run a 30s sleep with a 2s timeout — should return well before 30s
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = IncusOutputContext(ctx, "exec", containerName, "--", "sleep", "30")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected error from cancelled context, got nil")
+	}
+
+	// Should have returned in roughly 2s, not 30s. Allow up to 5s for overhead.
+	if elapsed > 5*time.Second {
+		t.Errorf("IncusOutputContext took %v, expected cancellation within ~2s", elapsed)
+	}
+}
+
+// TestIncusExecContext_Cancellation verifies that IncusExecContext returns
+// promptly when its context is cancelled.
+func TestIncusExecContext_Cancellation(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-ctx-exec"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = IncusExecContext(ctx, "exec", containerName, "--", "sleep", "30")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected error from cancelled context, got nil")
+	}
+
+	if elapsed > 5*time.Second {
+		t.Errorf("IncusExecContext took %v, expected cancellation within ~2s", elapsed)
+	}
+}
+
+// TestIncusOutputContext_Success verifies that IncusOutputContext works
+// correctly for a normal (non-cancelled) command.
+func TestIncusOutputContext_Success(t *testing.T) {
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping integration test")
+	}
+	if !Available() {
+		t.Skip("incus daemon not running, skipping integration test")
+	}
+	exists, err := ImageExists("coi")
+	if err != nil || !exists {
+		t.Skip("coi image not found, skipping integration test (run 'coi build' first)")
+	}
+
+	containerName := "coi-test-ctx-success"
+	mgr := NewManager(containerName)
+
+	t.Cleanup(func() {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	})
+
+	if exists, _ := mgr.Exists(); exists {
+		_ = mgr.Stop(true)
+		_ = mgr.Delete(true)
+	}
+
+	if err := mgr.Launch("coi", false); err != nil {
+		t.Fatalf("Failed to launch container: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	output, err := IncusOutputContext(ctx, "exec", containerName, "--", "echo", "hello")
+	if err != nil {
+		t.Fatalf("IncusOutputContext failed: %v", err)
+	}
+
+	if output != "hello" {
+		t.Errorf("Expected output %q, got %q", "hello", output)
+	}
+}

--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -39,7 +39,7 @@ func GetCgroupPath(ctx context.Context, containerName string) (string, error) {
 // findCgroupPathViaIncus uses incus info to find the cgroup path
 func findCgroupPathViaIncus(ctx context.Context, containerName string) (string, error) {
 	// Get container info
-	output, err := container.IncusOutput("info", containerName)
+	output, err := container.IncusOutputContext(ctx, "info", containerName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get container info: %w", err)
 	}

--- a/internal/monitor/daemon.go
+++ b/internal/monitor/daemon.go
@@ -90,7 +90,7 @@ func (d *Daemon) run() {
 
 			// Handle threats
 			for _, threat := range threats {
-				if err := d.responder.Handle(threat); err != nil {
+				if err := d.responder.Handle(d.ctx, threat); err != nil {
 					if d.config.OnError != nil {
 						d.config.OnError(fmt.Errorf("threat response failed: %w", err))
 					}

--- a/internal/monitor/filesystem.go
+++ b/internal/monitor/filesystem.go
@@ -154,7 +154,7 @@ func DetectLargeWrites(stats FilesystemStats, thresholdMB float64, rateThreshold
 // CollectDiskSpace gathers disk space stats for /tmp and other critical paths
 func CollectDiskSpace(ctx context.Context, containerName string) (tmpUsedMB, tmpTotalMB, tmpUsedPercent float64, err error) {
 	// Execute df command in container to get /tmp usage
-	output, err := container.IncusOutput("exec", containerName, "--", "df", "-BM", "/tmp")
+	output, err := container.IncusOutputContext(ctx, "exec", containerName, "--", "df", "-BM", "/tmp")
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/internal/monitor/process.go
+++ b/internal/monitor/process.go
@@ -12,7 +12,7 @@ import (
 // CollectProcessStats collects running processes from the container
 func CollectProcessStats(ctx context.Context, containerName string) (ProcessStats, error) {
 	// Execute: incus exec <container> -- ps aux
-	output, err := container.IncusOutput("exec", containerName, "--", "ps", "aux")
+	output, err := container.IncusOutputContext(ctx, "exec", containerName, "--", "ps", "aux")
 	if err != nil {
 		return ProcessStats{Available: false}, fmt.Errorf("failed to execute ps: %w", err)
 	}

--- a/internal/monitor/responder_integration_test.go
+++ b/internal/monitor/responder_integration_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 	"sync"
@@ -66,7 +67,7 @@ func TestResponderPauseActualContainer(t *testing.T) {
 		Description: "Testing pause functionality",
 	}
 
-	err = responder.Handle(threat)
+	err = responder.Handle(context.Background(), threat)
 	if err != nil {
 		t.Fatalf("Failed to handle threat: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestResponderPauseActualContainer(t *testing.T) {
 	mu.Unlock()
 
 	// Verify second pause attempt doesn't error
-	err = responder.pauseContainer()
+	err = responder.pauseContainer(context.Background())
 	if err != nil {
 		t.Errorf("Second pause attempt should not error: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestResponderHandlesAlreadyFrozen(t *testing.T) {
 	responder := NewResponder(containerName, true, false, nil, nil)
 
 	// Attempt to pause already-frozen container
-	err = responder.pauseContainer()
+	err = responder.pauseContainer(context.Background())
 	if err != nil {
 		t.Errorf("pauseContainer should handle already-frozen without error: %v", err)
 	}
@@ -192,7 +193,7 @@ func TestResponderDeduplicationIntegration(t *testing.T) {
 
 	// Send same threat 5 times rapidly
 	for i := 0; i < 5; i++ {
-		if err := responder.Handle(threat); err != nil {
+		if err := responder.Handle(context.Background(), threat); err != nil {
 			t.Fatalf("Handle failed: %v", err)
 		}
 	}
@@ -210,7 +211,7 @@ func TestResponderDeduplicationIntegration(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Send again
-	if err := responder.Handle(threat); err != nil {
+	if err := responder.Handle(context.Background(), threat); err != nil {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
@@ -251,7 +252,7 @@ func TestResponderMultipleThreatTypes(t *testing.T) {
 
 	for _, threat := range threats {
 		threat.Timestamp = time.Now()
-		if err := responder.Handle(threat); err != nil {
+		if err := responder.Handle(context.Background(), threat); err != nil {
 			t.Fatalf("Handle failed: %v", err)
 		}
 	}

--- a/internal/monitor/responder_test.go
+++ b/internal/monitor/responder_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestResponderDeduplication(t *testing.T) {
 
 	// Handle the same threat multiple times rapidly
 	for i := 0; i < 5; i++ {
-		if err := responder.Handle(threat); err != nil {
+		if err := responder.Handle(context.Background(), threat); err != nil {
 			t.Fatalf("Handle failed: %v", err)
 		}
 	}
@@ -76,7 +77,7 @@ func TestResponderDeduplicationExpiry(t *testing.T) {
 	}
 
 	// First alert
-	if err := responder.Handle(threat); err != nil {
+	if err := responder.Handle(context.Background(), threat); err != nil {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
@@ -84,7 +85,7 @@ func TestResponderDeduplicationExpiry(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// Should alert again
-	if err := responder.Handle(threat); err != nil {
+	if err := responder.Handle(context.Background(), threat); err != nil {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
@@ -139,7 +140,7 @@ func TestResponderDifferentThreatsNotDeduplicated(t *testing.T) {
 	}
 
 	for _, threat := range threats {
-		if err := responder.Handle(threat); err != nil {
+		if err := responder.Handle(context.Background(), threat); err != nil {
 			t.Fatalf("Handle failed: %v", err)
 		}
 	}
@@ -184,7 +185,7 @@ func TestResponderPausedStateTracking(t *testing.T) {
 	}
 
 	// Handle should succeed without error (no pause attempt on already-paused)
-	if err := responder.Handle(threat); err != nil {
+	if err := responder.Handle(context.Background(), threat); err != nil {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
@@ -239,7 +240,7 @@ func TestResponderKilledState(t *testing.T) {
 	}
 
 	for _, threat := range threats {
-		if err := responder.Handle(threat); err != nil {
+		if err := responder.Handle(context.Background(), threat); err != nil {
 			t.Fatalf("Handle failed: %v", err)
 		}
 	}
@@ -311,7 +312,7 @@ func TestResponderThreatLevelActions(t *testing.T) {
 				Description: "Test description",
 			}
 
-			if err := responder.Handle(threat); err != nil {
+			if err := responder.Handle(context.Background(), threat); err != nil {
 				t.Fatalf("Handle failed: %v", err)
 			}
 

--- a/internal/nftmonitor/daemon.go
+++ b/internal/nftmonitor/daemon.go
@@ -156,7 +156,7 @@ func (d *Daemon) processEvents() {
 
 				// Handle threat (logging, alerting, response)
 				debugf("Calling responder.Handle for threat")
-				if err := d.responder.Handle(monitorThreat); err != nil {
+				if err := d.responder.Handle(d.ctx, monitorThreat); err != nil {
 					fmt.Printf("Error handling threat: %v\n", err)
 					debugf("Responder error: %v", err)
 				} else {


### PR DESCRIPTION
## Summary

- Add `context.Context` variants (`*Context`) for all `IncusExec*` / `IncusOutput*` / `IncusFilePush` functions; originals become thin `context.Background()` wrappers (non-breaking)
- Wire context through the monitoring daemon's collector and responder call chains so `Daemon.Stop()` can now interrupt in-flight Incus subprocesses instead of hitting a 5s shutdown timeout
- Also wire context through the NFT monitor daemon's responder call
- Delete dead code: `ContainerExec` and `ContainerExecOptions` (zero callers, used fragile shell `timeout` binary)
- Add integration tests verifying context cancellation terminates long-running commands promptly

## Test plan

- [x] `go build ./...` — no compilation errors
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/container/...` — unit + integration tests pass (including new context cancellation tests)
- [x] `go test ./internal/monitor/...` — all unit + integration tests pass
- [ ] CI passes