### PR TITLE
Add Slack community reference to README and wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/mensfeld/code-on-incus)](https://golang.org/)
 [![Latest Release](https://img.shields.io/github/v/release/mensfeld/code-on-incus)](https://github.com/mensfeld/code-on-incus/releases)
+[![Join the chat at https://slack.karafka.io](https://raw.githubusercontent.com/karafka/misc/master/slack.svg)](https://slack.karafka.io)
 
 **Security-Hardened Container Runtime for AI Coding Agents with Real-Time Threat Detection**
 
@@ -554,3 +555,9 @@ See the [FAQ](https://github.com/mensfeld/code-on-incus/wiki/FAQ) for answers to
 - Security model and prompt injection protection
 - API key security and trust model
 - What is Incus? (vs tmux)
+
+## Getting Help
+
+- **Slack**: [Join the COI community on Slack](https://slack.karafka.io) — ask questions, report issues, share feedback
+- **GitHub Issues**: [Open an issue](https://github.com/mensfeld/code-on-incus/issues) for bug reports and feature requests
+- **Wiki**: Browse the [documentation wiki](https://github.com/mensfeld/code-on-incus/wiki) for guides and reference


### PR DESCRIPTION
## Summary

- Added Slack badge (from `karafka/misc`) to the README badge row
- Added "Getting Help" section at the end of README with links to Slack, GitHub Issues, and the wiki
- Updated wiki Troubleshooting page with "Still Stuck?" section pointing to Slack
- Updated wiki FAQ page with "More Questions?" section pointing to Slack

Closes #289

## Test plan

- [x] Verify Slack badge renders correctly on GitHub
- [x] Verify https://slack.karafka.io resolves correctly
- [x] Confirm "Getting Help" section appears at the end of README
- [x] Confirm wiki Troubleshooting and FAQ pages show new Slack sections