### PR TITLE
Address Copilot review feedback on profile CRUD commands

### DIFF
--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -322,6 +322,11 @@ Examples:
 	},
 }
 
+// shellQuote wraps a string in single quotes for safe shell interpolation.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
 func formatStringSlice(ss []string) string {
 	quoted := make([]string, len(ss))
 	for i, s := range ss {
@@ -416,8 +421,13 @@ func resolveProfileDir(name string, forceUser, forceProject bool) (string, error
 		return "", fmt.Errorf("cannot resolve workspace: %w", err)
 	}
 	coiDir := filepath.Join(absWorkspace, ".coi")
-	if info, err := os.Stat(coiDir); err == nil && info.IsDir() {
-		return filepath.Join(coiDir, "profiles", name), nil
+	info, statErr := os.Stat(coiDir)
+	if statErr == nil {
+		if info.IsDir() {
+			return filepath.Join(coiDir, "profiles", name), nil
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", fmt.Errorf("cannot stat project .coi directory %q: %w", coiDir, statErr)
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -450,6 +460,9 @@ Examples:
 		if strings.Contains(name, "/") || strings.Contains(name, "\\") {
 			return fmt.Errorf("profile name cannot contain slashes")
 		}
+		if strings.Trim(name, ".") == "" {
+			return fmt.Errorf("profile name cannot be '.', '..', or consist only of dots")
+		}
 		if name == "default" {
 			return fmt.Errorf("cannot create a profile named 'default' (reserved for built-in profile)")
 		}
@@ -460,25 +473,33 @@ Examples:
 			return fmt.Errorf("--user and --project are mutually exclusive")
 		}
 
+		// Check if a profile with this name already exists in any config source
+		if existing := cfg.GetProfile(name); existing != nil {
+			return fmt.Errorf("profile '%s' already exists (source: %s)", name, existing.Source)
+		}
+
 		profileDir, err := resolveProfileDir(name, forceUser, forceProject)
 		if err != nil {
 			return err
 		}
 
-		// Check directory doesn't already exist
-		if _, err := os.Stat(profileDir); err == nil {
+		// Check directory doesn't already exist on disk
+		if _, statErr := os.Stat(profileDir); statErr == nil {
 			return fmt.Errorf("profile directory already exists: %s", profileDir)
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("failed to check profile directory %s: %w", profileDir, statErr)
 		}
 
 		// Build TOML content from flags
+		// Note: --image and --persistent are inherited from root PersistentFlags
 		var lines []string
-		if image, _ := cmd.Flags().GetString("image"); image != "" {
-			lines = append(lines, fmt.Sprintf("image = %q", image))
+		if cmd.Flags().Changed("image") {
+			lines = append(lines, fmt.Sprintf("image = %q", imageName))
 		}
 		if inherits, _ := cmd.Flags().GetString("inherits"); inherits != "" {
 			lines = append(lines, fmt.Sprintf("inherits = %q", inherits))
 		}
-		if persistent, _ := cmd.Flags().GetBool("persistent"); persistent {
+		if cmd.Flags().Changed("persistent") {
 			lines = append(lines, "persistent = true")
 		}
 
@@ -539,7 +560,8 @@ Examples:
 			editor = "vi"
 		}
 
-		editorCmd := exec.Command(editor, sourcePath)
+		// Use sh -c to support multi-word editor values like "code --wait"
+		editorCmd := exec.Command("sh", "-c", editor+" "+shellQuote(sourcePath))
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr
@@ -608,9 +630,7 @@ Examples:
 func init() {
 	profileListCmd.Flags().StringVar(&profileFormat, "format", "text", "Output format: text or json")
 
-	profileCreateCmd.Flags().String("image", "", "Set the image alias")
 	profileCreateCmd.Flags().String("inherits", "", "Set the parent profile to inherit from")
-	profileCreateCmd.Flags().Bool("persistent", false, "Set persistent = true")
 	profileCreateCmd.Flags().Bool("user", false, "Force creation in ~/.coi/profiles/")
 	profileCreateCmd.Flags().Bool("project", false, "Force creation in ./.coi/profiles/")
 

--- a/tests/cli/test_profile_crud.py
+++ b/tests/cli/test_profile_crud.py
@@ -7,7 +7,7 @@ import subprocess
 
 
 def test_profile_create_basic(coi_binary, tmp_path):
-    """coi profile create with --image should create a profile and show it in list."""
+    """coi profile create with --image should create a profile and write its config."""
     home_coi = tmp_path / ".coi"
     home_coi.mkdir()
 
@@ -148,6 +148,21 @@ def test_profile_create_project_flag(coi_binary, tmp_path):
     assert config_path.exists(), f"config.toml not created at {config_path}"
 
 
+def test_profile_create_dot_names_rejected(coi_binary, tmp_path):
+    """Profile names like '.' and '..' should be rejected (path traversal)."""
+    for dot_name in [".", "..", "..."]:
+        result = subprocess.run(
+            [coi_binary, "profile", "create", dot_name, "--user"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "HOME": str(tmp_path)},
+        )
+
+        assert result.returncode != 0, f"Name '{dot_name}' should be rejected"
+        assert "dots" in result.stderr.lower() or "cannot be" in result.stderr.lower()
+
+
 def test_profile_create_slash_in_name_rejected(coi_binary, tmp_path):
     """Profile names with slashes should be rejected."""
     result = subprocess.run(
@@ -259,6 +274,150 @@ def test_profile_edit_builtin_fails(coi_binary):
 
     assert result.returncode != 0
     assert "built-in" in result.stderr.lower()
+
+
+def test_profile_create_visible_in_list(coi_binary, tmp_path):
+    """A newly created profile should appear in 'profile list'."""
+    home_coi = tmp_path / ".coi"
+    home_coi.mkdir()
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+
+    result = subprocess.run(
+        [coi_binary, "profile", "create", "list-test", "--image", "coi-test", "--user"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0
+
+    result = subprocess.run(
+        [coi_binary, "profile", "list"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "list-test" in result.stdout
+
+
+def test_profile_create_no_flags_produces_empty_config(coi_binary, tmp_path):
+    """Creating a profile with no --image/--inherits/--persistent produces an empty config."""
+    home_coi = tmp_path / ".coi"
+    home_coi.mkdir()
+
+    result = subprocess.run(
+        [coi_binary, "profile", "create", "bare-profile", "--user"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert result.returncode == 0
+
+    config_path = home_coi / "profiles" / "bare-profile" / "config.toml"
+    assert config_path.exists()
+    assert config_path.read_text() == ""
+
+
+def test_profile_create_auto_detects_project(coi_binary, tmp_path):
+    """Without --user/--project, create should use project .coi/ if it exists."""
+    # Set up a project with .coi/ directory
+    project_coi = tmp_path / ".coi"
+    project_coi.mkdir()
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "profile",
+            "create",
+            "auto-proj",
+            "--image",
+            "img",
+            "--workspace",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}: {result.stderr}"
+
+    config_path = project_coi / "profiles" / "auto-proj" / "config.toml"
+    assert config_path.exists(), f"Expected profile at project location {config_path}"
+
+
+def test_profile_create_duplicate_across_locations_fails(coi_binary, tmp_path):
+    """Creating a profile name that already exists in another location should fail."""
+    home_coi = tmp_path / ".coi"
+    home_coi.mkdir()
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+
+    # Create at user level
+    result = subprocess.run(
+        [coi_binary, "profile", "create", "cross-dup", "--image", "img", "--user"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0
+
+    # Try to create same name at project level — should fail because name exists in cfg
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".coi").mkdir()
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "profile",
+            "create",
+            "cross-dup",
+            "--image",
+            "img2",
+            "--project",
+            "--workspace",
+            str(project_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "already exists" in result.stderr
+
+
+def test_profile_edit_with_true_editor(coi_binary, tmp_path):
+    """Edit with EDITOR=true should succeed (true exits 0 without modifying)."""
+    home_coi = tmp_path / ".coi"
+    home_coi.mkdir()
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+
+    # Create a profile first
+    result = subprocess.run(
+        [coi_binary, "profile", "create", "edit-test", "--image", "img", "--user"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0
+
+    # Edit with EDITOR=true (no-op editor that exits 0)
+    result = subprocess.run(
+        [coi_binary, "profile", "edit", "edit-test"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**env, "EDITOR": "true", "VISUAL": ""},
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}: {result.stderr}"
 
 
 def test_profile_delete_short_flag(coi_binary, tmp_path):


### PR DESCRIPTION
## Summary

Addresses 6 valid findings from the Copilot review on #300:

- **Fix flag redefinition panic**: `--image` and `--persistent` were registered as local flags on `profile create`, but they already exist as root PersistentFlags. Removed the local definitions and read from inherited flags via `cmd.Flags().Changed()` + the global variables
- **Reject path traversal names**: `.`, `..`, and dot-only strings are now rejected as profile names to prevent `filepath.Join` from resolving to parent directories
- **Handle os.Stat errors properly**: `resolveProfileDir` now returns non-ENOENT errors (e.g. permission denied) instead of silently falling back to user directory. Profile directory existence check also surfaces non-IsNotExist errors
- **Support multi-word $EDITOR**: Editor invocation now uses `sh -c` so values like `code --wait` or `vim -u <rc>` work correctly
- **Detect cross-location duplicates**: `profile create` now checks `cfg.Profiles` before writing, catching cases where the same name exists in a different scan location (which would cause config.Load to fail on next run)
- **Fix test docstring**: Updated to match actual assertions

## New integration tests

- `test_profile_create_visible_in_list` — verifies created profile shows up in `profile list`
- `test_profile_create_no_flags_produces_empty_config` — empty config when no flags given
- `test_profile_create_auto_detects_project` — auto-detects project `.coi/` without explicit `--project`
- `test_profile_create_duplicate_across_locations_fails` — cross-location name collision rejected
- `test_profile_create_dot_names_rejected` — `.`, `..`, `...` all rejected
- `test_profile_edit_with_true_editor` — edit with `EDITOR=true` succeeds (validates sh -c path)

## Test plan

- [x] `go build ./...` — compiles
- [x] `go vet ./...` — clean
- [x] `ruff check` + `ruff format --check` — passes
- [x] Manual smoke test of all fixed behaviors
- [ ] CI integration tests