### PR TITLE
Fix opencode install URL to use official endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- [Bug Fix] **opencode install URL updated** - Fixed the opencode installation script using an outdated GitHub raw URL that installed an old version (v0.0.55). Updated to the official `https://opencode.ai/install` URL per the opencode docs. Fixes #157.
+
 - [Bug Fix] **NFT monitor daemon errors no longer corrupt TUI** - Fixed `nftmonitor.Daemon` using `fmt.Printf` to report errors directly to stdout, which corrupted the terminal UI. Errors from log reader failures and threat handling now route through an `OnError` callback (matching the pattern already used by `monitor.Daemon`). Added `OnError func(error)` to `nftmonitor.Config` and wired it in the CLI. Includes regression tests.
 
 - [Bug Fix] **Config merge no longer silently drops boolean settings** - Fixed multi-layer config merge (`/etc/coi/config.toml` → `~/.config/coi/config.toml` → `.coi.toml`) silently overriding boolean fields with `false` when the higher-priority file omitted them. Security-critical defaults like `block_private_networks`, `block_metadata_endpoint`, `auto_pause_on_high`, `auto_kill_on_critical`, and `auto_stop` could all be lost. Converted 13 boolean config fields to pointer types (`*bool`) so `nil` correctly represents "not set in this file", extending the pattern already used by `git.writable_hooks`. Includes regression test.

--- a/scripts/build/coi.sh
+++ b/scripts/build/coi.sh
@@ -175,7 +175,7 @@ install_claude_cli() {
 install_opencode() {
     log "Installing opencode..."
 
-    su - "$CODE_USER" -c 'curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash'
+    su - "$CODE_USER" -c 'curl -fsSL https://opencode.ai/install | bash'
 
     local OPENCODE_PATH="/home/$CODE_USER/.opencode/bin/opencode"
     if [[ ! -x "$OPENCODE_PATH" ]]; then


### PR DESCRIPTION
## Summary

- Updated opencode install URL from `https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install` to `https://opencode.ai/install`
- The old URL installed an outdated version (v0.0.55)

Fixes #157

## Test plan

- [ ] Rebuild COI image and verify opencode installs the latest version