### PR TITLE
fix: stabilize flaky allowlist firewall test with rule polling

### DIFF
--- a/tests/network/test_allowlist.py
+++ b/tests/network/test_allowlist.py
@@ -9,8 +9,12 @@ Network isolation is implemented using firewalld direct rules.
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from support.helpers import wait_for_firewall_rules
 
 
 def test_allowlist_mode_allows_specified_domains(coi_binary, workspace_dir, cleanup_containers):
@@ -175,9 +179,10 @@ refresh_interval_minutes = 30
             timeout=10,
         )
 
-        # Wait for firewall rules to be fully applied (CI timing issue)
-        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
-        time.sleep(5)
+        # Wait for firewall rules to be fully applied (poll for default-deny rule)
+        assert wait_for_firewall_rules(container_name, timeout=30), (
+            "Firewall default-deny rule was not applied in time"
+        )
 
         # Test: curl blocked domain (should fail)
         result = subprocess.run(
@@ -524,8 +529,6 @@ refresh_interval_minutes = 30
         )
 
         # Give server time to start
-        import time
-
         time.sleep(2)
 
         # Get container's IP address using incus list (more reliable than hostname -I)
@@ -613,8 +616,6 @@ def test_restricted_allows_host_to_access_container_services(
     )
 
     # Give server time to start
-    import time
-
     time.sleep(2)
 
     # Get container's IP address using incus list (more reliable than hostname -I)

--- a/tests/network/test_network_allowlist_comprehensive.py
+++ b/tests/network/test_network_allowlist_comprehensive.py
@@ -9,8 +9,11 @@ Network isolation is implemented using firewalld direct rules.
 
 import os
 import subprocess
+import sys
 import tempfile
-import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from support.helpers import wait_for_firewall_rules
 
 
 def test_allowlist_allows_specified_domains(coi_binary, workspace_dir, cleanup_containers):
@@ -174,9 +177,10 @@ refresh_interval_minutes = 30
             timeout=10,
         )
 
-        # Wait for firewall rules to be fully applied (CI timing issue)
-        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
-        time.sleep(5)
+        # Wait for firewall rules to be fully applied (poll for default-deny rule)
+        assert wait_for_firewall_rules(container_name, timeout=30), (
+            "Firewall default-deny rule was not applied in time"
+        )
 
         # Test: curl example.com (NOT in allowlist, should fail)
         result = subprocess.run(
@@ -278,9 +282,10 @@ refresh_interval_minutes = 30
 
         assert container_name, f"Could not find container name in output: {output}"
 
-        # Wait for firewall rules to be fully applied (CI timing issue)
-        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
-        time.sleep(5)
+        # Wait for firewall rules to be fully applied (poll for default-deny rule)
+        assert wait_for_firewall_rules(container_name, timeout=30), (
+            "Firewall default-deny rule was not applied in time"
+        )
 
         # Test: attempt connection to 10.0.0.1 (even though in allowlist)
         result = subprocess.run(
@@ -463,9 +468,10 @@ refresh_interval_minutes = 30
 
         assert container_name, f"Could not find container name in output: {output}"
 
-        # Wait for firewall rules to be fully applied (CI timing issue)
-        # Use longer delay (5s) as firewalld rule propagation can be slow in CI
-        time.sleep(5)
+        # Wait for firewall rules to be fully applied (poll for default-deny rule)
+        assert wait_for_firewall_rules(container_name, timeout=30), (
+            "Firewall default-deny rule was not applied in time"
+        )
 
         # Test: nslookup query to Quad9 DNS 9.9.9.9 (NOT in allowlist, should fail)
         result = subprocess.run(

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1135,6 +1135,64 @@ def wait_for_pattern_in_monitor(monitor, pattern, timeout=30, poll_interval=0.5)
     return None
 
 
+def wait_for_firewall_rules(container_name, timeout=30, poll_interval=0.5):
+    """
+    Poll firewalld until the default-deny REJECT rule is active for a container.
+
+    Queries ``firewall-cmd --direct --get-all-rules`` and looks for the
+    priority-99 ``0.0.0.0/0 REJECT`` rule whose source matches the
+    container's IP.  Returns ``True`` once the rule appears, or ``False``
+    on timeout.
+
+    Args:
+        container_name: Incus container name (used to look up the IP).
+        timeout: Maximum seconds to wait (default 30).
+        poll_interval: Seconds between polls (default 0.5).
+    """
+    # Resolve the container's IPv4 address once.
+    ip_result = subprocess.run(
+        ["incus", "list", container_name, "--format=json"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if ip_result.returncode != 0:
+        return False
+
+    import json as _json
+
+    info = _json.loads(ip_result.stdout)
+    if not info:
+        return False
+
+    container_ip = None
+    for addr in info[0].get("state", {}).get("network", {}).get("eth0", {}).get("addresses", []):
+        if addr.get("family") == "inet":
+            container_ip = addr["address"]
+            break
+
+    if not container_ip:
+        return False
+
+    # Poll for the default-deny rule.
+    start = time.time()
+    while time.time() - start < timeout:
+        result = subprocess.run(
+            ["sudo", "-n", "firewall-cmd", "--direct", "--get-all-rules"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                # Match: ipv4 filter FORWARD 99 -s <container_ip> -d 0.0.0.0/0 -j REJECT
+                if container_ip in line and "0.0.0.0/0" in line and "REJECT" in line:
+                    return True
+        time.sleep(poll_interval)
+
+    return False
+
+
 def get_screen_display(child, refresh=False, clear_buffer=False):
     """
     Get the current rendered screen display.


### PR DESCRIPTION
## Summary

- Add `wait_for_firewall_rules()` helper that polls `firewall-cmd --direct --get-all-rules` until the default-deny REJECT rule is active for the container IP
- Replace fixed `time.sleep(5)` in `test_allowlist.py` and `test_network_allowlist_comprehensive.py` with the deterministic helper (30s timeout)
- Clean up unused `import time` statements

## Problem

`test_allowlist_blocks_non_allowed_domains` was flaky in CI — firewalld rule propagation sometimes took longer than the 5-second sleep, allowing `curl github.com` to succeed before the rules were in place.

Failure: https://github.com/mensfeld/code-on-incus/actions/runs/22962114534/job/66655519346

## Test plan

- [ ] CI network tests pass (specifically `test_allowlist_blocks_non_allowed_domains`)
- [ ] No regressions in other network tests