### PR TITLE
feat: configurable permission_mode for Claude and opencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- [Feature] **Configurable permission mode** — New `permission_mode` option under `[tool]` config allows switching between `"bypass"` (default, current behavior with all permissions auto-granted) and `"interactive"` (human-in-the-loop, tool asks before running commands). Supports both Claude and opencode. Configure via `permission_mode = "interactive"` in your `.coi.toml` under `[tool]`.
+
 ### Refactoring
 
 - [Refactoring] **Unified config handling for all tools** - Both `ClaudeTool` and `OpencodeTool` now implement the `ToolWithConfigDirFiles` interface, eliminating hardcoded Claude-specific defaults from `setupCLIConfig()`. Removed the dead `ToolWithHomeConfigFile` interface and `setupHomeConfigFile()` function. The `ToolWithConfigDirFiles` interface now includes `StateConfigFileName()` and `AlwaysSetupConfig()` so each tool fully describes its own config layout.

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -452,6 +452,13 @@ func getConfiguredTool(cfg *config.Config) (tool.Tool, error) {
 		}
 	}
 
+	// Set permission mode if the tool supports it
+	if twpm, ok := t.(tool.ToolWithPermissionMode); ok {
+		if cfg.Tool.PermissionMode != "" {
+			twpm.SetPermissionMode(cfg.Tool.PermissionMode)
+		}
+	}
+
 	return t, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,9 +122,10 @@ type ProfileConfig struct {
 
 // ToolConfig represents AI coding tool configuration
 type ToolConfig struct {
-	Name   string           `toml:"name"`   // Tool name: "claude", "aider", "cursor", etc.
-	Binary string           `toml:"binary"` // Binary name to execute (if empty, uses tool name)
-	Claude ClaudeToolConfig `toml:"claude"` // Claude-specific settings
+	Name           string           `toml:"name"`            // Tool name: "claude", "aider", "cursor", etc.
+	Binary         string           `toml:"binary"`          // Binary name to execute (if empty, uses tool name)
+	PermissionMode string           `toml:"permission_mode"` // Permission mode: "bypass" (default) or "interactive"
+	Claude         ClaudeToolConfig `toml:"claude"`          // Claude-specific settings
 }
 
 // ClaudeToolConfig contains Claude Code-specific settings
@@ -444,6 +445,10 @@ func (c *Config) Merge(other *Config) {
 	}
 	if other.Tool.Binary != "" {
 		c.Tool.Binary = other.Tool.Binary
+	}
+	// Merge permission mode
+	if other.Tool.PermissionMode != "" {
+		c.Tool.PermissionMode = other.Tool.PermissionMode
 	}
 	// Merge Claude-specific settings
 	if other.Tool.Claude.EffortLevel != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -544,6 +544,59 @@ func TestMergeBoolZeroValueBug(t *testing.T) {
 	}
 }
 
+func TestPermissionModeMerge(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseMode     string
+		otherMode    string
+		expectedMode string
+	}{
+		{
+			name:         "empty base + interactive other = interactive",
+			baseMode:     "",
+			otherMode:    "interactive",
+			expectedMode: "interactive",
+		},
+		{
+			name:         "bypass base + interactive other = interactive",
+			baseMode:     "bypass",
+			otherMode:    "interactive",
+			expectedMode: "interactive",
+		},
+		{
+			name:         "interactive base + empty other = interactive (preserved)",
+			baseMode:     "interactive",
+			otherMode:    "",
+			expectedMode: "interactive",
+		},
+		{
+			name:         "empty base + empty other = empty",
+			baseMode:     "",
+			otherMode:    "",
+			expectedMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := GetDefaultConfig()
+			base.Tool.PermissionMode = tt.baseMode
+
+			other := &Config{
+				Tool: ToolConfig{
+					PermissionMode: tt.otherMode,
+				},
+			}
+
+			base.Merge(other)
+
+			if base.Tool.PermissionMode != tt.expectedMode {
+				t.Errorf("Expected permission mode '%s', got '%s'", tt.expectedMode, base.Tool.PermissionMode)
+			}
+		})
+	}
+}
+
 func TestPreserveWorkspacePathMerge(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/tool/opencode.go
+++ b/internal/tool/opencode.go
@@ -1,7 +1,9 @@
 package tool
 
 // OpencodeTool implements Tool for opencode (https://opencode.ai)
-type OpencodeTool struct{}
+type OpencodeTool struct {
+	permissionMode string // "bypass" (default) or "interactive"
+}
 
 // NewOpencode creates a new opencode tool instance
 func NewOpencode() Tool { return &OpencodeTool{} }
@@ -28,12 +30,22 @@ func (c *OpencodeTool) DiscoverSessionID(stateDir string) string { return "" }
 
 // GetSandboxSettings returns the opencode permission bypass config.
 // Injected into ~/.config/opencode/opencode.json so opencode runs without interactive prompts.
+// Returns empty map when permission mode is "interactive" (human-in-the-loop).
 func (c *OpencodeTool) GetSandboxSettings() map[string]interface{} {
+	if c.permissionMode == "interactive" {
+		return map[string]interface{}{}
+	}
 	return map[string]interface{}{
 		"permission": map[string]interface{}{
 			"*": "allow",
 		},
 	}
+}
+
+// SetPermissionMode sets the permission mode for opencode.
+// Valid values: "bypass" (default) or "interactive" (human-in-the-loop).
+func (c *OpencodeTool) SetPermissionMode(mode string) {
+	c.permissionMode = mode
 }
 
 // EssentialConfigFiles implements ToolWithConfigDirFiles.

--- a/internal/tool/opencode_test.go
+++ b/internal/tool/opencode_test.go
@@ -137,6 +137,48 @@ func TestOpencodeTool_RegistryLookup(t *testing.T) {
 	}
 }
 
