### PR TITLE
Update README for 0.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,18 +195,19 @@ curl -fsSL https://raw.githubusercontent.com/mensfeld/code-on-incus/master/insta
 ### Build Images
 
 ```bash
-# Build the unified coi image (5-10 minutes)
+# Build the default coi-default image (5-10 minutes)
 coi build
 
 # Build without compression (faster iteration)
 coi build --compression none
 
-# Custom image from your own build script
-coi build custom my-rust-image --script build-rust.sh
-coi build custom my-image --base coi --script setup.sh
+# Build a custom image via a profile
+coi profile create my-image --image my-image
+# Edit .coi/profiles/my-image/config.toml to add a [build] section
+coi build --profile my-image
 ```
 
-**What's included in the `coi` image:**
+**What's included in the `coi-default` image:**
 - Ubuntu 22.04 base with Docker (full Docker-in-container support)
 - **mise** (polyglot runtime manager) — Python 3, pnpm, TypeScript, tsx pre-installed; add more with `mise use go@latest`, `mise use ruby@3`, etc.
 - Node.js 20 LTS (system, for Claude CLI) + npm
@@ -217,7 +218,7 @@ coi build custom my-image --base coi --script setup.sh
 - Database clients: sqlite3, postgresql-client, redis-tools
 - imagemagick for image processing
 
-**Custom images:** Build your own specialized images using build scripts that run on top of the base `coi` image.
+**Custom images:** Build your own specialized images using profile-based build scripts that run on top of the base `coi-default` image. See the [Image Management wiki page](https://github.com/mensfeld/code-on-incus/wiki/Image-Management) for complete profile-based build workflows.
 
 ## macOS Support
 
@@ -272,7 +273,7 @@ coi update
 --resume [SESSION_ID]   # Resume from session (omit ID to auto-detect latest for workspace)
 --continue [SESSION_ID] # Alias for --resume
 --profile NAME          # Use named profile
---image NAME            # Use custom image (default: coi)
+--image NAME            # Use custom image (default: coi-default)
 ```
 
 Most container customization (network mode, mounts, environment variables, SSH agent, monitoring, timezone, resource limits, etc.) is configured via config files or profiles. See the [Configuration wiki page](https://github.com/mensfeld/code-on-incus/wiki/Configuration) for the full reference.
@@ -329,7 +330,7 @@ Config file: `~/.coi/config.toml`
 
 ```toml
 [defaults]
-image = "coi"
+image = "coi-default"
 persistent = true
 
 [tool]
@@ -400,6 +401,15 @@ Environment maps merge (child keys win, `""` clears a parent key). Arrays (`moun
 **Profile context files:** When a profile includes `context = "CONTEXT.md"`, the referenced markdown file is automatically appended to `~/SANDBOX_CONTEXT.md` and tool-native auto-context files (e.g., `~/.claude/CLAUDE.md`) under a `# User-Provided Profile Context` heading. This gives AI agents profile-specific instructions (e.g., "use pytest", "follow PEP 8") without manual setup.
 
 ```bash
+# Create a new profile
+coi profile create rust-dev --image coi-rust --inherits default
+
+# Edit a profile's config.toml in $EDITOR
+coi profile edit rust-dev
+
+# Delete a profile
+coi profile delete rust-dev --force
+
 # Use a profile
 coi shell --profile rust-dev
 


### PR DESCRIPTION
## Summary

- Rename default image `coi` → `coi-default` in build examples, global flags block, and config sample
- Replace removed `coi build custom` command with profile-based build workflow
- Document new `coi profile create`/`edit`/`delete` commands alongside existing `list`/`info`
- Point custom image docs to the Image Management wiki

## Context

0.8.0 ships several breaking changes that make the current README actively misleading: the default image was renamed, `coi build custom` was removed in favor of profile-based build, and the `profile show`/`info` rename landed. This PR brings the README in lockstep with the 0.8.0 CHANGELOG so a user following the docs succeeds on the first run.

A companion wiki update (path substitution, new Inheritance and Managing Profiles sections, Image-Management workflow replacement) is being published alongside this PR.

## Test plan

- [ ] `grep -n 'build custom' README.md` — empty
- [ ] `grep -n 'image = "coi"' README.md` — empty (only `coi-default`)
- [ ] `grep -n 'profile show' README.md` — empty
- [ ] `grep -n '\.config/coi' README.md` — empty
- [ ] Render preview on GitHub — links to Image Management wiki resolve, profile command block reads cleanly