### PR TITLE
fix: update post_install firewalld hint to match auto-setup flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -408,9 +408,12 @@ post_install() {
     fi
 
     if ! command -v firewall-cmd &> /dev/null; then
-        echo -e "${YELLOW}⚠ For network isolation (restricted/allowlist modes), install firewalld:${NC}"
-        echo "   ${BLUE}sudo apt install firewalld && sudo systemctl enable --now firewalld${NC}"
-        echo "   See README for full setup instructions."
+        echo -e "${YELLOW}⚠ Firewalld is not installed — network isolation (restricted/allowlist modes) will not work.${NC}"
+        echo "   Re-run this installer or set up manually: ${BLUE}sudo apt install firewalld && sudo systemctl enable --now firewalld && sudo firewall-cmd --permanent --add-masquerade && sudo firewall-cmd --reload${NC}"
+        echo ""
+    elif ! sudo -n firewall-cmd --query-masquerade &> /dev/null 2>&1; then
+        echo -e "${YELLOW}⚠ Firewalld masquerade is not enabled — containers may not reach the internet.${NC}"
+        echo "   Run: ${BLUE}sudo firewall-cmd --permanent --add-masquerade && sudo firewall-cmd --reload${NC}"
         echo ""
     fi
 


### PR DESCRIPTION
## Summary

- The `post_install()` function in `install.sh` still printed incomplete manual firewalld instructions (missing masquerade) even though `check_firewalld()` now handles interactive setup (from #216)
- Updated the hint to mention masquerade in the manual command
- Added a new check: if firewalld is installed but masquerade is not enabled, warn specifically about that

## Test plan

- [x] `go test ./internal/installer/ -run TestInstallSh -v` — all pass