### PR TITLE
Fix config merge silently dropping boolean settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- [Bug Fix] **Config merge no longer silently drops boolean settings** - Fixed multi-layer config merge (`/etc/coi/config.toml` → `~/.config/coi/config.toml` → `.coi.toml`) silently overriding boolean fields with `false` when the higher-priority file omitted them. Security-critical defaults like `block_private_networks`, `block_metadata_endpoint`, `auto_pause_on_high`, `auto_kill_on_critical`, and `auto_stop` could all be lost. Converted 13 boolean config fields to pointer types (`*bool`) so `nil` correctly represents "not set in this file", extending the pattern already used by `git.writable_hooks`. Includes regression test.
+
 - [Bug Fix] **Incus config values now applied to command execution** - Fixed `incus.project`, `incus.group`, `incus.code_uid`, and `incus.code_user` config settings being ignored. These values were defined as hardcoded constants in the container package while the config struct had matching fields that were never wired in. The constants are now package-level variables initialized from the loaded config via `container.Configure()`, so custom TOML settings (e.g., `incus.project = "myproject"`) take effect on all Incus command execution.
 
 - [Bug Fix] **Settings.json merge now preserves user env vars** - Fixed sandbox settings merge overwriting user's `env` section in `settings.json`. The shallow `dict.update()` replaced the entire `env` dict, losing user-configured environment variables (e.g., AWS Bedrock settings like `AWS_PROFILE`). Changed to deep merge so nested dicts like `env` are merged key-by-key instead of replaced wholesale.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,7 +91,7 @@ Examples:
 
 		// Apply config defaults to flags that weren't explicitly set
 		if !cmd.Flags().Changed("persistent") {
-			persistent = cfg.Defaults.Persistent
+			persistent = config.BoolVal(cfg.Defaults.Persistent)
 		}
 
 		return nil

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -277,14 +277,14 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	// Start monitoring daemons if enabled (via config or --monitor flag)
 	var monitorDaemon *monitor.Daemon
 	var nftDaemon *nftmonitor.Daemon
