### PR TITLE
feat: split version checks between health (warn) and CLI commands (fail)

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -69,6 +69,11 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
 	}
 
+	// Check minimum Incus version
+	if err := container.CheckMinimumVersion(); err != nil {
+		return err
+	}
+
 	// Configure build options
 	opts := image.BuildOptions{
 		Force:       buildForce,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -54,6 +54,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
 	}
 
+	// Check minimum Incus version
+	if err := container.CheckMinimumVersion(); err != nil {
+		return err
+	}
+
 	// Allocate slot if not specified
 	slotNum := slot
 	if slotNum == 0 {

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -82,6 +82,11 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
 	}
 
+	// Check minimum Incus version
+	if err := container.CheckMinimumVersion(); err != nil {
+		return err
+	}
+
 	// Get configured tool (needed to determine tool-specific sessions directory)
 	// --tool flag overrides whatever is in .coi.toml or global config
 	if toolFlag != "" {

--- a/internal/container/version.go
+++ b/internal/container/version.go
@@ -82,6 +82,32 @@ func MeetsMinimumVersion(v *IncusVersion) bool {
 	return false
 }
 
+// CheckMinimumVersion checks the running Incus server version and returns an error
+// if it is below the minimum required version. Returns nil if the version is OK or
+// cannot be determined (graceful degradation).
+func CheckMinimumVersion() error {
+	output, err := IncusOutput("version")
+	if err != nil {
+		return nil // Can't get version, don't block
+	}
+
+	versionStr, err := ExtractServerVersion(output)
+	if err != nil {
+		return nil
+	}
+
+	v, err := ParseIncusVersion(versionStr)
+	if err != nil {
+		return nil
+	}
+
+	if !MeetsMinimumVersion(v) {
+		return fmt.Errorf("%s", FormatMinVersionError(v))
+	}
+
+	return nil
+}
+
 // FormatMinVersionError returns an actionable error message for users with old Incus versions
 func FormatMinVersionError(v *IncusVersion) string {
 	return fmt.Sprintf(

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -159,7 +159,7 @@ func evaluateIncusVersion(versionOutput string) HealthCheck {
 	if !container.MeetsMinimumVersion(v) {
 		return HealthCheck{
 			Name:    "incus",
-			Status:  StatusFailed,
+			Status:  StatusWarning,
 			Message: container.FormatMinVersionError(v),
 			Details: map[string]interface{}{
 				"version": versionStr,
@@ -1602,7 +1602,7 @@ func evaluateNFTVersion(nftPath, versionOutput string) *HealthCheck {
 	if !nftmonitor.MeetsMinimumNFTVersion(v) {
 		return &HealthCheck{
 			Name:    "nftables",
-			Status:  StatusFailed,
+			Status:  StatusWarning,
 			Message: nftmonitor.FormatMinNFTVersionError(v),
 			Details: map[string]interface{}{
 				"nft_path": nftPath,

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -29,9 +29,9 @@ func TestCheckIncus_VersionCheck(t *testing.T) {
 		t.Errorf("Expected check name 'incus', got '%s'", result.Name)
 	}
 
-	// Should be OK or Failed (version too old)
-	if result.Status != StatusOK && result.Status != StatusFailed {
-		t.Errorf("Expected StatusOK or StatusFailed, got %s: %s", result.Status, result.Message)
+	// Should be OK or Warning (version too old)
+	if result.Status != StatusOK && result.Status != StatusWarning {
+		t.Errorf("Expected StatusOK or StatusWarning, got %s: %s", result.Status, result.Message)
 	}
 
 	// Details should contain a version
@@ -58,18 +58,18 @@ func TestCheckIncus_VersionCheck(t *testing.T) {
 			t.Errorf("Message should contain version %q, got %q", versionStr, result.Message)
 		}
 	} else {
-		if result.Status != StatusFailed {
+		if result.Status != StatusWarning {
 			t.Errorf("Version %s is below minimum but status is %s", versionStr, result.Status)
 		}
 		if !strings.Contains(result.Message, "zabbly") {
-			t.Errorf("Failed message should mention zabbly, got %q", result.Message)
+			t.Errorf("Warning message should mention zabbly, got %q", result.Message)
 		}
 	}
 
 	t.Logf("CheckIncus: status=%s version=%s message=%s", result.Status, versionStr, result.Message)
 }
 
-// evaluateIncusVersion should return StatusFailed with zabbly upgrade instructions for old versions
+// evaluateIncusVersion should return StatusWarning with zabbly upgrade instructions for old versions
 // (6.0.x, 5.x), StatusOK for versions meeting minimum (6.1+, 7.x), and degrade gracefully
 // (StatusOK) when the version output is unparseable or empty.
 func TestEvaluateIncusVersion_OldVersion(t *testing.T) {
@@ -80,21 +80,21 @@ func TestEvaluateIncusVersion_OldVersion(t *testing.T) {
 		expectContains string
 	}{
 		{
-			"Ubuntu 6.0.x fails",
+			"Ubuntu 6.0.x warns",
 			"Client version: 6.0.3\nServer version: 6.0.3",
-			StatusFailed,
+			StatusWarning,
 			"zabbly",
 		},
 		{
-			"6.0.0 fails",
+			"6.0.0 warns",
 			"Client version: 6.0.0\nServer version: 6.0.0",
-			StatusFailed,
+			StatusWarning,
 			"6.1",
 		},
 		{
-			"5.x fails",
+			"5.x warns",
 			"Server version: 5.21",
-			StatusFailed,
+			StatusWarning,
 			"zabbly",
 		},
 		{
@@ -118,7 +118,7 @@ func TestEvaluateIncusVersion_OldVersion(t *testing.T) {
 		{
 			"single line fallback",
 			"6.0.1",
-			StatusFailed,
+			StatusWarning,
 			"zabbly",
 		},
 		{
@@ -191,7 +191,7 @@ func TestCheckNFTables_VersionCheck(t *testing.T) {
 			t.Errorf("OK message should contain version %q, got %q", versionStr, result.Message)
 		}
 	} else {
-		if result.Status != StatusFailed {
+		if result.Status != StatusWarning {
 			t.Errorf("Version %s is below minimum but status is %s", versionStr, result.Status)
 		}
 	}
@@ -199,7 +199,7 @@ func TestCheckNFTables_VersionCheck(t *testing.T) {
 	t.Logf("CheckNFTables: status=%s version=%s message=%s", result.Status, versionStr, result.Message)
 }
 
-// evaluateNFTVersion should return a StatusFailed HealthCheck for old versions (0.8.x, 0.7.x),
+// evaluateNFTVersion should return a StatusWarning HealthCheck for old versions (0.8.x, 0.7.x),
 // nil for versions meeting minimum (0.9.0+, 1.x), and nil when the version output is
 // unparseable or empty (graceful degradation, version check is skipped).
 func TestEvaluateNFTVersion_OldVersion(t *testing.T) {
@@ -255,8 +255,8 @@ func TestEvaluateNFTVersion_OldVersion(t *testing.T) {
 				if result == nil {
 					t.Fatal("Expected a failed HealthCheck, got nil")
 				}
-				if result.Status != StatusFailed {
-					t.Errorf("Expected StatusFailed, got %s: %s", result.Status, result.Message)
+				if result.Status != StatusWarning {
+					t.Errorf("Expected StatusWarning, got %s: %s", result.Status, result.Message)
 				}
 				if !strings.Contains(result.Message, tt.expectContains) {
 					t.Errorf("Expected message to contain %q, got %q", tt.expectContains, result.Message)


### PR DESCRIPTION
## Summary

- `coi health` now shows **StatusWarning** (not StatusFailed) for old Incus/nftables versions, so it reports the issue without making the overall status "unhealthy" on version alone
- `coi shell`, `coi run`, and `coi build` now call `container.CheckMinimumVersion()` and **exit with a non-zero error** if Incus < 6.1, preventing users from hitting the cryptic idmapping error
- Added `container.CheckMinimumVersion()` helper that runs `incus version`, parses the output, and returns an error if below minimum (gracefully returns nil if version can't be determined)
- Added Karafka-style descriptive comments to all integration tests

## Behavior

| Command | Old Incus version | New Incus version |
|---|---|---|
| `coi health` | `[WARN] Incus: Incus version 6.0.3 is below...` (exit 1, degraded) | `[OK] Incus: Running (version 6.21)` (exit 0) |
| `coi shell` | `Error: Incus version 6.0.3 is below...` (exit 1) | Normal operation |
| `coi run` | `Error: Incus version 6.0.3 is below...` (exit 1) | Normal operation |
| `coi build` | `Error: Incus version 6.0.3 is below...` (exit 1) | Normal operation |

## Test plan

- [x] `go test ./internal/health/ -run TestEvaluateIncusVersion` — old versions produce StatusWarning
- [x] `go test ./internal/health/ -run TestEvaluateNFTVersion` — old versions produce StatusWarning
- [x] `go test ./internal/health/ -run TestCheckIncus_VersionCheck` — real Incus produces correct status
- [x] `go test ./internal/health/ -run TestCheckNFTables_VersionCheck` — real nft produces correct status
- [x] `go build ./...` — clean build