### PR TITLE
fix: opencode interactive permission mode ineffective

### DIFF
--- a/internal/tool/opencode.go
+++ b/internal/tool/opencode.go
@@ -28,12 +28,18 @@ func (c *OpencodeTool) BuildCommand(sessionID string, resume bool, resumeSession
 // DiscoverSessionID returns "" because opencode uses SQLite (not JSONL files).
 func (c *OpencodeTool) DiscoverSessionID(stateDir string) string { return "" }
 
-// GetSandboxSettings returns the opencode permission bypass config.
-// Injected into ~/.config/opencode/opencode.json so opencode runs without interactive prompts.
-// Returns empty map when permission mode is "interactive" (human-in-the-loop).
+// GetSandboxSettings returns the opencode permission config.
+// In bypass mode (default): injects {"permission": {"*": "allow"}} so opencode runs
+// without interactive prompts.
+// In interactive mode: injects {"permission": {"*": "ask"}} so opencode prompts the
+// user before each action (human-in-the-loop).
 func (c *OpencodeTool) GetSandboxSettings() map[string]interface{} {
 	if c.permissionMode == "interactive" {
-		return map[string]interface{}{}
+		return map[string]interface{}{
+			"permission": map[string]interface{}{
+				"*": "ask",
+			},
+		}
 	}
 	return map[string]interface{}{
 		"permission": map[string]interface{}{

--- a/internal/tool/opencode_test.go
+++ b/internal/tool/opencode_test.go
@@ -153,8 +153,20 @@ func TestOpencodeTool_GetSandboxSettings_InteractiveMode(t *testing.T) {
 	oc := &OpencodeTool{permissionMode: "interactive"}
 	settings := oc.GetSandboxSettings()
 
-	if len(settings) != 0 {
-		t.Errorf("Expected empty map in interactive mode, got %v", settings)
+	perm, ok := settings["permission"]
+	if !ok {
+		t.Fatal("GetSandboxSettings() missing 'permission' key in interactive mode")
+	}
+	permMap, ok := perm.(map[string]interface{})
+	if !ok {
+		t.Fatalf("'permission' value is %T, want map[string]interface{}", perm)
+	}
+	val, ok := permMap["*"]
+	if !ok {
+		t.Fatal("permission map missing '*' key in interactive mode")
+	}
+	if val != "ask" {
+		t.Errorf("permission['*'] = %q, want %q", val, "ask")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When `permission_mode = "interactive"`, `GetSandboxSettings()` returned an empty map `{}`
- In opencode, no permissions config means no restrictions — so interactive mode was identical to bypass mode
- Fix: return `{"permission": {"*": "ask"}}` in interactive mode, which correctly makes opencode prompt the user before each action
- See [opencode permissions docs](https://opencode.ai/docs/permissions/) for reference

Ref #186

## Test plan

- [ ] Unit test `TestOpencodeTool_GetSandboxSettings_InteractiveMode` updated and passes
- [ ] All existing tool tests pass: `go test ./internal/tool/`
- [ ] `make build` succeeds