### PR TITLE
fix: address Copilot review feedback for forward_env

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -349,9 +349,9 @@ func appendEnvArgs(incusArgs []string) []string {
 	}
 
 	// Resolve forward_env: merge config + --forward-env flag, deduplicate, look up host values
-	forwardNames := mergeStringSliceUnique(cfg.Defaults.ForwardEnv, forwardEnvVars)
+	forwardNames := config.MergeStringSliceUnique(cfg.Defaults.ForwardEnv, forwardEnvVars)
 	for _, name := range forwardNames {
-		if val := os.Getenv(name); val != "" {
+		if val, ok := os.LookupEnv(name); ok {
 			incusArgs = append(incusArgs, "--env", fmt.Sprintf("%s=%s", name, val))
 		} else {
 			fmt.Fprintf(os.Stderr, "Warning: forward_env variable %q is not set on host, skipping\n", name)

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -541,9 +541,9 @@ func buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
 	}
 
 	// Resolve forward_env: merge config + --forward-env flag, deduplicate, then look up host values
-	forwardNames := mergeStringSliceUnique(cfg.Defaults.ForwardEnv, forwardEnvVars)
+	forwardNames := config.MergeStringSliceUnique(cfg.Defaults.ForwardEnv, forwardEnvVars)
 	for _, name := range forwardNames {
-		if val := os.Getenv(name); val != "" {
+		if val, ok := os.LookupEnv(name); ok {
 			containerEnv[name] = val
 		} else {
 			fmt.Fprintf(os.Stderr, "Warning: forward_env variable %q is not set on host, skipping\n", name)
@@ -564,21 +564,6 @@ func buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
 	}
 
 	return containerEnv, userPtr
-}
-
-// mergeStringSliceUnique appends items from other to base, skipping duplicates
-func mergeStringSliceUnique(base, other []string) []string {
-	seen := make(map[string]bool, len(base))
-	for _, s := range base {
-		seen[s] = true
-	}
-	for _, s := range other {
-		if !seen[s] {
-			base = append(base, s)
-			seen[s] = true
-		}
-	}
-	return base
 }
 
 // ensureTmuxServer starts the tmux server and polls until it is ready (up to 2 seconds).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -393,7 +393,7 @@ func (c *Config) Merge(other *Config) {
 
 	// Merge forward_env (append without duplicates)
 	if len(other.Defaults.ForwardEnv) > 0 {
-		c.Defaults.ForwardEnv = mergeStringSliceUnique(c.Defaults.ForwardEnv, other.Defaults.ForwardEnv)
+		c.Defaults.ForwardEnv = MergeStringSliceUnique(c.Defaults.ForwardEnv, other.Defaults.ForwardEnv)
 	}
 
 	// Merge environment (other takes precedence for overlapping keys)
@@ -624,8 +624,8 @@ func mergeMonitoring(base *MonitoringConfig, other *MonitoringConfig) {
 	}
 }
 
-// mergeStringSliceUnique appends items from other to base, skipping duplicates
-func mergeStringSliceUnique(base, other []string) []string {
+// MergeStringSliceUnique appends items from other to base, skipping duplicates
+func MergeStringSliceUnique(base, other []string) []string {
 	seen := make(map[string]bool, len(base))
 	for _, s := range base {
 		seen[s] = true


### PR DESCRIPTION
## Summary

Addresses the 4 Copilot review comments from PR #202:

- **Deduplicate `mergeStringSliceUnique`**: Export as `config.MergeStringSliceUnique` and remove the duplicate copy from `cli/shell.go`. Both `shell.go` and `run.go` now call the single shared implementation.
- **Use `os.LookupEnv` instead of `os.Getenv`**: Correctly distinguishes "not set" from "set to empty string". Variables intentionally set to `""` on the host are now forwarded instead of being skipped with a warning.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/` passes
- [x] Existing integration tests cover the behavior