-	monitoringEnabled := cfg.Monitoring.Enabled || enableMonitoring
+	monitoringEnabled := config.BoolVal(cfg.Monitoring.Enabled) || enableMonitoring
 	if monitoringEnabled {
 		// Override config settings when --monitor flag is used
 		if enableMonitoring {
-			cfg.Monitoring.Enabled = true
-			cfg.Monitoring.AutoKillOnCritical = true
-			cfg.Monitoring.AutoPauseOnHigh = true
-			cfg.Monitoring.NFT.Enabled = true // Also enable NFT network monitoring
+			cfg.Monitoring.Enabled = ptrBool(true)
+			cfg.Monitoring.AutoKillOnCritical = ptrBool(true)
+			cfg.Monitoring.AutoPauseOnHigh = ptrBool(true)
+			cfg.Monitoring.NFT.Enabled = ptrBool(true) // Also enable NFT network monitoring
 		}
 		// Start traditional monitoring (process/filesystem)
 		if err := startMonitoringDaemon(result.ContainerName, absWorkspace, cfg, &monitorDaemon); err != nil {
@@ -293,7 +293,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		// Start nftables monitoring (network only)
-		if cfg.Monitoring.NFT.Enabled {
+		if config.BoolVal(cfg.Monitoring.NFT.Enabled) {
 			if err := startNFTMonitoringDaemon(result.ContainerName, cfg, &nftDaemon); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to start NFT monitoring: %v\n", err)
 				// Don't fail the session if NFT monitoring fails
@@ -411,6 +411,11 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	return err
+}
+
+// ptrBool returns a pointer to a bool value
+func ptrBool(b bool) *bool {
+	return &b
 }
 
 // getEnvValue checks for an env var in --env flags first, then os.Getenv
@@ -719,8 +724,8 @@ func startMonitoringDaemon(containerName, workspacePath string, cfg *config.Conf
 		AllowedDomains:       cfg.Network.AllowedDomains,
 		FileReadThresholdMB:  cfg.Monitoring.FileReadThresholdMB,
 		FileReadRateMBPerSec: cfg.Monitoring.FileReadRateMBPerSec,
-		AutoPauseOnHigh:      cfg.Monitoring.AutoPauseOnHigh,
-		AutoKillOnCritical:   cfg.Monitoring.AutoKillOnCritical,
+		AutoPauseOnHigh:      config.BoolVal(cfg.Monitoring.AutoPauseOnHigh),
+		AutoKillOnCritical:   config.BoolVal(cfg.Monitoring.AutoKillOnCritical),
 		OnThreat: func(threat monitor.ThreatEvent) {
 			// Threats are logged to audit file - no terminal output to avoid corrupting TUI
 		},
@@ -781,7 +786,7 @@ func startNFTMonitoringDaemon(containerName string, cfg *config.Config, daemon *
 		AuditLogPath:       auditLogPath,
 		RateLimitPerSecond: cfg.Monitoring.NFT.RateLimitPerSecond,
 		DNSQueryThreshold:  cfg.Monitoring.NFT.DNSQueryThreshold,
-		LogDNSQueries:      cfg.Monitoring.NFT.LogDNSQueries,
+		LogDNSQueries:      config.BoolVal(cfg.Monitoring.NFT.LogDNSQueries),
 		LimaHost:           cfg.Monitoring.NFT.LimaHost,
 		OnThreat: func(threat nftmonitor.ThreatEvent) {
 			// Threats are logged to audit file - no terminal output to avoid corrupting TUI

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,7 @@ func DefaultProtectedPaths() []string {
 // DefaultsConfig contains default settings
 type DefaultsConfig struct {
 	Image      string `toml:"image"`
-	Persistent bool   `toml:"persistent"`
+	Persistent *bool  `toml:"persistent"`
 	Model      string `toml:"model"`
 }
 
@@ -98,17 +98,17 @@ const (
 // NetworkConfig contains network isolation settings
 type NetworkConfig struct {
 	Mode                    NetworkMode          `toml:"mode"`
-	BlockPrivateNetworks    bool                 `toml:"block_private_networks"`
-	BlockMetadataEndpoint   bool                 `toml:"block_metadata_endpoint"`
+	BlockPrivateNetworks    *bool                `toml:"block_private_networks"`
+	BlockMetadataEndpoint   *bool                `toml:"block_metadata_endpoint"`
 	AllowedDomains          []string             `toml:"allowed_domains"`
 	RefreshIntervalMinutes  int                  `toml:"refresh_interval_minutes"`
-	AllowLocalNetworkAccess bool                 `toml:"allow_local_network_access"` // Allow established connections from entire local network (not just gateway)
+	AllowLocalNetworkAccess *bool                `toml:"allow_local_network_access"` // Allow established connections from entire local network (not just gateway)
 	Logging                 NetworkLoggingConfig `toml:"logging"`
 }
 
 // NetworkLoggingConfig contains network logging settings
 type NetworkLoggingConfig struct {
-	Enabled bool   `toml:"enabled"`
+	Enabled *bool  `toml:"enabled"`
 	Path    string `toml:"path"`
 }
 
@@ -116,7 +116,7 @@ type NetworkLoggingConfig struct {
 type ProfileConfig struct {
 	Image       string            `toml:"image"`
 	Environment map[string]string `toml:"environment"`
-	Persistent  bool              `toml:"persistent"`
+	Persistent  *bool             `toml:"persistent"`
 	Limits      *LimitsConfig     `toml:"limits"`
 }
 
@@ -178,24 +178,24 @@ type DiskLimits struct {
 type RuntimeLimits struct {
 	MaxDuration  string `toml:"max_duration"`  // "2h", "30m", "1h30m", "" (unlimited)
 	MaxProcesses int    `toml:"max_processes"` // 0 = unlimited
-	AutoStop     bool   `toml:"auto_stop"`     // auto-stop when limit reached
-	StopGraceful bool   `toml:"stop_graceful"` // graceful vs force stop
+	AutoStop     *bool  `toml:"auto_stop"`     // auto-stop when limit reached
+	StopGraceful *bool  `toml:"stop_graceful"` // graceful vs force stop
 }
 
 // NFTMonitoringConfig contains nftables-based network monitoring settings
 type NFTMonitoringConfig struct {
-	Enabled            bool   `toml:"enabled"`               // Enable nftables monitoring
+	Enabled            *bool  `toml:"enabled"`               // Enable nftables monitoring
 	RateLimitPerSecond int    `toml:"rate_limit_per_second"` // Limit log volume (default 100)
 	DNSQueryThreshold  int    `toml:"dns_query_threshold"`   // Alert if >N queries/min (default 100)
-	LogDNSQueries      bool   `toml:"log_dns_queries"`       // Separate DNS logging (default true)
+	LogDNSQueries      *bool  `toml:"log_dns_queries"`       // Separate DNS logging (default true)
 	LimaHost           string `toml:"lima_host"`             // Lima host for macOS (e.g., "lima-default")
 }
 
 // MonitoringConfig contains security monitoring settings
 type MonitoringConfig struct {
-	Enabled               bool                `toml:"enabled"`                   // Enable background monitoring
-	AutoPauseOnHigh       bool                `toml:"auto_pause_on_high"`        // Pause container on high-severity threats
-	AutoKillOnCritical    bool                `toml:"auto_kill_on_critical"`     // Kill container on critical threats
+	Enabled               *bool               `toml:"enabled"`                   // Enable background monitoring
+	AutoPauseOnHigh       *bool               `toml:"auto_pause_on_high"`        // Pause container on high-severity threats
+	AutoKillOnCritical    *bool               `toml:"auto_kill_on_critical"`     // Kill container on critical threats
 	PollIntervalSec       int                 `toml:"poll_interval_sec"`         // How often to collect stats
 	FileReadThresholdMB   float64             `toml:"file_read_threshold_mb"`    // MB read in poll interval before alert
 	FileReadRateMBPerSec  float64             `toml:"file_read_rate_mb_per_sec"` // MB/sec sustained rate before alert
@@ -214,7 +214,7 @@ func GetDefaultConfig() *Config {
 	return &Config{
 		Defaults: DefaultsConfig{
 			Image:      "coi",
-			Persistent: false,
+			Persistent: ptrBool(false),
 			Model:      "claude-sonnet-4-5",
 		},
 		Paths: PathsConfig{
@@ -230,8 +230,8 @@ func GetDefaultConfig() *Config {
 		},
 		Network: NetworkConfig{
 			Mode:                  NetworkModeRestricted,
-			BlockPrivateNetworks:  true,
-			BlockMetadataEndpoint: true,
+			BlockPrivateNetworks:  ptrBool(true),
+			BlockMetadataEndpoint: ptrBool(true),
 			AllowedDomains: []string{
 				// Default allowlist for allowlist mode (--network=allowlist)
 				// Note: Gateway IP is auto-detected and added automatically
@@ -242,9 +242,10 @@ func GetDefaultConfig() *Config {
 				"api.anthropic.com",   // Claude API
 				"platform.claude.com", // Claude Platform (OAuth, Console)
 			},
-			RefreshIntervalMinutes: 30,
+			AllowLocalNetworkAccess: ptrBool(false),
+			RefreshIntervalMinutes:  30,
 			Logging: NetworkLoggingConfig{
-				Enabled: true,
+				Enabled: ptrBool(true),
 				Path:    filepath.Join(baseDir, "logs", "network.log"),
 			},
 		},
@@ -284,23 +285,23 @@ func GetDefaultConfig() *Config {
 			Runtime: RuntimeLimits{
 				MaxDuration:  "",
 				MaxProcesses: 0,
-				AutoStop:     true,
-				StopGraceful: true,
+				AutoStop:     ptrBool(true),
+				StopGraceful: ptrBool(true),
 			},
 		},
 		Monitoring: MonitoringConfig{
-			Enabled:               false,
-			AutoPauseOnHigh:       true,
-			AutoKillOnCritical:    true,
+			Enabled:               ptrBool(false),
+			AutoPauseOnHigh:       ptrBool(true),
+			AutoKillOnCritical:    ptrBool(true),
 			PollIntervalSec:       2,
 			FileReadThresholdMB:   50.0,
 			FileReadRateMBPerSec:  10.0,
 			AuditLogRetentionDays: 30,
 			NFT: NFTMonitoringConfig{
-				Enabled:            false,
+				Enabled:            ptrBool(false),
 				RateLimitPerSecond: 100,
 				DNSQueryThreshold:  100,
-				LogDNSQueries:      true,
+				LogDNSQueries:      ptrBool(true),
 				LimaHost:           "", // Empty for native Linux
 			},
 		},
@@ -339,6 +340,14 @@ func ptrBool(b bool) *bool {
 	return &b
 }
 
+// BoolVal safely dereferences a *bool, returning false if nil
+func BoolVal(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
 // ExpandPath expands ~ in paths to home directory
 func ExpandPath(path string) string {
 	if len(path) == 0 {
@@ -366,10 +375,9 @@ func (c *Config) Merge(other *Config) {
 	if other.Defaults.Model != "" {
 		c.Defaults.Model = other.Defaults.Model
 	}
-	// For booleans, we need a way to distinguish "not set" from "false"
-	// In TOML, if a field is not present, it will be false (zero value)
-	// This is a limitation - we'll just override if file exists
-	c.Defaults.Persistent = other.Defaults.Persistent
+	if other.Defaults.Persistent != nil {
+		c.Defaults.Persistent = other.Defaults.Persistent
+	}
 
 	// Merge paths
 	if other.Paths.SessionsDir != "" {
@@ -403,11 +411,15 @@ func (c *Config) Merge(other *Config) {
 	if other.Network.Mode != "" {
 		c.Network.Mode = other.Network.Mode
 	}
-	// For booleans, we merge if they appear to be explicitly set
-	// This is imperfect in TOML but works for most cases
-	c.Network.BlockPrivateNetworks = other.Network.BlockPrivateNetworks
-	c.Network.BlockMetadataEndpoint = other.Network.BlockMetadataEndpoint
-	c.Network.AllowLocalNetworkAccess = other.Network.AllowLocalNetworkAccess
+	if other.Network.BlockPrivateNetworks != nil {
+		c.Network.BlockPrivateNetworks = other.Network.BlockPrivateNetworks
+	}
+	if other.Network.BlockMetadataEndpoint != nil {
+		c.Network.BlockMetadataEndpoint = other.Network.BlockMetadataEndpoint
+	}
+	if other.Network.AllowLocalNetworkAccess != nil {
+		c.Network.AllowLocalNetworkAccess = other.Network.AllowLocalNetworkAccess
+	}
 
 	// Merge allowed domains (replace entirely if set)
 	if len(other.Network.AllowedDomains) > 0 {
@@ -422,7 +434,9 @@ func (c *Config) Merge(other *Config) {
 	if other.Network.Logging.Path != "" {
 		c.Network.Logging.Path = ExpandPath(other.Network.Logging.Path)
 	}
-	c.Network.Logging.Enabled = other.Network.Logging.Enabled
+	if other.Network.Logging.Enabled != nil {
+		c.Network.Logging.Enabled = other.Network.Logging.Enabled
+	}
 
 	// Merge Tool settings
 	if other.Tool.Name != "" {
@@ -522,18 +536,25 @@ func mergeLimits(base *LimitsConfig, other *LimitsConfig) {
 	if other.Runtime.MaxProcesses != 0 {
 		base.Runtime.MaxProcesses = other.Runtime.MaxProcesses
 	}
-	// For booleans, we take the other value if it differs from default
-	// This is imperfect but works for most cases
-	base.Runtime.AutoStop = other.Runtime.AutoStop
-	base.Runtime.StopGraceful = other.Runtime.StopGraceful
+	if other.Runtime.AutoStop != nil {
+		base.Runtime.AutoStop = other.Runtime.AutoStop
+	}
+	if other.Runtime.StopGraceful != nil {
+		base.Runtime.StopGraceful = other.Runtime.StopGraceful
+	}
 }
 
 // mergeMonitoring merges monitoring configurations (other takes precedence)
 func mergeMonitoring(base *MonitoringConfig, other *MonitoringConfig) {
-	// For booleans, we take the other value
-	base.Enabled = other.Enabled
-	base.AutoPauseOnHigh = other.AutoPauseOnHigh
-	base.AutoKillOnCritical = other.AutoKillOnCritical
+	if other.Enabled != nil {
+		base.Enabled = other.Enabled
+	}
+	if other.AutoPauseOnHigh != nil {
+		base.AutoPauseOnHigh = other.AutoPauseOnHigh
+	}
+	if other.AutoKillOnCritical != nil {
+		base.AutoKillOnCritical = other.AutoKillOnCritical
+	}
 
 	// Merge thresholds
 	if other.PollIntervalSec != 0 {
@@ -550,14 +571,18 @@ func mergeMonitoring(base *MonitoringConfig, other *MonitoringConfig) {
 	}
 
 	// Merge NFT monitoring
-	base.NFT.Enabled = other.NFT.Enabled
+	if other.NFT.Enabled != nil {
+		base.NFT.Enabled = other.NFT.Enabled
+	}
 	if other.NFT.RateLimitPerSecond != 0 {
 		base.NFT.RateLimitPerSecond = other.NFT.RateLimitPerSecond
 	}
 	if other.NFT.DNSQueryThreshold != 0 {
 		base.NFT.DNSQueryThreshold = other.NFT.DNSQueryThreshold
 	}
-	base.NFT.LogDNSQueries = other.NFT.LogDNSQueries
+	if other.NFT.LogDNSQueries != nil {
+		base.NFT.LogDNSQueries = other.NFT.LogDNSQueries
+	}
 	if other.NFT.LimaHost != "" {
 		base.NFT.LimaHost = other.NFT.LimaHost
 	}
@@ -581,7 +606,9 @@ func (c *Config) ApplyProfile(name string) bool {
 	if profile.Image != "" {
 		c.Defaults.Image = profile.Image
 	}
-	c.Defaults.Persistent = profile.Persistent
+	if profile.Persistent != nil {
+		c.Defaults.Persistent = profile.Persistent
+	}
 
 	// Apply profile limits if present
 	if profile.Limits != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,7 +116,7 @@ func TestGetProfile(t *testing.T) {
 	// Add a test profile
 	cfg.Profiles["test"] = ProfileConfig{
 		Image:      "test-image",
-		Persistent: true,
+		Persistent: ptrBool(true),
 	}
 
 	// Test getting existing profile
@@ -143,7 +143,7 @@ func TestApplyProfile(t *testing.T) {
 	// Add a test profile
 	cfg.Profiles["rust"] = ProfileConfig{
 		Image:      "rust-image",
-		Persistent: true,
+		Persistent: ptrBool(true),
 	}
 
 	// Apply the profile
@@ -157,7 +157,7 @@ func TestApplyProfile(t *testing.T) {
 		t.Errorf("Expected image 'rust-image', got '%s'", cfg.Defaults.Image)
 	}
 
-	if !cfg.Defaults.Persistent {
+	if cfg.Defaults.Persistent == nil || !*cfg.Defaults.Persistent {
 		t.Error("Expected persistent to be true")
 	}
 
@@ -464,6 +464,83 @@ func TestClaudeEffortLevelMerge(t *testing.T) {
 				t.Errorf("Expected effort level '%s', got '%s'", tt.expectedLevel, base.Tool.Claude.EffortLevel)
 			}
 		})
+	}
+}
+
+func TestMergeBoolZeroValueBug(t *testing.T) {
+	// This test demonstrates a bug where merging a zero-value Config (simulating
+	// a TOML file that only sets string fields) overwrites security-critical
+	// boolean defaults with false. For example, a user config at
+	// ~/.config/coi/config.toml that only sets image = "my-image" should NOT
+	// reset block_private_networks from true to false.
+
+	base := GetDefaultConfig()
+
+	// Verify defaults are set correctly before merge
+	if base.Network.BlockPrivateNetworks == nil || !*base.Network.BlockPrivateNetworks {
+		t.Fatal("Expected default BlockPrivateNetworks to be true")
+	}
+	if base.Network.BlockMetadataEndpoint == nil || !*base.Network.BlockMetadataEndpoint {
+		t.Fatal("Expected default BlockMetadataEndpoint to be true")
+	}
+	if base.Monitoring.AutoPauseOnHigh == nil || !*base.Monitoring.AutoPauseOnHigh {
+		t.Fatal("Expected default AutoPauseOnHigh to be true")
+	}
+	if base.Monitoring.AutoKillOnCritical == nil || !*base.Monitoring.AutoKillOnCritical {
+		t.Fatal("Expected default AutoKillOnCritical to be true")
+	}
+	if base.Limits.Runtime.AutoStop == nil || !*base.Limits.Runtime.AutoStop {
+		t.Fatal("Expected default AutoStop to be true")
+	}
+	if base.Limits.Runtime.StopGraceful == nil || !*base.Limits.Runtime.StopGraceful {
+		t.Fatal("Expected default StopGraceful to be true")
+	}
+	if base.Network.Logging.Enabled == nil || !*base.Network.Logging.Enabled {
+		t.Fatal("Expected default NetworkLogging.Enabled to be true")
+	}
+	if base.Monitoring.NFT.LogDNSQueries == nil || !*base.Monitoring.NFT.LogDNSQueries {
+		t.Fatal("Expected default NFT.LogDNSQueries to be true")
+	}
+
+	// Create a zero-value config, simulating a TOML file that only sets
+	// image = "my-image" (all booleans remain nil / zero-value).
+	other := &Config{
+		Defaults: DefaultsConfig{
+			Image: "my-image",
+		},
+	}
+
+	base.Merge(other)
+
+	// After merge, all security-critical bool defaults must survive.
+	if base.Network.BlockPrivateNetworks == nil || !*base.Network.BlockPrivateNetworks {
+		t.Error("BlockPrivateNetworks was silently reset to false by merge")
+	}
+	if base.Network.BlockMetadataEndpoint == nil || !*base.Network.BlockMetadataEndpoint {
+		t.Error("BlockMetadataEndpoint was silently reset to false by merge")
+	}
+	if base.Monitoring.AutoPauseOnHigh == nil || !*base.Monitoring.AutoPauseOnHigh {
+		t.Error("AutoPauseOnHigh was silently reset to false by merge")
+	}
+	if base.Monitoring.AutoKillOnCritical == nil || !*base.Monitoring.AutoKillOnCritical {
+		t.Error("AutoKillOnCritical was silently reset to false by merge")
+	}
+	if base.Limits.Runtime.AutoStop == nil || !*base.Limits.Runtime.AutoStop {
+		t.Error("AutoStop was silently reset to false by merge")
+	}
+	if base.Limits.Runtime.StopGraceful == nil || !*base.Limits.Runtime.StopGraceful {
+		t.Error("StopGraceful was silently reset to false by merge")
+	}
+	if base.Network.Logging.Enabled == nil || !*base.Network.Logging.Enabled {
+		t.Error("NetworkLogging.Enabled was silently reset to false by merge")
+	}
+	if base.Monitoring.NFT.LogDNSQueries == nil || !*base.Monitoring.NFT.LogDNSQueries {
+		t.Error("NFT.LogDNSQueries was silently reset to false by merge")
+	}
+
+	// Verify the image WAS overridden (merge still works for string fields).
+	if base.Defaults.Image != "my-image" {
+		t.Errorf("Expected image 'my-image', got '%s'", base.Defaults.Image)
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -80,7 +80,7 @@ func loadFromEnv(cfg *Config) {
 
 	// CLAUDE_ON_INCUS_PERSISTENT
 	if env := os.Getenv("CLAUDE_ON_INCUS_PERSISTENT"); env == "true" || env == "1" {
-		cfg.Defaults.Persistent = true
+		cfg.Defaults.Persistent = ptrBool(true)
 	}
 
 	// Limit environment variables (using COI_ prefix for brevity)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -45,7 +45,7 @@ func TestLoadFromEnv(t *testing.T) {
 		t.Errorf("Expected image 'env-image', got '%s'", cfg.Defaults.Image)
 	}
 
-	if !cfg.Defaults.Persistent {
+	if cfg.Defaults.Persistent == nil || !*cfg.Defaults.Persistent {
 		t.Error("Expected persistent to be true from env")
 	}
 }

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -940,10 +940,11 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 
 	// Apply restricted mode firewall rules
 	firewallManager = network.NewFirewallManager(containerIP, gatewayIP)
+	boolTrue := true
 	restrictedConfig := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
-		BlockPrivateNetworks:  true,
-		BlockMetadataEndpoint: true,
+		BlockPrivateNetworks:  &boolTrue,
+		BlockMetadataEndpoint: &boolTrue,
 	}
 
 	if err := firewallManager.ApplyRestricted(restrictedConfig); err != nil {
@@ -1873,14 +1874,14 @@ func CheckCgroupAvailability() HealthCheck {
 // CheckMonitoringConfiguration checks if monitoring is properly configured
 func CheckMonitoringConfiguration(cfg *config.Config) HealthCheck {
 	details := map[string]interface{}{
-		"enabled":                cfg.Monitoring.Enabled,
-		"auto_pause_on_high":     cfg.Monitoring.AutoPauseOnHigh,
-		"auto_kill_on_critical":  cfg.Monitoring.AutoKillOnCritical,
+		"enabled":                config.BoolVal(cfg.Monitoring.Enabled),
+		"auto_pause_on_high":     config.BoolVal(cfg.Monitoring.AutoPauseOnHigh),
+		"auto_kill_on_critical":  config.BoolVal(cfg.Monitoring.AutoKillOnCritical),
 		"poll_interval_sec":      cfg.Monitoring.PollIntervalSec,
 		"file_read_threshold_mb": cfg.Monitoring.FileReadThresholdMB,
 	}
 
-	if !cfg.Monitoring.Enabled {
+	if !config.BoolVal(cfg.Monitoring.Enabled) {
 		return HealthCheck{
 			Name:    "monitoring_configuration",
 			Status:  StatusWarning,

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -87,7 +87,7 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	checks["network_restriction"] = CheckNetworkRestriction(cfg.Defaults.Image)
 
 	// NFT monitoring checks (only if enabled in config)
-	if cfg.Monitoring.NFT.Enabled {
+	if config.BoolVal(cfg.Monitoring.NFT.Enabled) {
 		checks["nftables"] = CheckNFTables()
 		checks["systemd_journal"] = CheckSystemdJournal()
 		checks["libsystemd"] = CheckLibsystemd()

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -43,7 +43,7 @@ func (f *FirewallManager) ApplyRestricted(cfg *config.NetworkConfig) error {
 	}
 
 	// Handle local network access
-	if cfg.AllowLocalNetworkAccess {
+	if config.BoolVal(cfg.AllowLocalNetworkAccess) {
 		// Allow all RFC1918 when local network access is enabled
 		if err := f.addRule(1, f.containerIP, "10.0.0.0/8", "ACCEPT"); err != nil {
 			return fmt.Errorf("failed to add RFC1918 allow rule: %w", err)
@@ -54,7 +54,7 @@ func (f *FirewallManager) ApplyRestricted(cfg *config.NetworkConfig) error {
 		if err := f.addRule(1, f.containerIP, "192.168.0.0/16", "ACCEPT"); err != nil {
 			return fmt.Errorf("failed to add RFC1918 allow rule: %w", err)
 		}
-	} else if cfg.BlockPrivateNetworks {
+	} else if config.BoolVal(cfg.BlockPrivateNetworks) {
 		// Block RFC1918 ranges
 		if err := f.addRule(10, f.containerIP, "10.0.0.0/8", "REJECT"); err != nil {
 			return fmt.Errorf("failed to add RFC1918 block rule: %w", err)
@@ -68,7 +68,7 @@ func (f *FirewallManager) ApplyRestricted(cfg *config.NetworkConfig) error {
 	}
 
 	// Block metadata endpoints
-	if cfg.BlockMetadataEndpoint {
+	if config.BoolVal(cfg.BlockMetadataEndpoint) {
 		if err := f.addRule(10, f.containerIP, "169.254.0.0/16", "REJECT"); err != nil {
 			return fmt.Errorf("failed to add metadata block rule: %w", err)
 		}
@@ -100,7 +100,7 @@ func (f *FirewallManager) ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs [
 	}
 
 	// Handle local network access
-	if cfg.AllowLocalNetworkAccess {
+	if config.BoolVal(cfg.AllowLocalNetworkAccess) {
 		// Allow all RFC1918 when local network access is enabled
 		if err := f.addRule(1, f.containerIP, "10.0.0.0/8", "ACCEPT"); err != nil {
 			return fmt.Errorf("failed to add RFC1918 allow rule: %w", err)
@@ -130,7 +130,7 @@ func (f *FirewallManager) ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs [
 	}
 
 	// Block RFC1918 and metadata (unless local network access is enabled)
-	if !cfg.AllowLocalNetworkAccess {
+	if !config.BoolVal(cfg.AllowLocalNetworkAccess) {
 		if err := f.addRule(10, f.containerIP, "10.0.0.0/8", "REJECT"); err != nil {
 			return fmt.Errorf("failed to add RFC1918 block rule: %w", err)
 		}

--- a/internal/network/firewall_cleanup_integration_test.go
+++ b/internal/network/firewall_cleanup_integration_test.go
@@ -185,10 +185,11 @@ func TestRestrictedModeFirewallCleanup(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Set up network manager with restricted mode
+	boolTrue := true
 	netCfg := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
-		BlockPrivateNetworks:  true,
-		BlockMetadataEndpoint: true,
+		BlockPrivateNetworks:  &boolTrue,
+		BlockMetadataEndpoint: &boolTrue,
 	}
 	netMgr := NewManager(netCfg)
 
@@ -286,10 +287,11 @@ func TestFirewallCleanupBeforeContainerDeletion(t *testing.T) {
 	t.Logf("Container IP: %s", containerIP)
 
 	// Set up network manager with restricted mode
+	boolTrue := true
 	netCfg := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
-		BlockPrivateNetworks:  true,
-		BlockMetadataEndpoint: true,
+		BlockPrivateNetworks:  &boolTrue,
+		BlockMetadataEndpoint: &boolTrue,
 	}
 	netMgr := NewManager(netCfg)
 
@@ -391,10 +393,11 @@ func TestFirewallCleanupCorrectOrder(t *testing.T) {
 	t.Logf("Container IP: %s", containerIP)
 
 	// Set up network manager with restricted mode
+	boolTrue := true
 	netCfg := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
-		BlockPrivateNetworks:  true,
-		BlockMetadataEndpoint: true,
+		BlockPrivateNetworks:  &boolTrue,
+		BlockMetadataEndpoint: &boolTrue,
 	}
 	netMgr := NewManager(netCfg)
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -128,10 +128,10 @@ func (m *Manager) setupRestricted(ctx context.Context, containerName string) err
 	log.Printf("Firewall rules applied for container %s", containerName)
 
 	// Log what is blocked
-	if m.config.BlockPrivateNetworks {
+	if config.BoolVal(m.config.BlockPrivateNetworks) {
 		log.Println("  Blocking private networks (RFC1918)")
 	}
-	if m.config.BlockMetadataEndpoint {
+	if config.BoolVal(m.config.BlockMetadataEndpoint) {
 		log.Println("  Blocking cloud metadata endpoints")
 	}
 

--- a/internal/session/cleanup_integration_test.go
+++ b/internal/session/cleanup_integration_test.go
@@ -234,10 +234,11 @@ func TestEndToEndCleanupWithRestrictedMode(t *testing.T) {
 	t.Logf("Container IP: %s", containerIP)
 
 	// Set up network manager with restricted mode
+	boolTrue := true
 	netCfg := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
-		BlockPrivateNetworks:  true,
-		BlockMetadataEndpoint: true,
+		BlockPrivateNetworks:  &boolTrue,
+		BlockMetadataEndpoint: &boolTrue,
 	}
 	netMgr := network.NewManager(netCfg)
 

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -415,8 +415,8 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 			result.TimeoutMonitor = limits.NewTimeoutMonitor(
 				result.ContainerName,
 				duration,
-				opts.LimitsConfig.Runtime.AutoStop,
-				opts.LimitsConfig.Runtime.StopGraceful,
+				config.BoolVal(opts.LimitsConfig.Runtime.AutoStop),
+				config.BoolVal(opts.LimitsConfig.Runtime.StopGraceful),
 				opts.IncusProject,
 				opts.Logger,
 			)


### PR DESCRIPTION
## Summary

- **Fixed multi-layer config merge silently overriding boolean fields with `false`** when a higher-priority TOML file omitted them. Security-critical defaults like `block_private_networks`, `block_metadata_endpoint`, `auto_pause_on_high`, `auto_kill_on_critical`, and `auto_stop` could all be lost.
- **Converted 13 boolean config fields to `*bool` pointer types** so `nil` correctly represents "not set in this file", extending the pattern already used by `git.writable_hooks`.
- **Added `BoolVal()` helper** for safe dereference at call sites, and a regression test (`TestMergeBoolZeroValueBug`).

### Example of the bug

System config at `/etc/coi/config.toml` sets `block_private_networks = true` (the default). A user config at `~/.config/coi/config.toml` that only sets `image = "my-image"` would silently reset `block_private_networks` to `false` because the decoded struct had `BlockPrivateNetworks: false` (Go zero value) which got unconditionally copied.

### Fields converted (13 across 7 structs)

| Struct | Fields |
|---|---|
| `DefaultsConfig` | `Persistent` |
| `NetworkConfig` | `BlockPrivateNetworks`, `BlockMetadataEndpoint`, `AllowLocalNetworkAccess` |
| `NetworkLoggingConfig` | `Enabled` |
| `RuntimeLimits` | `AutoStop`, `StopGraceful` |
| `MonitoringConfig` | `Enabled`, `AutoPauseOnHigh`, `AutoKillOnCritical` |
| `NFTMonitoringConfig` | `Enabled`, `LogDNSQueries` |
| `ProfileConfig` | `Persistent` |

### Not changed (intentionally)

Sticky bools (`PreserveWorkspacePath`, `DisableShift`, `DisableProtection`) use a one-way `if other.X { c.X = true }` pattern that already handles zero values correctly.

## Test plan

- [x] `go build ./...` — no compilation errors
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/config/...` — all config tests pass including new `TestMergeBoolZeroValueBug`
- [x] `go test -short ./...` — all packages pass (pre-existing integration test failures in container/session unrelated)