### PR TITLE
Disable Incus guest API to prevent host topology leaks (P1-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
             description: "UID mapping integration tests (2 tests)"
           - name: git-hooks
             path: tests/git_hooks
-            description: "Git hooks and security protection tests (29 tests)"
+            description: "Git hooks and security protection tests (32 tests)"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 
 - [Feature] **`coi clean --pools`** — New flag detects COI containers (matched by container name prefix) sitting in storage pools that no profile loaded in the current directory references, and offers to remove them. **The pool itself is never deleted.** A prominent warning explains that COI can only see profiles in `~/.coi/` and `./.coi/`, so pools may still be in use by profiles in other projects on this machine that are invisible to the current `coi` invocation. Honours `--dry-run` and `--force`; included in `--all`.
 
+- [Feature] **Guest API disabled by default (P1-3)** — The Incus guest API (`/dev/incus`) is now disabled on all COI containers via `security.guestapi=false`. This prevents container processes from querying host source paths via the device topology API, which leaked the host username and workspace layout (FLAWS Finding 3).
+
 - [Feature] **Mount namespace bypass regression tests (P1-2)** — Added defense-in-depth integration tests covering the `unshare -m` + `umount` attack across all default protected paths (`.git/hooks`, `.git/config`, `.husky`, `.vscode`). Includes a negative test proving the bypass works when immutable protection is disabled, validating the tests aren't vacuous. All immutable protection assertion messages now reference FLAWS.md Finding 1 for traceability.
 
 ### Bug Fixes

--- a/internal/container/commands.go
+++ b/internal/container/commands.go
@@ -258,6 +258,9 @@ func LaunchContainer(imageAlias, containerName, pool string) error {
 	if err := EnableDockerSupport(containerName); err != nil {
 		return err
 	}
+	if err := DisableGuestAPI(containerName); err != nil {
+		return err
+	}
 	if err := CheckNotPrivileged(containerName); err != nil {
 		return err
 	}
@@ -276,6 +279,9 @@ func LaunchContainerPersistent(imageAlias, containerName, pool string) error {
 		return err
 	}
 	if err := EnableDockerSupport(containerName); err != nil {
+		return err
+	}
+	if err := DisableGuestAPI(containerName); err != nil {
 		return err
 	}
 	if err := CheckNotPrivileged(containerName); err != nil {
@@ -325,6 +331,15 @@ func EnableDockerSupport(containerName string) error {
 	}
 
 	return nil
+}
+
+// DisableGuestAPI prevents the Incus guest API (/dev/incus) from being
+// accessible inside the container. The guest API exposes host source paths
+// in the device topology, leaking the host username and workspace layout
+// (see FLAWS.md Finding 3). COI communicates with containers via the host
+// admin socket and does not need the guest API.
+func DisableGuestAPI(containerName string) error {
+	return IncusExec("config", "set", containerName, "security.guestapi=false")
 }
 
 // StopContainer stops a container

--- a/internal/container/security_test.go
+++ b/internal/container/security_test.go
@@ -35,18 +35,29 @@ func TestContainsPrivilegedValue(t *testing.T) {
 }
 
 // TestDisableGuestAPI verifies that DisableGuestAPI sets security.guestapi=false
-// on a real Incus container. Skipped when no Incus daemon is available.
+// on a real Incus container. Skipped when Incus prerequisites are unavailable.
 func TestDisableGuestAPI(t *testing.T) {
 	// Skip if incus is not available
 	if _, err := exec.LookPath("incus"); err != nil {
 		t.Skip("incus not found in PATH, skipping integration test")
 	}
 
-	name := fmt.Sprintf("coi-test-guestapi-%d", time.Now().UnixNano()%100000)
+	// Skip if the Incus daemon is unavailable
+	if !Available() {
+		t.Skip("Incus daemon not available, skipping integration test")
+	}
+
+	// Skip if the required test image alias is unavailable
+	exists, err := ImageExists("coi-default")
+	if err != nil || !exists {
+		t.Skip("Incus image alias \"coi-default\" not available, skipping integration test")
+	}
+
+	name := fmt.Sprintf("coi-test-guestapi-%d", time.Now().UnixNano())
 
 	// Create a stopped container (init, not start)
 	if err := IncusExec("init", "coi-default", name); err != nil {
-		t.Skipf("could not init test container (Incus daemon not available?): %v", err)
+		t.Fatalf("could not init test container %q from image %q: %v", name, "coi-default", err)
 	}
 	defer func() {
 		_ = IncusExecQuiet("delete", name, "--force")

--- a/internal/container/security_test.go
+++ b/internal/container/security_test.go
@@ -1,7 +1,10 @@
 package container
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestContainsPrivilegedValue(t *testing.T) {
@@ -28,5 +31,38 @@ func TestContainsPrivilegedValue(t *testing.T) {
 				t.Errorf("containsPrivilegedValue(%q) = %v, want %v", tt.output, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDisableGuestAPI verifies that DisableGuestAPI sets security.guestapi=false
+// on a real Incus container. Skipped when no Incus daemon is available.
+func TestDisableGuestAPI(t *testing.T) {
+	// Skip if incus is not available
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found in PATH, skipping integration test")
+	}
+
+	name := fmt.Sprintf("coi-test-guestapi-%d", time.Now().UnixNano()%100000)
+
+	// Create a stopped container (init, not start)
+	if err := IncusExec("init", "coi-default", name); err != nil {
+		t.Skipf("could not init test container (Incus daemon not available?): %v", err)
+	}
+	defer func() {
+		_ = IncusExecQuiet("delete", name, "--force")
+	}()
+
+	// Call DisableGuestAPI
+	if err := DisableGuestAPI(name); err != nil {
+		t.Fatalf("DisableGuestAPI() returned error: %v", err)
+	}
+
+	// Read back the value
+	output, err := IncusOutput("config", "get", name, "security.guestapi")
+	if err != nil {
+		t.Fatalf("failed to read security.guestapi: %v", err)
+	}
+	if output != "false" {
+		t.Errorf("security.guestapi = %q, want %q", output, "false")
 	}
 }

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -375,6 +375,11 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 			return nil, fmt.Errorf("failed to enable Docker support: %w", err)
 		}
 
+		// Disable guest API to prevent host topology leaks (FLAWS Finding 3)
+		if err := container.DisableGuestAPI(result.ContainerName); err != nil {
+			return nil, fmt.Errorf("failed to disable guest API: %w", err)
+		}
+
 		// Block privileged containers — they defeat all isolation
 		if err := container.CheckNotPrivileged(result.ContainerName); err != nil {
 			return nil, err

--- a/tests/git_hooks/test_guest_api_hardening.py
+++ b/tests/git_hooks/test_guest_api_hardening.py
@@ -1,0 +1,113 @@
+"""Test that the Incus guest API is disabled inside COI containers.
+
+The Incus guest API (/dev/incus) exposes the full device topology including
+host source paths (username, workspace location, which paths are RO-protected).
+This is a reconnaissance aid for mount namespace bypass attacks.
+
+COI does NOT use the guest agent internally — it communicates with containers
+via the host admin socket. Disabling the guest API has zero impact on COI
+functionality.
+
+See FLAWS.md Finding 3.
+"""
+
+import subprocess
+
+
+class TestGuestAPIHardening:
+    """Verify that /dev/incus is not accessible inside COI containers."""
+
+    def test_dev_incus_not_accessible(self, coi_binary, workspace_dir, cleanup_containers):
+        """Test that /dev/incus does not exist inside the container.
+
+        When security.guestapi=false, Incus does not create the /dev/incus
+        device inside the container at all.
+        """
+        result = subprocess.run(
+            [
+                coi_binary,
+                "run",
+                "--workspace",
+                workspace_dir,
+                "--",
+                "sh",
+                "-c",
+                "ls /dev/incus/ 2>&1 || echo NO_DEV_INCUS",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        combined = result.stdout + result.stderr
+        # /dev/incus should not exist — either ls fails or we get our marker
+        assert (
+            "NO_DEV_INCUS" in combined or "No such file" in combined or "cannot access" in combined
+        ), (
+            f"FLAWS Finding 3: /dev/incus appears to be accessible inside the container. "
+            f"Output: {combined}"
+        )
+
+    def test_guest_api_socket_not_available(self, coi_binary, workspace_dir, cleanup_containers):
+        """Test that the guest API socket is not reachable.
+
+        Even if /dev/incus somehow existed, the socket should not respond.
+        """
+        result = subprocess.run(
+            [
+                coi_binary,
+                "run",
+                "--workspace",
+                workspace_dir,
+                "--",
+                "sh",
+                "-c",
+                "curl -s --unix-socket /dev/incus/sock http://_/1.0 2>&1 || echo SOCKET_UNAVAILABLE",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        combined = result.stdout + result.stderr
+        # The socket should not be available
+        assert (
+            "SOCKET_UNAVAILABLE" in combined
+            or "No such file" in combined
+            or "Connection refused" in combined
+            or "Couldn't connect" in combined
+            or "cannot access" in combined
+        ), (
+            f"FLAWS Finding 3: Guest API socket appears reachable inside the container. "
+            f"Output: {combined}"
+        )
+
+    def test_no_host_path_leak(self, coi_binary, workspace_dir, cleanup_containers):
+        """Test that host source paths are not leaked via the device topology API.
+
+        This is the specific attack from FLAWS.md Finding 3: querying
+        /1.0/devices returns host source paths including username and
+        workspace location.
+        """
+        result = subprocess.run(
+            [
+                coi_binary,
+                "run",
+                "--workspace",
+                workspace_dir,
+                "--",
+                "sh",
+                "-c",
+                "curl -s --unix-socket /dev/incus/sock http://_/1.0/devices 2>&1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        combined = result.stdout + result.stderr
+        # The workspace source path should NOT appear in the output
+        assert workspace_dir not in combined, (
+            f"FLAWS Finding 3: Host workspace path leaked via guest API device topology. "
+            f"Workspace path '{workspace_dir}' found in output: {combined}"
+        )

--- a/tests/git_hooks/test_guest_api_hardening.py
+++ b/tests/git_hooks/test_guest_api_hardening.py
@@ -123,21 +123,24 @@ class TestGuestAPIHardening:
             f"Stdout: {result.stdout} Stderr: {result.stderr}"
         )
 
-        combined = result.stdout + result.stderr
+        # Only check stdout (the in-container command output). stderr contains
+        # COI's own setup logs which naturally reference the workspace path.
+        cmd_output = result.stdout
 
         # The guest API should be blocked entirely — verify we got the expected
         # failure marker or a connection error, not a successful JSON response
         assert (
-            "GUEST_API_BLOCKED" in combined
-            or "No such file" in combined
-            or "Connection refused" in combined
-            or "Couldn't connect" in combined
-            or "cannot access" in combined
-        ), f"FLAWS Finding 3: Guest API /devices endpoint appears reachable. Output: {combined}"
+            "GUEST_API_BLOCKED" in cmd_output
+            or "No such file" in cmd_output
+            or "Connection refused" in cmd_output
+            or "Couldn't connect" in cmd_output
+            or "cannot access" in cmd_output
+        ), f"FLAWS Finding 3: Guest API /devices endpoint appears reachable. Output: {cmd_output}"
 
         # Defense-in-depth: even if the above assertion somehow passed with
         # unexpected output, the workspace source path must never appear
-        assert workspace_dir not in combined, (
+        # in the command output (it would indicate the device topology leaked)
+        assert workspace_dir not in cmd_output, (
             f"FLAWS Finding 3: Host workspace path leaked via guest API device topology. "
-            f"Workspace path '{workspace_dir}' found in output: {combined}"
+            f"Workspace path '{workspace_dir}' found in output: {cmd_output}"
         )

--- a/tests/git_hooks/test_guest_api_hardening.py
+++ b/tests/git_hooks/test_guest_api_hardening.py
@@ -39,6 +39,12 @@ class TestGuestAPIHardening:
             timeout=120,
         )
 
+        assert result.returncode == 0, (
+            f"'coi run' failed before /dev/incus could be checked. "
+            f"Return code: {result.returncode}. "
+            f"Stdout: {result.stdout} Stderr: {result.stderr}"
+        )
+
         combined = result.stdout + result.stderr
         # /dev/incus should not exist — either ls fails or we get our marker
         assert (
@@ -67,6 +73,12 @@ class TestGuestAPIHardening:
             capture_output=True,
             text=True,
             timeout=120,
+        )
+
+        assert result.returncode == 0, (
+            f"'coi run' failed before guest API socket could be checked. "
+            f"Return code: {result.returncode}. "
+            f"Stdout: {result.stdout} Stderr: {result.stderr}"
         )
 
         combined = result.stdout + result.stderr
@@ -98,15 +110,33 @@ class TestGuestAPIHardening:
                 "--",
                 "sh",
                 "-c",
-                "curl -s --unix-socket /dev/incus/sock http://_/1.0/devices 2>&1",
+                "curl -s --unix-socket /dev/incus/sock http://_/1.0/devices 2>&1 || echo GUEST_API_BLOCKED",
             ],
             capture_output=True,
             text=True,
             timeout=120,
         )
 
+        assert result.returncode == 0, (
+            f"'coi run' failed before device topology could be checked. "
+            f"Return code: {result.returncode}. "
+            f"Stdout: {result.stdout} Stderr: {result.stderr}"
+        )
+
         combined = result.stdout + result.stderr
-        # The workspace source path should NOT appear in the output
+
+        # The guest API should be blocked entirely — verify we got the expected
+        # failure marker or a connection error, not a successful JSON response
+        assert (
+            "GUEST_API_BLOCKED" in combined
+            or "No such file" in combined
+            or "Connection refused" in combined
+            or "Couldn't connect" in combined
+            or "cannot access" in combined
+        ), f"FLAWS Finding 3: Guest API /devices endpoint appears reachable. Output: {combined}"
+
+        # Defense-in-depth: even if the above assertion somehow passed with
+        # unexpected output, the workspace source path must never appear
         assert workspace_dir not in combined, (
             f"FLAWS Finding 3: Host workspace path leaked via guest API device topology. "
             f"Workspace path '{workspace_dir}' found in output: {combined}"


### PR DESCRIPTION
## Summary

- Sets `security.guestapi=false` on every COI container before first boot, disabling `/dev/incus` inside the container
- Prevents container processes from querying host source paths via the device topology API (FLAWS Finding 3)
- COI communicates with containers via the host admin socket — the guest API is unused and disabling it has zero functional impact

## Changes

- **`internal/container/commands.go`**: New `DisableGuestAPI()` function + calls in `LaunchContainer` and `LaunchContainerPersistent`
- **`internal/session/setup.go`**: Call `DisableGuestAPI` after `EnableDockerSupport` in `Setup()`
- **`internal/container/security_test.go`**: Go integration test verifying the config key is set
- **`tests/git_hooks/test_guest_api_hardening.py`**: 3 Python integration tests (device not accessible, socket unavailable, no host path leak)
- **`CHANGELOG.md`**: P1-3 feature entry
- **`.github/workflows/ci.yml`**: Updated git-hooks test count comment (29 → 32)

## Test plan

- [x] `go build ./...` compiles
- [x] `go vet ./...` passes
- [x] `go test ./internal/container/ -run TestDisableGuestAPI` passes (0.73s)
- [x] `ruff check` + `ruff format --check` pass on new Python test
- [ ] CI git-hooks group runs all 3 new Python integration tests