### PR TITLE
Add security posture health check to coi health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Features
 
+- [Feature] **Security posture health check** — `coi health` now shows a "Security posture" check under CRITICAL that reports whether seccomp and AppArmor isolation are active on the default Incus profile. Reports full isolation (unprivileged + seccomp + AppArmor), seccomp-only (macOS/Lima where AppArmor is unavailable), warns on custom `raw.seccomp`/`raw.apparmor` overrides, and fails when `security.privileged=true` disables all isolation. Includes detailed JSON output with per-feature status.
 - [Feature] **Kernel version check (warning)** — `coi shell`, `coi run`, and `coi build` now warn on stderr when the host kernel is below 5.15, which may lack security features needed for safe container isolation. The check skips gracefully on macOS/darwin and on any failure. Also surfaced as a SYSTEM check in `coi health`. (#237)
 - [Feature] **Privileged container guard (hard block)** — COI now refuses to start containers when `security.privileged=true` is detected on either the container config or the default Incus profile, which silently defeats all container isolation. Returns an actionable error message with the exact `incus` command to fix it. Checked in `LaunchContainer`, `LaunchContainerPersistent`, and session setup. Also surfaced as a CRITICAL check in `coi health`. (#237)
 

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -89,7 +89,7 @@ func outputHealthText(result *health.HealthResult) error {
 	// Group checks by category
 	categories := map[string][]string{
 		"SYSTEM":        {"os", "kernel_version"},
-		"CRITICAL":      {"incus", "permissions", "image", "image_age", "privileged_profile"},
+		"CRITICAL":      {"incus", "permissions", "image", "image_age", "privileged_profile", "security_posture"},
 		"NETWORKING":    {"network_bridge", "ip_forwarding", "firewall", "bridge_firewalld_zone", "docker_forward_policy"},
 		"MONITORING":    {"nftables", "systemd_journal", "libsystemd"},
 		"STORAGE":       {"coi_directory", "sessions_directory", "disk_space", "incus_storage_pool"},
@@ -230,6 +230,7 @@ func formatCheckName(name string) string {
 		"dns_resolution":        "DNS resolution",
 		"passwordless_sudo":     "Passwordless sudo",
 		"orphaned_resources":    "Orphaned resources",
+		"security_posture":      "Security posture",
 	}
 
 	if displayName, ok := specialCases[name]; ok {

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -2239,3 +2239,108 @@ func CheckPrivilegedProfile() HealthCheck {
 		Message: "Default profile uses unprivileged containers",
 	}
 }
+
+// CheckSecurityPosture checks the overall container security posture by inspecting
+// seccomp, AppArmor, and privilege settings on the default Incus profile.
+func CheckSecurityPosture() HealthCheck {
+	if !container.Available() {
+		return HealthCheck{
+			Name:    "security_posture",
+			Status:  StatusOK,
+			Message: "Skipped (Incus not available)",
+		}
+	}
+
+	details := map[string]interface{}{}
+
+	// Check security.privileged
+	privOutput, err := container.IncusOutput("profile", "get", "default", "security.privileged")
+	if err != nil {
+		return HealthCheck{
+			Name:    "security_posture",
+			Status:  StatusWarning,
+			Message: "Could not check default profile — unable to verify security posture",
+			Details: map[string]interface{}{
+				"error": err.Error(),
+			},
+		}
+	}
+
+	privileged := strings.TrimSpace(privOutput) == "true"
+	details["privileged"] = privileged
+
+	if privileged {
+		details["seccomp"] = "disabled (privileged)"
+		details["apparmor"] = "disabled (privileged)"
+		details["raw_seccomp_override"] = false
+		details["raw_apparmor_override"] = false
+
+		return HealthCheck{
+			Name:   "security_posture",
+			Status: StatusFailed,
+			Message: "Privileged containers — seccomp and AppArmor are disabled. " +
+				"Remove with: incus profile unset default security.privileged",
+			Details: details,
+		}
+	}
+
+	// Check raw.seccomp override
+	rawSeccomp, _ := container.IncusOutput("profile", "get", "default", "raw.seccomp")
+	rawSeccompOverride := strings.TrimSpace(rawSeccomp) != ""
+	details["raw_seccomp_override"] = rawSeccompOverride
+
+	if rawSeccompOverride {
+		details["seccomp"] = "custom override"
+	} else {
+		details["seccomp"] = "enabled (default)"
+	}
+
+	// Check raw.apparmor override
+	rawApparmor, _ := container.IncusOutput("profile", "get", "default", "raw.apparmor")
+	rawApparmorOverride := strings.TrimSpace(rawApparmor) != ""
+	details["raw_apparmor_override"] = rawApparmorOverride
+
+	// Check host AppArmor availability
+	apparmorAvailable := false
+
+	if runtime.GOOS == "linux" {
+		if content, err := os.ReadFile("/sys/module/apparmor/parameters/enabled"); err == nil {
+			apparmorAvailable = strings.TrimSpace(string(content)) == "Y"
+		}
+	}
+
+	if rawApparmorOverride {
+		details["apparmor"] = "custom override"
+	} else if apparmorAvailable {
+		details["apparmor"] = "enabled (default)"
+	} else {
+		details["apparmor"] = "not available"
+	}
+
+	// Determine status
+	if rawSeccompOverride || rawApparmorOverride {
+		msg := "Custom security profile overrides detected — verify your raw.seccomp/raw.apparmor settings"
+		return HealthCheck{
+			Name:    "security_posture",
+			Status:  StatusWarning,
+			Message: msg,
+			Details: details,
+		}
+	}
+
+	if !apparmorAvailable {
+		return HealthCheck{
+			Name:    "security_posture",
+			Status:  StatusOK,
+			Message: "Seccomp enabled, AppArmor not available (seccomp-only isolation)",
+			Details: details,
+		}
+	}
+
+	return HealthCheck{
+		Name:    "security_posture",
+		Status:  StatusOK,
+		Message: "Full isolation — unprivileged containers with seccomp and AppArmor",
+		Details: details,
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -62,6 +62,7 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	checks["image"] = CheckImage(cfg.Defaults.Image)
 	checks["image_age"] = CheckImageAge(cfg.Defaults.Image)
 	checks["privileged_profile"] = CheckPrivilegedProfile()
+	checks["security_posture"] = CheckSecurityPosture()
 
 	// Networking checks
 	checks["network_bridge"] = CheckNetworkBridge()

--- a/tests/health/health_json_output.py
+++ b/tests/health/health_json_output.py
@@ -68,6 +68,7 @@ def test_health_json_output(coi_binary):
         "permissions",
         "image",
         "privileged_profile",
+        "security_posture",
         "network_bridge",
         "disk_space",
         "incus_storage_pool",

--- a/tests/health/health_security_posture.py
+++ b/tests/health/health_security_posture.py
@@ -1,0 +1,211 @@
+"""
+Test for coi health — security posture check.
+
+Tests that:
+1. Security posture appears in text output
+2. security_posture appears in JSON output with correct structure and details
+3. On a clean default profile, status is "ok"
+4. When security.privileged=true, status is "failed"
+5. When raw.seccomp is overridden, status is "warning"
+6. When raw.apparmor is overridden, status is "warning"
+"""
+
+import json
+import subprocess
+
+
+def _get_profile_value(key):
+    """Get a config value from the default profile."""
+    result = subprocess.run(
+        ["incus", "profile", "get", "default", key],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip() or None
+    return None
+
+
+def _set_profile_value(key, value):
+    """Set a config value on the default profile."""
+    result = subprocess.run(
+        ["incus", "profile", "set", "default", f"{key}={value}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"Failed to set {key}={value}: {result.stderr}"
+
+
+def _unset_profile_value(key):
+    """Unset a config value on the default profile."""
+    subprocess.run(
+        ["incus", "profile", "unset", "default", key],
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def _restore_profile_value(key, original_value):
+    """Restore a profile config value to its original state."""
+    if original_value is None or original_value == "":
+        _unset_profile_value(key)
+    else:
+        _set_profile_value(key, original_value)
+
+
+def _run_health_json(coi_binary):
+    """Run coi health --format json and return parsed security_posture check."""
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    data = json.loads(result.stdout)
+    return result.returncode, data["checks"]["security_posture"]
+
+
+def test_health_security_posture_text(coi_binary):
+    """
+    Verify coi health text output includes the Security posture check.
+    """
+    result = subprocess.run(
+        [coi_binary, "health"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2], (
+        f"Health check failed unexpectedly. stderr: {result.stderr}"
+    )
+
+    output = result.stdout
+    assert "Security posture" in output, (
+        f"Should show Security posture in text output. Got:\n{output}"
+    )
+
+
+def test_health_security_posture_json(coi_binary):
+    """
+    Verify coi health JSON output includes security_posture with correct structure.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2], (
+        f"Health check failed with exit {result.returncode}. stderr: {result.stderr}"
+    )
+
+    data = json.loads(result.stdout)
+    checks = data["checks"]
+
+    assert "security_posture" in checks, "Should have security_posture check"
+
+    sp = checks["security_posture"]
+    assert sp["name"] == "security_posture", (
+        f"Check name should be 'security_posture'. Got: {sp['name']}"
+    )
+    assert sp["status"] in ["ok", "warning", "failed"], f"Invalid status: {sp['status']}"
+    assert "message" in sp, "Should have a message"
+
+    # Verify details are present (unless skipped)
+    if "Skipped" not in sp["message"]:
+        assert "details" in sp, "Should have details when not skipped"
+        details = sp["details"]
+        assert "seccomp" in details, "Details should include seccomp"
+        assert "apparmor" in details, "Details should include apparmor"
+        assert "privileged" in details, "Details should include privileged"
+        assert "raw_seccomp_override" in details, "Details should include raw_seccomp_override"
+        assert "raw_apparmor_override" in details, "Details should include raw_apparmor_override"
+
+
+def test_health_security_posture_ok_on_default(coi_binary):
+    """
+    On a clean default profile (unprivileged, no raw overrides), status should be "ok".
+    """
+    rc, sp = _run_health_json(coi_binary)
+
+    assert rc in [0, 1], f"Health check failed with exit {rc}"
+    assert sp["status"] == "ok", (
+        f"Default profile should have ok security posture. Got: {sp['status']} — {sp['message']}"
+    )
+
+
+def test_health_security_posture_failed_when_privileged(coi_binary):
+    """
+    Verify security_posture is "failed" when security.privileged=true.
+
+    Saves and restores the original profile value to be self-contained.
+    """
+    original = _get_profile_value("security.privileged")
+    try:
+        _set_profile_value("security.privileged", "true")
+
+        rc, sp = _run_health_json(coi_binary)
+
+        assert rc == 2, f"Health should be unhealthy with privileged profile. Exit code: {rc}"
+        assert sp["status"] == "failed", (
+            f"security_posture should be 'failed' when privileged. "
+            f"Got: {sp['status']} — {sp['message']}"
+        )
+        assert sp["details"]["privileged"] is True, "Details should show privileged=true"
+        assert "disabled" in sp["details"]["seccomp"], "Seccomp should be disabled"
+        assert "disabled" in sp["details"]["apparmor"], "AppArmor should be disabled"
+    finally:
+        _restore_profile_value("security.privileged", original)
+
+
+def test_health_security_posture_warning_on_raw_seccomp(coi_binary):
+    """
+    Verify security_posture is "warning" when raw.seccomp is overridden.
+
+    Saves and restores the original profile value to be self-contained.
+    """
+    original = _get_profile_value("raw.seccomp")
+    try:
+        _set_profile_value("raw.seccomp", "2 1 amd64")
+
+        rc, sp = _run_health_json(coi_binary)
+
+        assert rc in [1, 2], f"Health should be degraded or unhealthy. Exit code: {rc}"
+        assert sp["status"] == "warning", (
+            f"security_posture should be 'warning' with raw.seccomp override. "
+            f"Got: {sp['status']} — {sp['message']}"
+        )
+        assert sp["details"]["raw_seccomp_override"] is True, (
+            "Details should show raw_seccomp_override=true"
+        )
+    finally:
+        _restore_profile_value("raw.seccomp", original)
+
+
+def test_health_security_posture_warning_on_raw_apparmor(coi_binary):
+    """
+    Verify security_posture is "warning" when raw.apparmor is overridden.
+
+    Saves and restores the original profile value to be self-contained.
+    """
+    original = _get_profile_value("raw.apparmor")
+    try:
+        _set_profile_value("raw.apparmor", "/usr/bin/** rix,")
+
+        rc, sp = _run_health_json(coi_binary)
+
+        assert rc in [1, 2], f"Health should be degraded or unhealthy. Exit code: {rc}"
+        assert sp["status"] == "warning", (
+            f"security_posture should be 'warning' with raw.apparmor override. "
+            f"Got: {sp['status']} — {sp['message']}"
+        )
+        assert sp["details"]["raw_apparmor_override"] is True, (
+            "Details should show raw_apparmor_override=true"
+        )
+    finally:
+        _restore_profile_value("raw.apparmor", original)

--- a/tests/health/health_text_output.py
+++ b/tests/health/health_text_output.py
@@ -49,6 +49,7 @@ def test_health_text_output(coi_binary):
     assert "Operating system" in output, "Should show OS info"
     assert "Kernel version" in output, "Should check kernel version"
     assert "Privileged check" in output, "Should check privileged profile"
+    assert "Security posture" in output, "Should check security posture"
     assert "Network bridge" in output, "Should check network bridge"
     assert "Disk space" in output, "Should check disk space"
     assert "Incus storage pool" in output, "Should check Incus storage pool"


### PR DESCRIPTION
## Summary
- Adds a new **"Security posture"** check under CRITICAL in `coi health` that reports whether seccomp and AppArmor isolation are active on the default Incus profile
- Checks `security.privileged`, `raw.seccomp`, and `raw.apparmor` config keys plus host AppArmor availability via `/sys/module/apparmor/parameters/enabled`
- Status logic: OK (full isolation), OK with note (seccomp-only, e.g. macOS/Lima), Warning (custom raw overrides), Failed (privileged containers)
- JSON output includes detailed `seccomp`, `apparmor`, `privileged`, `raw_seccomp_override`, `raw_apparmor_override` fields

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./internal/health/...` passes
- [x] `ruff format --check tests/ && ruff check tests/` passes
- [x] `coi health` shows "Security posture" under CRITICAL
- [x] `coi health --format json` includes `security_posture` with details
- [x] New integration tests: text output, JSON structure + details, OK on default, failed on privileged, warning on raw.seccomp override, warning on raw.apparmor override
- [x] Existing tests updated: `health_json_output.py` expects `security_posture`, `health_text_output.py` asserts "Security posture"