+func TestOpencodeTool_ImplementsPermissionMode(t *testing.T) {
+	oc := NewOpencode()
+
+	twpm, ok := oc.(ToolWithPermissionMode)
+	if !ok {
+		t.Fatal("OpencodeTool should implement ToolWithPermissionMode")
+	}
+
+	// Verify method works without panic
+	twpm.SetPermissionMode("interactive")
+}
+
+func TestOpencodeTool_GetSandboxSettings_InteractiveMode(t *testing.T) {
+	oc := &OpencodeTool{permissionMode: "interactive"}
+	settings := oc.GetSandboxSettings()
+
+	if len(settings) != 0 {
+		t.Errorf("Expected empty map in interactive mode, got %v", settings)
+	}
+}
+
+func TestOpencodeTool_GetSandboxSettings_BypassDefault(t *testing.T) {
+	oc := &OpencodeTool{} // Empty permissionMode = default bypass
+	settings := oc.GetSandboxSettings()
+
+	perm, ok := settings["permission"]
+	if !ok {
+		t.Fatal("GetSandboxSettings() missing 'permission' key in bypass mode")
+	}
+	permMap, ok := perm.(map[string]interface{})
+	if !ok {
+		t.Fatalf("'permission' value is %T, want map[string]interface{}", perm)
+	}
+	val, ok := permMap["*"]
+	if !ok {
+		t.Fatal("permission map missing '*' key")
+	}
+	if val != "allow" {
+		t.Errorf("permission['*'] = %q, want %q", val, "allow")
+	}
+}
+
 func TestListSupported_IncludesOpencode(t *testing.T) {
 	supported := ListSupported()
 	found := false

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -67,7 +67,8 @@ type ToolWithConfigDirFiles interface {
 
 // ClaudeTool implements Tool for Claude Code
 type ClaudeTool struct {
-	effortLevel string // "low", "medium", "high" - defaults to "medium" if empty
+	effortLevel    string // "low", "medium", "high" - defaults to "medium" if empty
+	permissionMode string // "bypass" (default) or "interactive"
 }
 
 // NewClaude creates a new Claude tool instance
@@ -93,7 +94,12 @@ func (c *ClaudeTool) SessionsDirName() string {
 
 func (c *ClaudeTool) BuildCommand(sessionID string, resume bool, resumeSessionID string) []string {
 	// Base command with flags
-	cmd := []string{"claude", "--verbose", "--permission-mode", "bypassPermissions"}
+	cmd := []string{"claude", "--verbose"}
+
+	// Only add bypass permissions when not in interactive mode
+	if c.permissionMode != "interactive" {
+		cmd = append(cmd, "--permission-mode", "bypassPermissions")
+	}
 
 	// Add session/resume flag
 	if resume {
@@ -130,14 +136,15 @@ func (c *ClaudeTool) DiscoverSessionID(stateDir string) string {
 }
 
 func (c *ClaudeTool) GetSandboxSettings() map[string]interface{} {
-	// Settings to inject into .claude/settings.json for bypassing permissions
-	// and setting effort level
-	settings := map[string]interface{}{
-		"allowDangerouslySkipPermissions": true,
-		"bypassPermissionsModeAccepted":   true,
-		"permissions": map[string]string{
+	settings := map[string]interface{}{}
+
+	// Only inject bypass permission settings when not in interactive mode
+	if c.permissionMode != "interactive" {
+		settings["allowDangerouslySkipPermissions"] = true
+		settings["bypassPermissionsModeAccepted"] = true
+		settings["permissions"] = map[string]string{
 			"defaultMode": "bypassPermissions",
-		},
+		}
 	}
 
 	// Set effort level (default to "medium" if not configured)
@@ -191,4 +198,19 @@ type ToolWithEffortLevel interface {
 	// SetEffortLevel sets the effort level for the tool.
 	// Valid values depend on the tool (e.g., "low", "medium", "high" for Claude).
 	SetEffortLevel(level string)
+}
+
+// SetPermissionMode sets the permission mode for Claude Code.
+// Valid values: "bypass" (default, all permissions auto-granted) or "interactive" (human-in-the-loop).
+func (c *ClaudeTool) SetPermissionMode(mode string) {
+	c.permissionMode = mode
+}
+
+// ToolWithPermissionMode is an optional interface for tools that support
+// configurable permission modes (e.g., bypass vs interactive).
+type ToolWithPermissionMode interface {
+	Tool
+	// SetPermissionMode sets the permission mode for the tool.
+	// Valid values: "bypass" (default) or "interactive" (human-in-the-loop).
+	SetPermissionMode(mode string)
 }

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -308,6 +308,152 @@ func TestRegistryGetDefault(t *testing.T) {
 	}
 }
 
+func TestClaudeSetPermissionMode_Interface(t *testing.T) {
+	tool := NewClaude()
+
+	// Verify ClaudeTool implements ToolWithPermissionMode
+	twpm, ok := tool.(ToolWithPermissionMode)
+	if !ok {
+		t.Fatal("Claude tool should implement ToolWithPermissionMode")
+	}
+
+	// Verify the method works without panic
+	twpm.SetPermissionMode("interactive")
+}
+
+func TestClaudeBuildCommand_InteractiveMode(t *testing.T) {
+	ct := &ClaudeTool{permissionMode: "interactive"}
+	sessionID := "test-session-123"
+
+	cmd := ct.BuildCommand(sessionID, false, "")
+
+	// Should have --verbose and --session-id but NOT --permission-mode/bypassPermissions
+	if !contains(cmd, "--verbose") {
+		t.Error("Expected command to contain '--verbose'")
+	}
+	if !contains(cmd, "--session-id") {
+		t.Error("Expected command to contain '--session-id'")
+	}
+	if !contains(cmd, sessionID) {
+		t.Errorf("Expected command to contain '%s'", sessionID)
+	}
+	if contains(cmd, "--permission-mode") {
+		t.Error("Expected command NOT to contain '--permission-mode' in interactive mode")
+	}
+	if contains(cmd, "bypassPermissions") {
+		t.Error("Expected command NOT to contain 'bypassPermissions' in interactive mode")
+	}
+}
+
+func TestClaudeBuildCommand_BypassModeExplicit(t *testing.T) {
+	ct := &ClaudeTool{permissionMode: "bypass"}
+	sessionID := "test-session-123"
+
+	cmd := ct.BuildCommand(sessionID, false, "")
+
+	// Explicit "bypass" should behave like default (include --permission-mode bypassPermissions)
+	if !contains(cmd, "--permission-mode") {
+		t.Error("Expected command to contain '--permission-mode' in bypass mode")
+	}
+	if !contains(cmd, "bypassPermissions") {
+		t.Error("Expected command to contain 'bypassPermissions' in bypass mode")
+	}
+}
+
+func TestClaudeGetSandboxSettings_InteractiveMode(t *testing.T) {
+	ct := &ClaudeTool{permissionMode: "interactive"}
+
+	settings := ct.GetSandboxSettings()
+
+	// Should NOT have bypass permission keys
+	if _, ok := settings["allowDangerouslySkipPermissions"]; ok {
+		t.Error("Expected no 'allowDangerouslySkipPermissions' key in interactive mode")
+	}
+	if _, ok := settings["bypassPermissionsModeAccepted"]; ok {
+		t.Error("Expected no 'bypassPermissionsModeAccepted' key in interactive mode")
+	}
+	if _, ok := settings["permissions"]; ok {
+		t.Error("Expected no 'permissions' key in interactive mode")
+	}
+
+	// Should still have effort level keys
+	if settings["effortLevel"] != "medium" {
+		t.Errorf("Expected effortLevel 'medium', got '%v'", settings["effortLevel"])
+	}
+	if settings["effortLevelAccepted"] != true {
+		t.Error("Expected effortLevelAccepted to be true")
+	}
+	if settings["hasSeenEffortPrompt"] != true {
+		t.Error("Expected hasSeenEffortPrompt to be true")
+	}
+	if settings["effortCalloutDismissed"] != true {
+		t.Error("Expected effortCalloutDismissed to be true")
+	}
+
+	env, ok := settings["env"].(map[string]string)
+	if !ok {
+		t.Fatal("Expected env to be map[string]string")
+	}
+	if env["CLAUDE_CODE_EFFORT_LEVEL"] != "medium" {
+		t.Errorf("Expected CLAUDE_CODE_EFFORT_LEVEL 'medium', got '%s'", env["CLAUDE_CODE_EFFORT_LEVEL"])
+	}
+}
+
+func TestClaudeGetSandboxSettings_BypassModeDefault(t *testing.T) {
+	ct := &ClaudeTool{} // Empty permissionMode = default bypass
+
+	settings := ct.GetSandboxSettings()
+
+	// Should have bypass permission keys (default behavior)
+	if settings["allowDangerouslySkipPermissions"] != true {
+		t.Error("Expected allowDangerouslySkipPermissions to be true")
+	}
+	if settings["bypassPermissionsModeAccepted"] != true {
+		t.Error("Expected bypassPermissionsModeAccepted to be true")
+	}
+
+	permissions, ok := settings["permissions"].(map[string]string)
+	if !ok {
+		t.Fatal("Expected permissions to be map[string]string")
+	}
+	if permissions["defaultMode"] != "bypassPermissions" {
+		t.Errorf("Expected defaultMode 'bypassPermissions', got '%s'", permissions["defaultMode"])
+	}
+
+	// Should also have effort level keys
+	if settings["effortLevel"] != "medium" {
+		t.Errorf("Expected effortLevel 'medium', got '%v'", settings["effortLevel"])
+	}
+}
+
+func TestClaudeBuildCommand_ResumeInteractiveMode(t *testing.T) {
+	ct := &ClaudeTool{permissionMode: "interactive"}
+	resumeSessionID := "cli-session-456"
+
+	cmd := ct.BuildCommand("", true, resumeSessionID)
+
+	// Should have --resume with session ID
+	if !contains(cmd, "--resume") {
+		t.Error("Expected command to contain '--resume'")
+	}
+	if !contains(cmd, resumeSessionID) {
+		t.Errorf("Expected command to contain '%s'", resumeSessionID)
+	}
+
+	// Should NOT have permission flags
+	if contains(cmd, "--permission-mode") {
+		t.Error("Expected command NOT to contain '--permission-mode' in interactive mode")
+	}
+	if contains(cmd, "bypassPermissions") {
+		t.Error("Expected command NOT to contain 'bypassPermissions' in interactive mode")
+	}
+
+	// Should still have --verbose
+	if !contains(cmd, "--verbose") {
+		t.Error("Expected command to contain '--verbose'")
+	}
+}
+
 // Helper functions
 
 func contains(slice []string, item string) bool {


### PR DESCRIPTION
## Summary

Closes #165

- Adds `permission_mode` option under `[tool]` config section with values `"bypass"` (default) and `"interactive"` (human-in-the-loop)
- When `"interactive"`: Claude omits `--permission-mode bypassPermissions` flag and bypass settings from `settings.json`; opencode returns empty sandbox settings
- Effort level settings are always injected regardless of permission mode
- Default behavior is unchanged for backward compatibility

## Changes

- `internal/config/config.go` — `PermissionMode` field on `ToolConfig` + merge logic
- `internal/tool/tool.go` — `ToolWithPermissionMode` interface, `ClaudeTool.SetPermissionMode()`, conditional bypass in `BuildCommand()` and `GetSandboxSettings()`
- `internal/tool/opencode.go` — `SetPermissionMode()`, conditional bypass in `GetSandboxSettings()`
- `internal/cli/shell.go` — Wire config to tool via `ToolWithPermissionMode` interface
- Tests for all three packages (10 new tests)
- `CHANGELOG.md` — Feature entry

## Test plan

- [x] `go build ./...` compiles
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (no new issues)
- [x] `go test ./internal/tool/...` — 10 new tests pass
- [x] `go test ./internal/config/...` — 1 new table-driven test (4 cases) passes
- [x] All existing tests unchanged and still passing