### PR TITLE
Address Copilot review on tmux history-limit test (#313)

### DIFF
--- a/tests/tmux/tmux_history_limit.py
+++ b/tests/tmux/tmux_history_limit.py
@@ -67,6 +67,11 @@ def test_tmux_history_limit_default(coi_binary, cleanup_containers, workspace_di
     )
 
     # === Phase 3: A fresh tmux session honours the configured value ===
+    #
+    # Run as the `code` user (UID 1000) — that's who actually launches
+    # tmux when a real `coi shell` session starts. Running as root would
+    # miss regressions where /etc/tmux.conf is unreadable to non-root,
+    # or where a user-level config silently overrides the system setting.
 
     tmux_session = f"coi-{container_name}-histlimit"
 
@@ -76,6 +81,8 @@ def test_tmux_history_limit_default(coi_binary, cleanup_containers, workspace_di
             "container",
             "exec",
             container_name,
+            "--user",
+            "1000",
             "--",
             "tmux",
             "new-session",
@@ -98,6 +105,8 @@ def test_tmux_history_limit_default(coi_binary, cleanup_containers, workspace_di
             "container",
             "exec",
             container_name,
+            "--user",
+            "1000",
             "--",
             "tmux",
             "show-options",
@@ -110,10 +119,12 @@ def test_tmux_history_limit_default(coi_binary, cleanup_containers, workspace_di
     )
     assert result.returncode == 0, f"tmux show-options should succeed. stderr: {result.stderr}"
     # `coi container exec` may route command stdout through its stderr
-    # when no TTY is attached — check both.
+    # when no TTY is attached — check both. `tmux show-options -gv`
+    # prints just the value, so we assert exact equality (a substring
+    # match would happily accept "150000" or "500000").
     combined_show = (result.stdout + result.stderr).strip()
-    assert "50000" in combined_show, (
-        f"tmux history-limit must be 50000 in a default-image session. "
+    assert combined_show == "50000", (
+        f"tmux history-limit must be exactly 50000 in a default-image session. "
         f"Got: stdout={result.stdout!r} stderr={result.stderr!r}"
     )
 


### PR DESCRIPTION
## Summary

Follow-up to merged #313. Copilot left two valid review comments on the integration test added there; this PR addresses both.

1. **Run tmux phase as code user (UID 1000), not root.** `coi container exec` defaults to root, but `coi shell` actually launches tmux as the `code` user. The test now passes `--user 1000` to both the `tmux new-session` and `tmux show-options` calls, so it would catch regressions where `/etc/tmux.conf` becomes unreadable to non-root or a user-level config silently overrides the system setting.

2. **Tighten the history-limit assertion to exact equality.** `tmux show-options -gv history-limit` prints just the numeric value, so the previous `"50000" in combined_show` check would have happily accepted `150000` or `500000`. Now asserts `combined_show == "50000"`.

Refs:
- PR #313 (merged)
- Issue #312

## Test plan

- [ ] CI: `core` job runs `tests/tmux/tmux_history_limit.py` against the freshly-built default image
- [ ] Test still passes (the default image already ships `set -g history-limit 50000`)
- [ ] `ruff format --check` and `ruff check` clean (verified locally)