### PR TITLE
fix: make install.sh work with curl|bash pipe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,48 @@ BINARY_NAME="coi"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 VERSION="${VERSION:-latest}"
 
+# Detect non-interactive mode (piped input, CI, or explicit opt-in)
+if [ "${NONINTERACTIVE:-0}" = "1" ] || [ "${CI:-}" = "true" ] || ! [ -t 0 ]; then
+    NONINTERACTIVE=1
+else
+    NONINTERACTIVE=0
+fi
+
+# Prompt user for yes/no confirmation.
+# In non-interactive mode (curl|bash, CI), exits with error since we can't ask.
+# In interactive mode, reads from /dev/tty so it works even when script is piped.
+prompt_continue() {
+    local message="${1:-Continue anyway?}"
+    if [ "$NONINTERACTIVE" = "1" ]; then
+        echo -e "${YELLOW}⚠ Non-interactive mode: cannot prompt. Aborting.${NC}"
+        echo "  Re-run the script directly (not piped) or fix the issue above."
+        exit 1
+    fi
+    read -p "$message [y/N] " -n 1 -r </dev/tty
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+}
+
+# Prompt user for a choice (single character).
+# In non-interactive mode, returns the default value.
+# In interactive mode, reads from /dev/tty.
+prompt_choice() {
+    local message="$1"
+    local default="$2"
+    if [ "$NONINTERACTIVE" = "1" ]; then
+        echo -e "${BLUE}→ Non-interactive mode: using default ($default)${NC}"
+        REPLY="$default"
+        return
+    fi
+    read -p "$message" -n 1 -r </dev/tty
+    echo ""
+    if [ -z "$REPLY" ]; then
+        REPLY="$default"
+    fi
+}
+
 # Detect OS and architecture
 detect_platform() {
     local os
@@ -67,11 +109,7 @@ check_incus() {
         echo "    sudo incus admin init --auto"
         echo "    sudo usermod -aG incus-admin \$USER"
         echo ""
-        read -p "Continue installation anyway? [y/N] " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            exit 1
-        fi
+        prompt_continue "Continue installation anyway?"
     else
         local incus_version_output
         incus_version_output="$(incus version 2>/dev/null)"
@@ -102,11 +140,7 @@ check_incus() {
                     echo "  Please install Incus >= 6.1 from the Zabbly repository:"
                     echo "    https://github.com/zabbly/incus"
                     echo ""
-                    read -p "Continue installation anyway? [y/N] " -n 1 -r
-                    echo
-                    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-                        exit 1
-                    fi
+                    prompt_continue "Continue installation anyway?"
                 fi
             fi
         fi
@@ -347,8 +381,7 @@ main() {
 
     # Check if releases exist
     if curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" &> /dev/null; then
-        read -p "Choose [1/2] (default: 1): " -n 1 -r
-        echo ""
+        prompt_choice "Choose [1/2] (default: 1): " "1"
 
         case $REPLY in
             2)

--- a/internal/installer/install_sh_test.go
+++ b/internal/installer/install_sh_test.go
@@ -1,0 +1,149 @@
+package installer_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installShPath returns the absolute path to install.sh at the repo root.
+func installShPath(t *testing.T) string {
+	t.Helper()
+	// Walk up from this test file to repo root
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Join(wd, "..", "..")
+	path := filepath.Join(root, "install.sh")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install.sh not found at %s: %v", path, err)
+	}
+	return path
+}
+
+// runBashSnippet runs a bash snippet that sources the install.sh functions and
+// returns stdout, stderr, and the exit code. The snippet runs with
+// NONINTERACTIVE=1 by default unless overridden via env.
+func runBashSnippet(t *testing.T, snippet string, env ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = append(os.Environ(), env...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run snippet: %v", err)
+		}
+	}
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// When stdin is not a terminal (piped input), install.sh should detect non-interactive
+// mode automatically via the `! [ -t 0 ]` check in the NONINTERACTIVE detection block.
+func TestInstallSh_DetectsNonInteractiveWhenPiped(t *testing.T) {
+	script := installShPath(t)
+
+	// Source install.sh functions and check the NONINTERACTIVE variable.
+	// We pipe through bash (simulating curl|bash) so stdin is not a TTY.
+	snippet := `
+		# Source just the variable/function definitions (stop before main runs)
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		echo "NONINTERACTIVE=$NONINTERACTIVE"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "NONINTERACTIVE=1") {
+		t.Errorf("expected NONINTERACTIVE=1 when piped, got: %s", strings.TrimSpace(stdout))
+	}
+}
+
+// When NONINTERACTIVE=1 is set explicitly, prompt_continue should abort with a
+// clear message instead of trying to read from the terminal.
+func TestInstallSh_PromptContinueAbortsNonInteractive(t *testing.T) {
+	script := installShPath(t)
+
+	snippet := `
+		export NONINTERACTIVE=1
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		prompt_continue "Continue anyway?"
+		echo "SHOULD_NOT_REACH"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "NONINTERACTIVE=1")
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit code from prompt_continue in non-interactive mode")
+	}
+	if strings.Contains(stdout, "SHOULD_NOT_REACH") {
+		t.Errorf("prompt_continue should have exited, but execution continued")
+	}
+	if !strings.Contains(stdout, "Non-interactive mode") {
+		t.Errorf("expected non-interactive warning message, got: %s", stdout)
+	}
+}
+
+// When NONINTERACTIVE=1 is set, prompt_choice should return the default value
+// without attempting to read from the terminal.
+func TestInstallSh_PromptChoiceUsesDefaultNonInteractive(t *testing.T) {
+	script := installShPath(t)
+
+	snippet := `
+		export NONINTERACTIVE=1
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		prompt_choice "Pick one: " "1"
+		echo "REPLY=$REPLY"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "NONINTERACTIVE=1")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "REPLY=1") {
+		t.Errorf("expected REPLY=1 (default), got: %s", strings.TrimSpace(stdout))
+	}
+}
+
+// When CI=true is set, install.sh should detect non-interactive mode even
+// without piped stdin or explicit NONINTERACTIVE flag.
+func TestInstallSh_DetectsCI(t *testing.T) {
+	script := installShPath(t)
+
+	snippet := `
+		export CI=true
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		echo "NONINTERACTIVE=$NONINTERACTIVE"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "CI=true")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "NONINTERACTIVE=1") {
+		t.Errorf("expected NONINTERACTIVE=1 with CI=true, got: %s", strings.TrimSpace(stdout))
+	}
+}
+
+// prompt_choice should use a non-default value ("2") when that is passed as default.
+func TestInstallSh_PromptChoiceCustomDefault(t *testing.T) {
+	script := installShPath(t)
+
+	snippet := `
+		export NONINTERACTIVE=1
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		prompt_choice "Pick one: " "2"
+		echo "REPLY=$REPLY"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "NONINTERACTIVE=1")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "REPLY=2") {
+		t.Errorf("expected REPLY=2, got: %s", strings.TrimSpace(stdout))
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `curl -fsSL .../install.sh | bash` failing silently because `read` consumed script content from stdin instead of reading user input
- Add `prompt_continue()` and `prompt_choice()` helpers that read from `/dev/tty` in interactive mode
- Auto-detect non-interactive mode via `! [ -t 0 ]`, `CI=true`, or `NONINTERACTIVE=1`
- In non-interactive mode: `prompt_continue` aborts cleanly with a message, `prompt_choice` uses the default value

Addresses #212 (point 2)

## Test plan
- [x] `go test ./internal/installer/ -v` — 5 integration tests covering pipe detection, prompt abort, choice defaults, CI detection
- [ ] Manual: `curl -fsSL .../install.sh | bash` no longer hangs
- [ ] Manual: `bash install.sh` still prompts interactively