### PR TITLE
fix: opencode session resume in ephemeral mode (#196)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ test-config.toml
 # Session data (for local testing)
 .claude-on-incus/
 
+# opencode data (created when running opencode in workspace)
+.local/
+
 # Backup files
 *.bck.yml
 *.backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- [Fix] **opencode session resume in ephemeral mode** — `coi shell --tool=opencode --continue` now correctly resumes the previous session. Two fixes: (1) `BuildCommand()` passes `--continue` (or `--session <id>`) to opencode when resuming, instead of always returning bare `opencode`. (2) New `ToolWithContainerEnv` interface allows tools to inject environment variables into the container; opencode uses this to set `XDG_DATA_HOME` and `XDG_STATE_HOME` to workspace subdirectories, so the SQLite database persists on the host mount across ephemeral container recreations instead of being destroyed with the container's `~/.local/share/opencode/`. Fixes #196.
+
 - [Fix] **`coi build --force` works from any directory** — Build assets (`coi.sh` build script and `dummy` test stub) are now embedded into the binary at compile time via `//go:embed`, so `coi build` no longer requires running from the project root. Disk files still take priority for development (#176).
 
 ### Features

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -566,6 +566,15 @@ func ensureTmuxServer(mgr *container.Manager, userPtr *int) {
 	}
 }
 
+// mergeToolEnv adds tool-specific environment variables (if the tool implements ToolWithContainerEnv).
+func mergeToolEnv(env map[string]string, t tool.Tool, workspacePath string) {
+	if twce, ok := t.(tool.ToolWithContainerEnv); ok {
+		for k, v := range twce.GetContainerEnv(workspacePath) {
+			env[k] = v
+		}
+	}
+}
+
 // runCLI executes the CLI tool in the container interactively
 func runCLI(result *session.SetupResult, sessionID string, useResumeFlag, restoreOnly bool, sessionsDir, resumeID string, t tool.Tool) error {
 	cmdToRun := buildCLICommand(sessionID, useResumeFlag, restoreOnly, sessionsDir, resumeID, t)
@@ -575,6 +584,7 @@ func runCLI(result *session.SetupResult, sessionID string, useResumeFlag, restor
 	if workspacePath == "" {
 		workspacePath = "/workspace" // Fallback for backwards compatibility
 	}
+	mergeToolEnv(containerEnv, t, workspacePath)
 	opts := container.ExecCommandOptions{
 		User:        userPtr,
 		Cwd:         workspacePath,
@@ -598,6 +608,7 @@ func runCLIInTmux(result *session.SetupResult, sessionID string, detached bool, 
 
 	cliCmd := buildCLICommand(sessionID, useResumeFlag, restoreOnly, sessionsDir, resumeID, t)
 	containerEnv, userPtr := buildContainerEnv(result)
+	mergeToolEnv(containerEnv, t, workspacePath)
 
 	// Build environment export commands for tmux
 	envExports := ""

--- a/internal/cli/shell_opencode_test.go
+++ b/internal/cli/shell_opencode_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/tool"
+)
+
+// TestBuildCLICommand_Opencode_NewSession verifies that opencode gets a bare
+// command when starting a new session (no resume flags).
+func TestBuildCLICommand_Opencode_NewSession(t *testing.T) {
+	oc := tool.NewOpencode()
+	cmd := buildCLICommand("session-1", false, false, "/tmp/sessions", "", oc)
+	if cmd != "opencode" {
+		t.Errorf("buildCLICommand(new session) = %q, want %q", cmd, "opencode")
+	}
+}
+
+// TestBuildCLICommand_Opencode_Resume verifies that opencode gets --continue
+// when resuming without a specific session ID.
+func TestBuildCLICommand_Opencode_Resume(t *testing.T) {
+	oc := tool.NewOpencode()
+	cmd := buildCLICommand("", true, false, "/tmp/sessions", "prev-session", oc)
+	if cmd != "opencode --continue" {
+		t.Errorf("buildCLICommand(resume) = %q, want %q", cmd, "opencode --continue")
+	}
+}
+
+// TestBuildCLICommand_Opencode_RestoreOnly verifies that opencode gets --continue
+// when restoring from saved state (ephemeral container recreation).
+func TestBuildCLICommand_Opencode_RestoreOnly(t *testing.T) {
+	oc := tool.NewOpencode()
+	cmd := buildCLICommand("", false, true, "/tmp/sessions", "prev-session", oc)
+	if cmd != "opencode --continue" {
+		t.Errorf("buildCLICommand(restoreOnly) = %q, want %q", cmd, "opencode --continue")
+	}
+}
+
+// TestBuildCLICommand_Opencode_DummyMode verifies that the dummy mode override
+// replaces "opencode" with "dummy" (used in CI/testing).
+func TestBuildCLICommand_Opencode_DummyMode(t *testing.T) {
+	t.Setenv("COI_USE_DUMMY", "1")
+
+	oc := tool.NewOpencode()
+	cmd := buildCLICommand("session-1", false, false, "/tmp/sessions", "", oc)
+	if cmd != "dummy" {
+		t.Errorf("buildCLICommand(dummy) = %q, want %q", cmd, "dummy")
+	}
+}
+
+// TestBuildCLICommand_Opencode_DummyModeResume verifies dummy override preserves
+// resume flags.
+func TestBuildCLICommand_Opencode_DummyModeResume(t *testing.T) {
+	t.Setenv("COI_USE_DUMMY", "1")
+
+	oc := tool.NewOpencode()
+	cmd := buildCLICommand("", true, false, "/tmp/sessions", "prev-session", oc)
+	if cmd != "dummy --continue" {
+		t.Errorf("buildCLICommand(dummy resume) = %q, want %q", cmd, "dummy --continue")
+	}
+}
+
+// TestMergeToolEnv_Opencode verifies that opencode's XDG env vars are merged
+// into the container environment.
+func TestMergeToolEnv_Opencode(t *testing.T) {
+	env := map[string]string{"HOME": "/home/code"}
+	oc := tool.NewOpencode()
+	mergeToolEnv(env, oc, "/workspace")
+
+	if env["XDG_DATA_HOME"] != "/workspace/.local/share" {
+		t.Errorf("XDG_DATA_HOME = %q, want %q", env["XDG_DATA_HOME"], "/workspace/.local/share")
+	}
+	if env["XDG_STATE_HOME"] != "/workspace/.local/state" {
+		t.Errorf("XDG_STATE_HOME = %q, want %q", env["XDG_STATE_HOME"], "/workspace/.local/state")
+	}
+	// HOME should not be overwritten
+	if env["HOME"] != "/home/code" {
+		t.Errorf("HOME = %q, want %q", env["HOME"], "/home/code")
+	}
+}
+
+// TestMergeToolEnv_Claude verifies that Claude (no ToolWithContainerEnv) doesn't
+// add extra env vars.
+func TestMergeToolEnv_Claude(t *testing.T) {
+	env := map[string]string{"HOME": "/home/code"}
+	cl := tool.NewClaude()
+	mergeToolEnv(env, cl, "/workspace")
+
+	if _, ok := env["XDG_DATA_HOME"]; ok {
+		t.Error("Claude should not set XDG_DATA_HOME")
+	}
+}

--- a/internal/session/setup_opencode_test.go
+++ b/internal/session/setup_opencode_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/tool"
+)
+
+// TestBuildJSONFromSettings_OpencodeBypass verifies that opencode's sandbox
+// settings (bypass mode) are correctly serialized to JSON.
+func TestBuildJSONFromSettings_OpencodeBypass(t *testing.T) {
+	oc := tool.NewOpencode()
+	settings := oc.GetSandboxSettings()
+
+	jsonStr, err := buildJSONFromSettings(settings)
+	if err != nil {
+		t.Fatalf("buildJSONFromSettings() error: %v", err)
+	}
+
+	// Parse the JSON back and verify structure
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	// Verify permission key
+	perm, ok := parsed["permission"]
+	if !ok {
+		t.Fatal("JSON missing 'permission' key")
+	}
+	permMap, ok := perm.(map[string]interface{})
+	if !ok {
+		t.Fatalf("'permission' is %T, want map", perm)
+	}
+	if permMap["*"] != "allow" {
+		t.Errorf("permission['*'] = %v, want 'allow'", permMap["*"])
+	}
+}
+
+// TestBuildJSONFromSettings_OpencodeInteractive verifies that interactive mode
+// produces correct sandbox settings JSON.
+func TestBuildJSONFromSettings_OpencodeInteractive(t *testing.T) {
+	oc := &tool.OpencodeTool{}
+	oc.SetPermissionMode("interactive")
+	settings := oc.GetSandboxSettings()
+
+	jsonStr, err := buildJSONFromSettings(settings)
+	if err != nil {
+		t.Fatalf("buildJSONFromSettings() error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	// Verify permission is "ask" in interactive mode
+	permMap := parsed["permission"].(map[string]interface{})
+	if permMap["*"] != "ask" {
+		t.Errorf("permission['*'] = %v, want 'ask'", permMap["*"])
+	}
+}
+
+// TestBuildJSONFromSettings_OpencodeRoundTrip verifies that the JSON output
+// can round-trip: marshal -> unmarshal -> re-marshal produces identical output.
+// This ensures no data is lost when the settings are written to opencode.json.
+func TestBuildJSONFromSettings_OpencodeRoundTrip(t *testing.T) {
+	oc := tool.NewOpencode()
+	settings := oc.GetSandboxSettings()
+
+	jsonStr, err := buildJSONFromSettings(settings)
+	if err != nil {
+		t.Fatalf("buildJSONFromSettings() error: %v", err)
+	}
+
+	// Unmarshal and re-marshal
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("Failed to parse first JSON: %v", err)
+	}
+
+	jsonStr2, err := buildJSONFromSettings(parsed)
+	if err != nil {
+		t.Fatalf("second buildJSONFromSettings() error: %v", err)
+	}
+
+	if jsonStr != jsonStr2 {
+		t.Errorf("Round-trip mismatch:\n  first:  %s\n  second: %s", jsonStr, jsonStr2)
+	}
+}

--- a/internal/tool/opencode.go
+++ b/internal/tool/opencode.go
@@ -1,5 +1,7 @@
 package tool
 
+import "path/filepath"
+
 // OpencodeTool implements Tool for opencode (https://opencode.ai)
 type OpencodeTool struct {
 	permissionMode string // "bypass" (default) or "interactive"
@@ -18,11 +20,18 @@ func (c *OpencodeTool) ConfigDirName() string { return ".config/opencode" }
 func (c *OpencodeTool) SessionsDirName() string { return "sessions-opencode" }
 
 // BuildCommand builds the opencode launch command.
-// opencode stores all sessions in the workspace's .opencode/ SQLite DB.
-// It always starts with a new session — use Ctrl+S inside opencode to switch
-// to a previous session. There's no CLI flag for auto-resume.
+// When resume is true, passes --continue to auto-resume the last session,
+// or --session <id> if a specific session ID is provided.
 func (c *OpencodeTool) BuildCommand(sessionID string, resume bool, resumeSessionID string) []string {
-	return []string{"opencode"}
+	cmd := []string{"opencode"}
+	if resume {
+		if resumeSessionID != "" {
+			cmd = append(cmd, "--session", resumeSessionID)
+		} else {
+			cmd = append(cmd, "--continue")
+		}
+	}
+	return cmd
 }
 
 // DiscoverSessionID returns "" because opencode uses SQLite (not JSONL files).
@@ -69,3 +78,15 @@ func (c *OpencodeTool) StateConfigFileName() string { return "" }
 // AlwaysSetupConfig implements ToolWithConfigDirFiles.
 // Opencode needs sandbox permission bypass even without host config dir.
 func (c *OpencodeTool) AlwaysSetupConfig() bool { return true }
+
+// GetContainerEnv implements ToolWithContainerEnv.
+// Redirects XDG data and state directories to the workspace mount so opencode's
+// SQLite database persists across ephemeral container recreations.
+// Without this, data lives in ~/.local/share/opencode/ (inside the container)
+// and is destroyed when the ephemeral container is deleted.
+func (c *OpencodeTool) GetContainerEnv(workspacePath string) map[string]string {
+	return map[string]string{
+		"XDG_DATA_HOME":  filepath.Join(workspacePath, ".local", "share"),
+		"XDG_STATE_HOME": filepath.Join(workspacePath, ".local", "state"),
+	}
+}

--- a/internal/tool/opencode_test.go
+++ b/internal/tool/opencode_test.go
@@ -31,19 +31,29 @@ func TestOpencodeTool_BuildCommand_NewSession(t *testing.T) {
 
 func TestOpencodeTool_BuildCommand_Resume(t *testing.T) {
 	oc := NewOpencode()
-	// opencode auto-continues from workspace .opencode/ SQLite, no flag needed
 	cmd := oc.BuildCommand("", true, "")
-	if len(cmd) != 1 || cmd[0] != "opencode" {
-		t.Errorf("BuildCommand(resume) = %v, want [opencode]", cmd)
+	expected := []string{"opencode", "--continue"}
+	if len(cmd) != len(expected) {
+		t.Fatalf("BuildCommand(resume) = %v, want %v", cmd, expected)
+	}
+	for i, v := range expected {
+		if cmd[i] != v {
+			t.Errorf("BuildCommand(resume)[%d] = %q, want %q", i, cmd[i], v)
+		}
 	}
 }
 
 func TestOpencodeTool_BuildCommand_ResumeWithID(t *testing.T) {
 	oc := NewOpencode()
-	// opencode auto-continues from workspace .opencode/ SQLite, no flag needed
 	cmd := oc.BuildCommand("", true, "some-id")
-	if len(cmd) != 1 || cmd[0] != "opencode" {
-		t.Errorf("BuildCommand(resume with ID) = %v, want [opencode]", cmd)
+	expected := []string{"opencode", "--session", "some-id"}
+	if len(cmd) != len(expected) {
+		t.Fatalf("BuildCommand(resume with ID) = %v, want %v", cmd, expected)
+	}
+	for i, v := range expected {
+		if cmd[i] != v {
+			t.Errorf("BuildCommand(resume with ID)[%d] = %q, want %q", i, cmd[i], v)
+		}
 	}
 }
 
@@ -188,6 +198,31 @@ func TestOpencodeTool_GetSandboxSettings_BypassDefault(t *testing.T) {
 	}
 	if val != "allow" {
 		t.Errorf("permission['*'] = %q, want %q", val, "allow")
+	}
+}
+
+func TestOpencodeTool_ImplementsContainerEnv(t *testing.T) {
+	oc := NewOpencode()
+
+	twce, ok := oc.(ToolWithContainerEnv)
+	if !ok {
+		t.Fatal("OpencodeTool should implement ToolWithContainerEnv")
+	}
+
+	env := twce.GetContainerEnv("/workspace")
+	if env["XDG_DATA_HOME"] != "/workspace/.local/share" {
+		t.Errorf("XDG_DATA_HOME = %q, want %q", env["XDG_DATA_HOME"], "/workspace/.local/share")
+	}
+	if env["XDG_STATE_HOME"] != "/workspace/.local/state" {
+		t.Errorf("XDG_STATE_HOME = %q, want %q", env["XDG_STATE_HOME"], "/workspace/.local/state")
+	}
+}
+
+func TestOpencodeTool_GetContainerEnv_CustomWorkspace(t *testing.T) {
+	oc := &OpencodeTool{}
+	env := oc.GetContainerEnv("/home/user/project")
+	if env["XDG_DATA_HOME"] != "/home/user/project/.local/share" {
+		t.Errorf("XDG_DATA_HOME = %q, want %q", env["XDG_DATA_HOME"], "/home/user/project/.local/share")
 	}
 }
 

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -200,6 +200,17 @@ type ToolWithEffortLevel interface {
 	SetEffortLevel(level string)
 }
 
+// ToolWithContainerEnv is an optional interface for tools that need extra
+// environment variables set inside the container (e.g., to redirect data
+// storage to the workspace mount so it persists across ephemeral sessions).
+type ToolWithContainerEnv interface {
+	Tool
+	// GetContainerEnv returns environment variables to set when executing
+	// the tool inside the container. workspacePath is the mount point
+	// inside the container (e.g. "/workspace").
+	GetContainerEnv(workspacePath string) map[string]string
+}
+
 // SetPermissionMode sets the permission mode for Claude Code.
 // Valid values: "bypass" (default, all permissions auto-granted) or "interactive" (human-in-the-loop).
 func (c *ClaudeTool) SetPermissionMode(mode string) {


### PR DESCRIPTION
## Summary

- **`BuildCommand()`** now passes `--continue` (or `--session <id>`) to opencode when resuming, instead of always returning bare `["opencode"]`
- **`ToolWithContainerEnv`** new optional interface lets tools inject env vars into the container; opencode uses it to set `XDG_DATA_HOME` and `XDG_STATE_HOME` to workspace subdirectories so the SQLite DB persists on the host mount across ephemeral container recreations
- **`mergeToolEnv()`** wired into both `runCLI` and `runCLIInTmux` to apply tool-specific env vars

Fixes #196

## Files changed

| File | Change |
|------|--------|
| `internal/tool/opencode.go` | `BuildCommand()` resume flags + `GetContainerEnv()` for XDG redirection |
| `internal/tool/tool.go` | New `ToolWithContainerEnv` interface |
| `internal/cli/shell.go` | `mergeToolEnv()` helper, wired into both execution paths |
| `internal/tool/opencode_test.go` | Updated resume tests + new `ToolWithContainerEnv` tests |
| `internal/cli/shell_opencode_test.go` | Integration tests for `buildCLICommand` + `mergeToolEnv` with opencode |
| `internal/session/setup_opencode_test.go` | Integration tests for `buildJSONFromSettings` round-trip |
| `CHANGELOG.md` | Entry under Unreleased |
| `.gitignore` | Ignore `.local/` (created by opencode in workspace) |

## Test plan

- [x] `go test ./internal/tool/ -run TestOpencode -v` — all 16 tests pass
- [x] `go test ./internal/cli/ -run "TestBuildCLICommand_Opencode|TestMergeToolEnv" -v` — all 7 tests pass
- [x] `go test ./internal/session/ -run TestBuildJSONFromSettings_Opencode -v` — all 3 tests pass
- [x] Manual: `coi shell --tool opencode`, chat, poweroff, `coi shell --tool opencode --continue` — previous session resumes
- [x] Verify `.local/share/opencode/` appears in workspace dir on host