### PR TITLE
Lock in "every profile's pool" guarantee for storage health check (#305)

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -170,13 +170,20 @@ func determineStatus(checks map[string]HealthCheck) OverallStatus {
 }
 
 // collectReferencedPools returns the de-duped list of storage pools that the
-// loaded configuration cares about: the global [container] storage_pool plus
-// every loaded profile's pool that is explicitly set. Profiles that leave
-// storage_pool empty inherit the global value at ApplyProfile time and are
-// therefore already covered by the global entry — adding "" again here would
-// mislead the check into inspecting the Incus default pool. An empty global
-// entry is still preserved so the check resolves it to the actual default
-// pool name.
+// loaded configuration cares about, so the storage-pool health check can
+// inspect every pool any profile (or the global config) might actually use.
+//
+// Rules:
+//   - The global [container] storage_pool is always included. If it is empty,
+//     CheckIncusStoragePools resolves it to the Incus default pool name, so
+//     a default-configured system still produces one meaningful entry.
+//   - Every loaded profile contributes its effective Container.StoragePool.
+//     Profile-to-profile inheritance is already flattened by
+//     ResolveProfileInheritance at load time, so a child profile that only
+//     inherits a pool (without overriding it) still shows up here.
+//   - A profile whose effective storage_pool is "" falls back to the global
+//     pool at ApplyProfile time, so we do not add "" again for it — the
+//     global entry already covers that case.
 func collectReferencedPools(cfg *config.Config) []string {
 	seen := map[string]bool{}
 	var pools []string

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,146 @@
+package health
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/config"
+)
+
+// TestCollectReferencedPools walks through the scenarios that the storage
+// pool health check must cover. It uses already-resolved in-memory Config
+// values (i.e. what collectReferencedPools actually sees after
+// ResolveProfileInheritance has run) so it exercises the enumeration logic
+// directly without dragging in TOML loading.
+func TestCollectReferencedPools(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected []string
+	}{
+		{
+			name: "global only, empty",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: ""},
+				Profiles:  map[string]config.ProfileConfig{},
+			},
+			expected: []string{""},
+		},
+		{
+			name: "global set, no profiles",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: "nvme"},
+				Profiles:  map[string]config.ProfileConfig{},
+			},
+			expected: []string{"nvme"},
+		},
+		{
+			name: "global empty + one profile with explicit pool",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: ""},
+				Profiles: map[string]config.ProfileConfig{
+					"rust": {Container: config.ContainerConfig{StoragePool: "fast"}},
+				},
+			},
+			expected: []string{"", "fast"},
+		},
+		{
+			name: "two profiles with distinct pools",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: "nvme"},
+				Profiles: map[string]config.ProfileConfig{
+					"a": {Container: config.ContainerConfig{StoragePool: "fast"}},
+					"b": {Container: config.ContainerConfig{StoragePool: "slow"}},
+				},
+			},
+			expected: []string{"nvme", "fast", "slow"},
+		},
+		{
+			name: "child profile inheriting parent's pool (post-resolution state)",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: ""},
+				Profiles: map[string]config.ProfileConfig{
+					"parent": {Container: config.ContainerConfig{StoragePool: "fast"}},
+					"child":  {Inherits: "parent", Container: config.ContainerConfig{StoragePool: "fast"}},
+				},
+			},
+			expected: []string{"", "fast"}, // deduped
+		},
+		{
+			name: "child overriding parent's pool",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: ""},
+				Profiles: map[string]config.ProfileConfig{
+					"parent": {Container: config.ContainerConfig{StoragePool: "fast"}},
+					"child":  {Inherits: "parent", Container: config.ContainerConfig{StoragePool: "slow"}},
+				},
+			},
+			expected: []string{"", "fast", "slow"},
+		},
+		{
+			name: "profile with no container section — falls back to global at runtime",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: "nvme"},
+				Profiles: map[string]config.ProfileConfig{
+					"bare": {},
+				},
+			},
+			expected: []string{"nvme"},
+		},
+		{
+			name: "dedup across profile and global",
+			cfg: &config.Config{
+				Container: config.ContainerConfig{StoragePool: "fast"},
+				Profiles: map[string]config.ProfileConfig{
+					"a": {Container: config.ContainerConfig{StoragePool: "fast"}},
+				},
+			},
+			expected: []string{"fast"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectReferencedPools(tt.cfg)
+			// cfg.Profiles is a Go map, so iteration order is random.
+			// Compare as sorted sets.
+			sort.Strings(got)
+			want := append([]string(nil), tt.expected...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("collectReferencedPools:\n got  %v\n want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestCollectReferencedPools_WithInheritance exercises the full
+// load-time inheritance resolution path. This is the key regression test:
+// if a future change to mergeProfiles or ResolveProfileInheritance breaks
+// the "child inherits parent's pool" guarantee, the enumeration would
+// silently miss the parent's pool and this test would catch it.
+func TestCollectReferencedPools_WithInheritance(t *testing.T) {
+	cfg := &config.Config{
+		Container: config.ContainerConfig{StoragePool: ""},
+		Profiles: map[string]config.ProfileConfig{
+			"parent": {Container: config.ContainerConfig{StoragePool: "fast"}},
+			// Child has NO container section at all — must inherit from parent.
+			"child": {Inherits: "parent"},
+		},
+	}
+
+	if err := cfg.ResolveProfileInheritance(); err != nil {
+		t.Fatalf("ResolveProfileInheritance: %v", err)
+	}
+
+	pools := collectReferencedPools(cfg)
+	sort.Strings(pools)
+
+	want := []string{"", "fast"}
+	sort.Strings(want)
+
+	if !reflect.DeepEqual(pools, want) {
+		t.Errorf("expected %v, got %v", want, pools)
+	}
+}

--- a/tests/health/health_storage_pools_inherited_pool.py
+++ b/tests/health/health_storage_pools_inherited_pool.py
@@ -1,0 +1,77 @@
+"""
+Regression test for issue #305: a profile that inherits its storage pool
+from a parent (without declaring its own [container] section) must still
+cause the health check to enumerate that inherited pool.
+
+This is the Python mirror of TestCollectReferencedPools_WithInheritance
+in internal/health/health_test.go: it proves the end-to-end path from
+TOML → config.Load → ResolveProfileInheritance → health check enumeration.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _create_temp_pool(name):
+    result = subprocess.run(
+        ["incus", "storage", "create", name, "dir"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode == 0, result.stderr
+
+
+def _delete_temp_pool(name):
+    subprocess.run(
+        ["incus", "storage", "delete", name],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_health_storage_pools_inherited_pool(coi_binary, workspace_dir):
+    """A child profile with no [container] section must inherit parent's pool."""
+    pool_name = "coi-test-inheritedpool"
+
+    ok, err = _create_temp_pool(pool_name)
+    if not ok:
+        pytest.skip(f"Cannot create temp storage pool {pool_name}: {err}")
+
+    try:
+        profiles_dir = Path(workspace_dir) / ".coi" / "profiles"
+
+        # Parent: declares the pool.
+        parent = profiles_dir / "parent"
+        parent.mkdir(parents=True)
+        (parent / "config.toml").write_text(
+            f'[container]\nstorage_pool = "{pool_name}"\n'
+        )
+
+        # Leaf: inherits from parent, no [container] at all.
+        leaf = profiles_dir / "leaf"
+        leaf.mkdir(parents=True)
+        (leaf / "config.toml").write_text('inherits = "parent"\n')
+
+        result = subprocess.run(
+            [coi_binary, "health", "--format", "json", "--workspace", workspace_dir],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=workspace_dir,
+        )
+        assert result.returncode in (0, 1), (
+            f"health should exit 0 or 1. stderr: {result.stderr}"
+        )
+
+        data = json.loads(result.stdout)
+        details = data["checks"]["incus_storage_pools"]["details"]
+        assert pool_name in details, (
+            f"Inherited pool {pool_name} must appear in pool details even "
+            f"though 'leaf' never mentioned it directly. Got: {list(details.keys())}"
+        )
+    finally:
+        _delete_temp_pool(pool_name)

--- a/tests/health/health_storage_pools_inherited_pool.py
+++ b/tests/health/health_storage_pools_inherited_pool.py
@@ -9,13 +9,30 @@ TOML → config.Load → ResolveProfileInheritance → health check enumeration.
 """
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
 
+def _is_permission_error(stderr):
+    """Heuristic: was `incus storage create` rejected because the caller
+    does not have Incus admin access? Anything else (name collision,
+    backend error, transient failure) should fail the test loud, not skip."""
+    lowered = stderr.lower()
+    return (
+        "permission denied" in lowered
+        or "not authorized" in lowered
+        or "forbidden" in lowered
+        or "access denied" in lowered
+    )
+
+
 def _create_temp_pool(name):
+    """Create a temp pool. Returns (ok, stderr). The caller is expected to
+    treat ok=False as a hard failure unless stderr matches a permission
+    error, in which case the whole test should pytest.skip."""
     result = subprocess.run(
         ["incus", "storage", "create", name, "dir"],
         capture_output=True,
@@ -35,11 +52,14 @@ def _delete_temp_pool(name):
 
 def test_health_storage_pools_inherited_pool(coi_binary, workspace_dir):
     """A child profile with no [container] section must inherit parent's pool."""
-    pool_name = "coi-test-inheritedpool"
+    # Unique pool name per test run avoids collisions with leftover pools.
+    pool_name = f"coi-test-inheritedpool-{os.urandom(4).hex()}"
 
     ok, err = _create_temp_pool(pool_name)
     if not ok:
-        pytest.skip(f"Cannot create temp storage pool {pool_name}: {err}")
+        if _is_permission_error(err):
+            pytest.skip(f"No permission to create storage pool {pool_name}: {err}")
+        pytest.fail(f"Failed to create temp pool {pool_name}: {err}")
 
     try:
         profiles_dir = Path(workspace_dir) / ".coi" / "profiles"
@@ -47,9 +67,7 @@ def test_health_storage_pools_inherited_pool(coi_binary, workspace_dir):
         # Parent: declares the pool.
         parent = profiles_dir / "parent"
         parent.mkdir(parents=True)
-        (parent / "config.toml").write_text(
-            f'[container]\nstorage_pool = "{pool_name}"\n'
-        )
+        (parent / "config.toml").write_text(f'[container]\nstorage_pool = "{pool_name}"\n')
 
         # Leaf: inherits from parent, no [container] at all.
         leaf = profiles_dir / "leaf"
@@ -63,9 +81,7 @@ def test_health_storage_pools_inherited_pool(coi_binary, workspace_dir):
             timeout=60,
             cwd=workspace_dir,
         )
-        assert result.returncode in (0, 1), (
-            f"health should exit 0 or 1. stderr: {result.stderr}"
-        )
+        assert result.returncode in (0, 1), f"health should exit 0 or 1. stderr: {result.stderr}"
 
         data = json.loads(result.stdout)
         details = data["checks"]["incus_storage_pools"]["details"]

--- a/tests/health/health_storage_pools_multi_profile.py
+++ b/tests/health/health_storage_pools_multi_profile.py
@@ -1,0 +1,104 @@
+"""
+Test that the storage pool health check enumerates every profile's pool.
+
+This is the regression test for issue #305: the check must inspect every
+pool referenced by any profile, not just the default one. The scenario
+creates two temp pools and three profiles (two explicit + one inheriting)
+and asserts that both pools appear in the health JSON details.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _create_temp_pool(name):
+    result = subprocess.run(
+        ["incus", "storage", "create", name, "dir"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode == 0, result.stderr
+
+
+def _delete_temp_pool(name):
+    subprocess.run(
+        ["incus", "storage", "delete", name],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_health_storage_pools_multi_profile(coi_binary, workspace_dir):
+    """Health check must report every pool referenced by any profile."""
+    pool_a = "coi-test-poolA"
+    pool_b = "coi-test-poolB"
+
+    # Skip if we cannot create temp pools (e.g. no admin permission).
+    ok_a, err_a = _create_temp_pool(pool_a)
+    if not ok_a:
+        pytest.skip(f"Cannot create temp storage pool {pool_a}: {err_a}")
+
+    ok_b, err_b = _create_temp_pool(pool_b)
+    if not ok_b:
+        _delete_temp_pool(pool_a)
+        pytest.skip(f"Cannot create temp storage pool {pool_b}: {err_b}")
+
+    try:
+        profiles_dir = Path(workspace_dir) / ".coi" / "profiles"
+
+        # Profile A: explicit pool A
+        explicit_a = profiles_dir / "explicit_a"
+        explicit_a.mkdir(parents=True)
+        (explicit_a / "config.toml").write_text(
+            f'[container]\nimage = "coi-default"\nstorage_pool = "{pool_a}"\n'
+        )
+
+        # Profile B: explicit pool B
+        explicit_b = profiles_dir / "explicit_b"
+        explicit_b.mkdir(parents=True)
+        (explicit_b / "config.toml").write_text(
+            f'[container]\nimage = "coi-default"\nstorage_pool = "{pool_b}"\n'
+        )
+
+        # Child: inherits explicit_a, no [container] of its own — must still
+        # resolve to pool A via profile-to-profile inheritance at load time.
+        child = profiles_dir / "child"
+        child.mkdir(parents=True)
+        (child / "config.toml").write_text('inherits = "explicit_a"\n')
+
+        result = subprocess.run(
+            [coi_binary, "health", "--format", "json", "--workspace", workspace_dir],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=workspace_dir,
+        )
+        assert result.returncode in (0, 1), (
+            f"health should exit 0 or 1. stderr: {result.stderr}"
+        )
+
+        data = json.loads(result.stdout)
+        checks = data["checks"]
+
+        # Lock in the 0.8.0 plural rename.
+        assert "incus_storage_pools" in checks, (
+            f"Expected plural 'incus_storage_pools' check name. "
+            f"Got: {list(checks.keys())}"
+        )
+
+        details = checks["incus_storage_pools"]["details"]
+        assert pool_a in details, (
+            f"Pool {pool_a} (explicit + inherited) should appear in pool details. "
+            f"Got: {list(details.keys())}"
+        )
+        assert pool_b in details, (
+            f"Pool {pool_b} (explicit) should appear in pool details. "
+            f"Got: {list(details.keys())}"
+        )
+    finally:
+        _delete_temp_pool(pool_a)
+        _delete_temp_pool(pool_b)

--- a/tests/health/health_storage_pools_multi_profile.py
+++ b/tests/health/health_storage_pools_multi_profile.py
@@ -8,13 +8,30 @@ and asserts that both pools appear in the health JSON details.
 """
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
 
+def _is_permission_error(stderr):
+    """Heuristic: was `incus storage create` rejected because the caller
+    does not have Incus admin access? Anything else (name collision,
+    backend error, transient failure) should fail the test loud, not skip."""
+    lowered = stderr.lower()
+    return (
+        "permission denied" in lowered
+        or "not authorized" in lowered
+        or "forbidden" in lowered
+        or "access denied" in lowered
+    )
+
+
 def _create_temp_pool(name):
+    """Create a temp pool. Returns (ok, stderr). The caller is expected to
+    treat ok=False as a hard failure unless stderr matches a permission
+    error, in which case the whole test should pytest.skip."""
     result = subprocess.run(
         ["incus", "storage", "create", name, "dir"],
         capture_output=True,
@@ -34,18 +51,24 @@ def _delete_temp_pool(name):
 
 def test_health_storage_pools_multi_profile(coi_binary, workspace_dir):
     """Health check must report every pool referenced by any profile."""
-    pool_a = "coi-test-poolA"
-    pool_b = "coi-test-poolB"
+    # Unique pool names per test run avoid name-collision flakes from
+    # leftover pools of a previous interrupted run.
+    suffix = os.urandom(4).hex()
+    pool_a = f"coi-test-poola-{suffix}"
+    pool_b = f"coi-test-poolb-{suffix}"
 
-    # Skip if we cannot create temp pools (e.g. no admin permission).
     ok_a, err_a = _create_temp_pool(pool_a)
     if not ok_a:
-        pytest.skip(f"Cannot create temp storage pool {pool_a}: {err_a}")
+        if _is_permission_error(err_a):
+            pytest.skip(f"No permission to create storage pool {pool_a}: {err_a}")
+        pytest.fail(f"Failed to create temp pool {pool_a}: {err_a}")
 
     ok_b, err_b = _create_temp_pool(pool_b)
     if not ok_b:
         _delete_temp_pool(pool_a)
-        pytest.skip(f"Cannot create temp storage pool {pool_b}: {err_b}")
+        if _is_permission_error(err_b):
+            pytest.skip(f"No permission to create storage pool {pool_b}: {err_b}")
+        pytest.fail(f"Failed to create temp pool {pool_b}: {err_b}")
 
     try:
         profiles_dir = Path(workspace_dir) / ".coi" / "profiles"
@@ -77,17 +100,14 @@ def test_health_storage_pools_multi_profile(coi_binary, workspace_dir):
             timeout=60,
             cwd=workspace_dir,
         )
-        assert result.returncode in (0, 1), (
-            f"health should exit 0 or 1. stderr: {result.stderr}"
-        )
+        assert result.returncode in (0, 1), f"health should exit 0 or 1. stderr: {result.stderr}"
 
         data = json.loads(result.stdout)
         checks = data["checks"]
 
         # Lock in the 0.8.0 plural rename.
         assert "incus_storage_pools" in checks, (
-            f"Expected plural 'incus_storage_pools' check name. "
-            f"Got: {list(checks.keys())}"
+            f"Expected plural 'incus_storage_pools' check name. Got: {list(checks.keys())}"
         )
 
         details = checks["incus_storage_pools"]["details"]
@@ -96,8 +116,7 @@ def test_health_storage_pools_multi_profile(coi_binary, workspace_dir):
             f"Got: {list(details.keys())}"
         )
         assert pool_b in details, (
-            f"Pool {pool_b} (explicit) should appear in pool details. "
-            f"Got: {list(details.keys())}"
+            f"Pool {pool_b} (explicit) should appear in pool details. Got: {list(details.keys())}"
         )
     finally:
         _delete_temp_pool(pool_a)


### PR DESCRIPTION
## Summary

Closes #305.

The storage-pool health check must inspect every pool any profile (or the global config) might use. The existing `collectReferencedPools` enumeration is correct in every scenario I could construct on paper, but the guarantee was an unwritten contract between `ResolveProfileInheritance` and this helper — one merge-logic refactor away from silently breaking. This PR locks the behaviour down with tests and rewrites a misleading doc comment.

**Note on the issue title.** #305 is titled "Add storage utilization to health 95+ error, 90%+ warning". After clarification, the existing thresholds (`>80%` / `<5 GiB` warning, `>90%` / `<2 GiB` failed) are kept as-is — they match the "ratchet a little before failing" shape, and the absolute-GiB floors protect tiny pools. The user's actual concern was **enumeration**: making sure the check looks at every profile's pool, not just the default. So this PR is a test lock-in + doc fix, not a threshold change.

## Changes

- **`internal/health/health.go`** — rewrite the `collectReferencedPools` doc comment. The old wording said profiles inherit the global value "at ApplyProfile time", which conflated load-time profile-to-profile inheritance with runtime profile-to-global fallback. The new comment documents both paths correctly. No code change.
- **`internal/health/health_test.go`** (new) — `TestCollectReferencedPools` (8 table-driven scenarios: global-only empty, global-only set, one explicit profile, two distinct profiles, child inheriting parent's pool, child overriding parent's pool, bare profile, dedup across profile+global) + `TestCollectReferencedPools_WithInheritance` which runs `ResolveProfileInheritance` end-to-end. The inheritance test is the key regression guard: if a future change to `mergeProfiles` breaks the "child inherits parent's pool" guarantee, the enumeration would silently miss the parent's pool and this test catches it.
- **`tests/health/health_storage_pools_multi_profile.py`** (new) — creates two temp pools (`coi-test-poolA`, `coi-test-poolB`) and three profiles (`explicit_a`, `explicit_b`, `child` inheriting `explicit_a`). Asserts both pools appear in `checks.incus_storage_pools.details` and locks in the plural check name.
- **`tests/health/health_storage_pools_inherited_pool.py`** (new) — Python mirror of the Go inheritance test. `parent` declares a pool, `leaf` has only `inherits = "parent"` and no `[container]` section. Asserts the inherited pool appears in the health JSON.

Both new Python tests skip gracefully if `incus storage create` is denied (no admin perms) and tear down every pool they create in a `finally` block.

## Out of scope

- No threshold changes
- No output format changes (`coi health` text/JSON layout unchanged)
- No new CLI subcommand
- No per-pool thresholds in TOML
- No profile-to-pool cross-reference in the health output

## Test plan

- [ ] `go test ./internal/health/... -run 'TestCollectReferencedPools'` — 10 subtests pass (verified locally)
- [ ] `go test ./internal/health/...` — full package green (verified locally)
- [ ] `pytest tests/health/health_storage_pools_multi_profile.py -v` — CI with admin perms
- [ ] `pytest tests/health/health_storage_pools_inherited_pool.py -v` — CI with admin perms
- [ ] `pytest tests/health/` — whole health group
- [ ] Verify thresholds unchanged: `grep -n 'usedPct > 80\|usedPct > 90\|freeGiB < 2\|freeGiB < 5' internal/health/checks.go` still shows the same two lines