### PR TITLE
Add container alias support (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 
 ### Features
 
+- [Feature] **Container aliases** — Containers can now be assigned human-friendly aliases via `[container] alias = "myproject"` in project or profile config. Use `coi shell myproject` to launch from any directory, `coi attach myproject` to reconnect, and `coi kill myproject` / `coi unfreeze myproject` to manage. Aliases are stored on containers as Incus `user.coi.alias` metadata and registered in `~/.coi/aliases.json` for cross-directory resolution. Slot suffixes work naturally: `coi attach myproject-2` targets slot 2. (#304)
+
 - [Feature] **Per-profile storage pool support** — Containers can now be routed to a specific Incus storage pool via `[container] storage_pool = "pool-name"` in the global config or any profile. The profile pool overrides the global pool, which falls back to the Incus default pool when empty. This lets users put project A on fast NVMe and project B on bulk spinning storage. Pool existence is validated up front by `coi shell`, `coi run`, `coi container launch`, and `coi build`, with a clear `incus storage create <name> dir|zfs|btrfs` example on failure. Build containers always use the same pool as the resolved profile, so build artefacts land alongside the runtime container. (#302)
 
 - [Feature] **`coi list` shows POOL** — Both text and JSON output of `coi list` now include the storage pool of each container's root device, parsed from `expanded_devices.root.pool` (no extra Incus calls). The value reflects the actual pool the container was created in, not the configured one.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,25 @@ coi clean
 coi update
 ```
 
+### Container Aliases
+
+Assign human-friendly names to containers for easy management from any directory:
+
+```toml
+# .coi/config.toml (in your project)
+[container]
+alias = "myproject"
+```
+
+```bash
+coi shell myproject              # Launch session using alias (from any directory)
+coi attach myproject             # Attach to running aliased container
+coi kill myproject --force       # Kill by alias
+coi attach myproject-2           # Attach to slot 2
+```
+
+Aliases are registered in `~/.coi/aliases.json` on first use and stored as `user.coi.alias` metadata on each container.
+
 ### Global Flags
 
 ```bash

--- a/internal/alias/registry.go
+++ b/internal/alias/registry.go
@@ -132,13 +132,24 @@ func (r *Registry) Save() error {
 		return fmt.Errorf("failed to marshal alias registry: %w", err)
 	}
 
-	// Atomic write: temp file + rename
-	tmp := r.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	// Atomic write: unique temp file + rename
+	tmpFile, err := os.CreateTemp(dir, ".aliases-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for alias registry: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
 		return fmt.Errorf("failed to write alias registry: %w", err)
 	}
-	if err := os.Rename(tmp, r.path); err != nil {
-		os.Remove(tmp) // best effort cleanup
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, r.path); err != nil {
+		os.Remove(tmpPath)
 		return fmt.Errorf("failed to rename alias registry: %w", err)
 	}
 

--- a/internal/alias/registry.go
+++ b/internal/alias/registry.go
@@ -1,0 +1,163 @@
+package alias
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+)
+
+// AliasEntry maps an alias to a workspace and optional profile.
+type AliasEntry struct {
+	Workspace string `json:"workspace"`
+	Profile   string `json:"profile,omitempty"`
+}
+
+// Registry persists alias → {workspace, profile} mappings in ~/.coi/aliases.json.
+type Registry struct {
+	mu      sync.Mutex
+	path    string
+	entries map[string]AliasEntry
+}
+
+// RegistryPath returns the default path to the alias registry file.
+func RegistryPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = "/tmp"
+	}
+	return filepath.Join(homeDir, ".coi", "aliases.json")
+}
+
+// Load reads the registry from disk, creating an empty one if the file does not exist.
+func Load() (*Registry, error) {
+	return LoadFrom(RegistryPath())
+}
+
+// LoadFrom reads the registry from a specific path.
+func LoadFrom(path string) (*Registry, error) {
+	r := &Registry{
+		path:    path,
+		entries: make(map[string]AliasEntry),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return r, nil // empty registry
+		}
+		return nil, fmt.Errorf("failed to read alias registry: %w", err)
+	}
+
+	if len(data) == 0 {
+		return r, nil
+	}
+
+	if err := json.Unmarshal(data, &r.entries); err != nil {
+		return nil, fmt.Errorf("failed to parse alias registry: %w", err)
+	}
+
+	return r, nil
+}
+
+// Register adds or updates an alias. It returns an error if the alias is
+// already mapped to a different workspace (conflict).
+func (r *Registry) Register(alias, workspace, profile string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[alias]; ok {
+		if existing.Workspace != workspace {
+			return fmt.Errorf("alias %q is already registered to workspace %q (current request: %q)", alias, existing.Workspace, workspace)
+		}
+	}
+
+	r.entries[alias] = AliasEntry{
+		Workspace: workspace,
+		Profile:   profile,
+	}
+	return nil
+}
+
+// Lookup returns the entry for an alias, or nil if not found.
+func (r *Registry) Lookup(alias string) *AliasEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[alias]; ok {
+		return &entry
+	}
+	return nil
+}
+
+// Remove deletes an alias from the registry.
+func (r *Registry) Remove(alias string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.entries[alias]; !ok {
+		return fmt.Errorf("alias %q not found in registry", alias)
+	}
+	delete(r.entries, alias)
+	return nil
+}
+
+// ListAll returns a copy of all alias entries.
+func (r *Registry) ListAll() map[string]AliasEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make(map[string]AliasEntry, len(r.entries))
+	for k, v := range r.entries {
+		out[k] = v
+	}
+	return out
+}
+
+// Save writes the registry to disk atomically (temp file + rename).
+func (r *Registry) Save() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Ensure parent directory exists
+	dir := filepath.Dir(r.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create registry directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(r.entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal alias registry: %w", err)
+	}
+
+	// Atomic write: temp file + rename
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write alias registry: %w", err)
+	}
+	if err := os.Rename(tmp, r.path); err != nil {
+		os.Remove(tmp) // best effort cleanup
+		return fmt.Errorf("failed to rename alias registry: %w", err)
+	}
+
+	return nil
+}
+
+// aliasPattern matches valid aliases: starts with a letter, alphanumeric + hyphens/underscores, max 64 chars.
+var aliasPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
+
+// ValidateAlias checks that an alias is well-formed.
+func ValidateAlias(alias string) error {
+	if alias == "" {
+		return nil // empty is valid (means "no alias")
+	}
+	if len(alias) > 64 {
+		return fmt.Errorf("alias %q is too long (max 64 characters)", alias)
+	}
+	if !aliasPattern.MatchString(alias) {
+		return fmt.Errorf("alias %q is invalid: must start with a letter and contain only letters, digits, hyphens, and underscores", alias)
+	}
+	return nil
+}

--- a/internal/alias/registry_test.go
+++ b/internal/alias/registry_test.go
@@ -205,19 +205,19 @@ func TestValidateAlias(t *testing.T) {
 		alias string
 		valid bool
 	}{
-		{"", true},                                                           // empty is valid (no alias)
-		{"myproject", true},                                                  // simple
-		{"my-project", true},                                                 // hyphens
-		{"my_project", true},                                                 // underscores
-		{"MyProject123", true},                                               // mixed case + digits
-		{"a", true},                                                          // single letter
+		{"", true},             // empty is valid (no alias)
+		{"myproject", true},    // simple
+		{"my-project", true},   // hyphens
+		{"my_project", true},   // underscores
+		{"MyProject123", true}, // mixed case + digits
+		{"a", true},            // single letter
 		{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901", true}, // 64 chars
-		{"123project", false},                // starts with digit
-		{"my project", false},                // space
-		{"my.project", false},                // dot
-		{"my!project", false},                // special char
-		{"-myproject", false},                // starts with hyphen
-		{"_myproject", false},                // starts with underscore
+		{"123project", false}, // starts with digit
+		{"my project", false}, // space
+		{"my.project", false}, // dot
+		{"my!project", false}, // special char
+		{"-myproject", false}, // starts with hyphen
+		{"_myproject", false}, // starts with underscore
 		{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789012", false}, // 65 chars (too long)
 	}
 
@@ -243,8 +243,8 @@ func TestSplitAliasSlot(t *testing.T) {
 		{"myproject-10", "myproject", 10},
 		{"my-project-3", "my-project", 3},
 		{"myproject-abc", "myproject-abc", 0}, // non-numeric suffix
-		{"-1", "-1", 0},                        // no base alias
-		{"a-0", "a", 0},                         // slot 0 (treated as no slot)
+		{"-1", "-1", 0},                       // no base alias
+		{"a-0", "a", 0},                       // slot 0 (treated as no slot)
 	}
 
 	for _, tt := range tests {

--- a/internal/alias/registry_test.go
+++ b/internal/alias/registry_test.go
@@ -1,0 +1,281 @@
+package alias
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tempRegistryPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "aliases.json")
+}
+
+func TestRegister_NewAlias(t *testing.T) {
+	r := &Registry{
+		path:    tempRegistryPath(t),
+		entries: make(map[string]AliasEntry),
+	}
+
+	err := r.Register("myproject", "/home/user/projects/myproject", "")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	entry := r.Lookup("myproject")
+	if entry == nil {
+		t.Fatal("Lookup returned nil for registered alias")
+	}
+	if entry.Workspace != "/home/user/projects/myproject" {
+		t.Errorf("Workspace = %q, want %q", entry.Workspace, "/home/user/projects/myproject")
+	}
+}
+
+func TestRegister_SameWorkspace_Idempotent(t *testing.T) {
+	r := &Registry{
+		path:    tempRegistryPath(t),
+		entries: make(map[string]AliasEntry),
+	}
+
+	if err := r.Register("myproject", "/workspace/a", ""); err != nil {
+		t.Fatal(err)
+	}
+	// Re-register same alias+workspace should succeed
+	if err := r.Register("myproject", "/workspace/a", ""); err != nil {
+		t.Fatalf("Re-register same workspace should succeed, got: %v", err)
+	}
+}
+
+func TestRegister_DifferentWorkspace_Conflict(t *testing.T) {
+	r := &Registry{
+		path:    tempRegistryPath(t),
+		entries: make(map[string]AliasEntry),
+	}
+
+	if err := r.Register("myproject", "/workspace/a", ""); err != nil {
+		t.Fatal(err)
+	}
+	err := r.Register("myproject", "/workspace/b", "")
+	if err == nil {
+		t.Fatal("Expected conflict error when registering same alias for different workspace")
+	}
+}
+
+func TestLookup_Found(t *testing.T) {
+	r := &Registry{
+		path: tempRegistryPath(t),
+		entries: map[string]AliasEntry{
+			"test": {Workspace: "/ws", Profile: "dev"},
+		},
+	}
+
+	entry := r.Lookup("test")
+	if entry == nil {
+		t.Fatal("Lookup returned nil")
+	}
+	if entry.Profile != "dev" {
+		t.Errorf("Profile = %q, want %q", entry.Profile, "dev")
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	r := &Registry{
+		path:    tempRegistryPath(t),
+		entries: make(map[string]AliasEntry),
+	}
+
+	if entry := r.Lookup("nonexistent"); entry != nil {
+		t.Errorf("Expected nil for nonexistent alias, got %+v", entry)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	r := &Registry{
+		path: tempRegistryPath(t),
+		entries: map[string]AliasEntry{
+			"test": {Workspace: "/ws"},
+		},
+	}
+
+	if err := r.Remove("test"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if entry := r.Lookup("test"); entry != nil {
+		t.Error("Alias should be removed but Lookup still returns it")
+	}
+}
+
+func TestRemove_NotFound(t *testing.T) {
+	r := &Registry{
+		path:    tempRegistryPath(t),
+		entries: make(map[string]AliasEntry),
+	}
+
+	err := r.Remove("nonexistent")
+	if err == nil {
+		t.Fatal("Expected error when removing nonexistent alias")
+	}
+}
+
+func TestSaveLoad_Roundtrip(t *testing.T) {
+	path := tempRegistryPath(t)
+
+	// Create and save
+	r := &Registry{
+		path:    path,
+		entries: make(map[string]AliasEntry),
+	}
+	_ = r.Register("proj1", "/workspace/one", "dev")
+	_ = r.Register("proj2", "/workspace/two", "")
+
+	if err := r.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Load back
+	r2, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	all := r2.ListAll()
+	if len(all) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(all))
+	}
+
+	entry := r2.Lookup("proj1")
+	if entry == nil || entry.Workspace != "/workspace/one" || entry.Profile != "dev" {
+		t.Errorf("proj1 roundtrip mismatch: %+v", entry)
+	}
+
+	entry = r2.Lookup("proj2")
+	if entry == nil || entry.Workspace != "/workspace/two" {
+		t.Errorf("proj2 roundtrip mismatch: %+v", entry)
+	}
+}
+
+func TestLoadFrom_NonexistentFile(t *testing.T) {
+	r, err := LoadFrom("/nonexistent/path/aliases.json")
+	if err != nil {
+		t.Fatalf("LoadFrom nonexistent should return empty registry, got error: %v", err)
+	}
+	if len(r.ListAll()) != 0 {
+		t.Error("Expected empty registry for nonexistent file")
+	}
+}
+
+func TestLoadFrom_EmptyFile(t *testing.T) {
+	path := tempRegistryPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom empty file should succeed, got: %v", err)
+	}
+	if len(r.ListAll()) != 0 {
+		t.Error("Expected empty registry for empty file")
+	}
+}
+
+func TestListAll_ReturnsCopy(t *testing.T) {
+	r := &Registry{
+		path: tempRegistryPath(t),
+		entries: map[string]AliasEntry{
+			"a": {Workspace: "/a"},
+		},
+	}
+
+	all := r.ListAll()
+	all["b"] = AliasEntry{Workspace: "/b"}
+
+	// Mutation of returned map should not affect registry
+	if r.Lookup("b") != nil {
+		t.Error("ListAll should return a copy, not a reference")
+	}
+}
+
+func TestValidateAlias(t *testing.T) {
+	tests := []struct {
+		alias string
+		valid bool
+	}{
+		{"", true},                                                           // empty is valid (no alias)
+		{"myproject", true},                                                  // simple
+		{"my-project", true},                                                 // hyphens
+		{"my_project", true},                                                 // underscores
+		{"MyProject123", true},                                               // mixed case + digits
+		{"a", true},                                                          // single letter
+		{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901", true}, // 64 chars
+		{"123project", false},                // starts with digit
+		{"my project", false},                // space
+		{"my.project", false},                // dot
+		{"my!project", false},                // special char
+		{"-myproject", false},                // starts with hyphen
+		{"_myproject", false},                // starts with underscore
+		{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789012", false}, // 65 chars (too long)
+	}
+
+	for _, tt := range tests {
+		err := ValidateAlias(tt.alias)
+		if tt.valid && err != nil {
+			t.Errorf("ValidateAlias(%q) = %v, want valid", tt.alias, err)
+		}
+		if !tt.valid && err == nil {
+			t.Errorf("ValidateAlias(%q) = nil, want error", tt.alias)
+		}
+	}
+}
+
+func TestSplitAliasSlot(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantAlias string
+		wantSlot  int
+	}{
+		{"myproject", "myproject", 0},
+		{"myproject-2", "myproject", 2},
+		{"myproject-10", "myproject", 10},
+		{"my-project-3", "my-project", 3},
+		{"myproject-abc", "myproject-abc", 0}, // non-numeric suffix
+		{"-1", "-1", 0},                        // no base alias
+		{"a-0", "a", 0},                         // slot 0 (treated as no slot)
+	}
+
+	for _, tt := range tests {
+		gotAlias, gotSlot := splitAliasSlot(tt.input)
+		if gotAlias != tt.wantAlias || gotSlot != tt.wantSlot {
+			t.Errorf("splitAliasSlot(%q) = (%q, %d), want (%q, %d)",
+				tt.input, gotAlias, gotSlot, tt.wantAlias, tt.wantSlot)
+		}
+	}
+}
+
+func TestIsContainerName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"coi-a1b2c3d4-1", true},
+		{"coi-abcdef12-10", true},
+		{"coi-00000000-1", true},
+		{"myproject", false},
+		{"coi-short-1", false},  // hash too short
+		{"coi-a1b2c3d4", false}, // no slot
+		{"coi-a1b2c3d4-", false},
+		{"other-a1b2c3d4-1", false},
+	}
+
+	for _, tt := range tests {
+		// Override pattern for test (since COI_CONTAINER_PREFIX might be set)
+		got := IsContainerName(tt.name)
+		if os.Getenv("COI_CONTAINER_PREFIX") == "" && got != tt.want {
+			t.Errorf("IsContainerName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/alias/registry_test.go
+++ b/internal/alias/registry_test.go
@@ -265,9 +265,10 @@ func TestIsContainerName(t *testing.T) {
 		{"coi-abcdef12-10", true},
 		{"coi-00000000-1", true},
 		{"myproject", false},
-		{"coi-short-1", false},  // hash too short
-		{"coi-a1b2c3d4", false}, // no slot
-		{"coi-a1b2c3d4-", false},
+		{"coi-short-1", true},     // starts with prefix → treated as container name
+		{"coi-a1b2c3d4", true},    // starts with prefix → treated as container name
+		{"coi-a1b2c3d4-", true},   // starts with prefix → treated as container name
+		{"coi-nonexistent", true}, // starts with prefix → treated as container name
 		{"other-a1b2c3d4-1", false},
 	}
 

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -1,0 +1,143 @@
+package alias
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mensfeld/code-on-incus/internal/container"
+	"github.com/mensfeld/code-on-incus/internal/session"
+)
+
+// ResolvedAlias is the result of resolving an alias for launching a new session.
+type ResolvedAlias struct {
+	Workspace string
+	Profile   string
+	Slot      int // >0 if alias had a slot suffix (e.g. "myproject-2")
+}
+
+// containerNamePattern matches the deterministic container name format: <prefix><hex8>-<digits>
+var containerNamePattern = regexp.MustCompile(`^` + regexp.QuoteMeta(session.GetContainerPrefix()) + `[a-f0-9]{8}-\d+$`)
+
+// IsContainerName returns true if the argument looks like an exact container name.
+func IsContainerName(arg string) bool {
+	return containerNamePattern.MatchString(arg)
+}
+
+// ResolveAliasForRunning resolves an alias (or alias-N) to a running container name.
+// If the arg is an exact container name, it is returned unchanged.
+// Errors if the alias matches 0 or >1 running containers (listing them for disambiguation).
+func ResolveAliasForRunning(arg string) (string, error) {
+	// 1. Exact container name → pass through
+	if IsContainerName(arg) {
+		return arg, nil
+	}
+
+	// 2. Try alias with optional slot suffix
+	alias, slotNum := splitAliasSlot(arg)
+
+	containers, err := FindContainersByAlias(alias)
+	if err != nil {
+		return "", fmt.Errorf("failed to find containers by alias: %w", err)
+	}
+
+	if len(containers) == 0 {
+		return "", fmt.Errorf("no running container found with alias %q", alias)
+	}
+
+	// If a slot suffix was given, filter to matching slot
+	if slotNum > 0 {
+		for _, name := range containers {
+			if _, s, err := session.ParseContainerName(name); err == nil && s == slotNum {
+				return name, nil
+			}
+		}
+		return "", fmt.Errorf("no running container found with alias %q at slot %d", alias, slotNum)
+	}
+
+	// No slot suffix — must be exactly one match
+	if len(containers) == 1 {
+		return containers[0], nil
+	}
+
+	return "", fmt.Errorf("alias %q matches %d running containers — specify a slot suffix to disambiguate:\n  %s",
+		alias, len(containers), strings.Join(containers, "\n  "))
+}
+
+// ResolveAliasForLaunch looks up the alias registry to find the workspace and profile.
+// Returns nil if the alias is not found in the registry.
+func ResolveAliasForLaunch(arg string) (*ResolvedAlias, error) {
+	alias, slotNum := splitAliasSlot(arg)
+
+	reg, err := Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load alias registry: %w", err)
+	}
+
+	entry := reg.Lookup(alias)
+	if entry == nil {
+		return nil, fmt.Errorf("alias %q not found — register it by adding [container] alias = %q to .coi/config.toml and running a session", alias, alias)
+	}
+
+	return &ResolvedAlias{
+		Workspace: entry.Workspace,
+		Profile:   entry.Profile,
+		Slot:      slotNum,
+	}, nil
+}
+
+// FindContainersByAlias queries Incus for COI containers whose user.coi.alias
+// config key matches the given alias.
+func FindContainersByAlias(alias string) ([]string, error) {
+	prefix := session.GetContainerPrefix()
+	pattern := fmt.Sprintf("^%s", prefix)
+
+	output, err := container.IncusOutput("list", pattern, "--format=json")
+	if err != nil {
+		return nil, err
+	}
+
+	var containers []map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &containers); err != nil {
+		return nil, fmt.Errorf("failed to parse container list: %w", err)
+	}
+
+	var matches []string
+	for _, c := range containers {
+		name, _ := c["name"].(string)
+		status, _ := c["status"].(string)
+
+		// Only consider running containers
+		if status != "Running" {
+			continue
+		}
+
+		cfg, _ := c["config"].(map[string]interface{})
+		containerAlias, _ := cfg["user.coi.alias"].(string)
+
+		if containerAlias == alias {
+			matches = append(matches, name)
+		}
+	}
+
+	return matches, nil
+}
+
+// splitAliasSlot splits "myproject-2" into ("myproject", 2).
+// If there is no numeric suffix, returns (arg, 0).
+func splitAliasSlot(arg string) (string, int) {
+	idx := strings.LastIndex(arg, "-")
+	if idx <= 0 || idx == len(arg)-1 {
+		return arg, 0
+	}
+
+	suffix := arg[idx+1:]
+	slotNum, err := strconv.Atoi(suffix)
+	if err != nil {
+		return arg, 0
+	}
+
+	return arg[:idx], slotNum
+}

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -46,7 +46,7 @@ func ResolveAliasForRunning(arg string) (string, error) {
 	}
 
 	if len(containers) == 0 {
-		return "", fmt.Errorf("no running container found with alias %q", alias)
+		return "", fmt.Errorf("container or alias %q not found — no running container matches", alias)
 	}
 
 	// If a slot suffix was given, filter to matching slot
@@ -56,7 +56,7 @@ func ResolveAliasForRunning(arg string) (string, error) {
 				return name, nil
 			}
 		}
-		return "", fmt.Errorf("no running container found with alias %q at slot %d", alias, slotNum)
+		return "", fmt.Errorf("container or alias %q not found at slot %d", alias, slotNum)
 	}
 
 	// No slot suffix — must be exactly one match

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -67,7 +67,7 @@ func ResolveAliasForRunning(arg string) (string, error) {
 }
 
 // ResolveAliasForLaunch looks up the alias registry to find the workspace and profile.
-// Returns nil if the alias is not found in the registry.
+// Returns an error if the alias is not found in the registry.
 func ResolveAliasForLaunch(arg string) (*ResolvedAlias, error) {
 	alias, slotNum := splitAliasSlot(arg)
 

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -21,9 +21,11 @@ type ResolvedAlias struct {
 // containerNamePattern matches the deterministic container name format: <prefix><hex8>-<digits>
 var containerNamePattern = regexp.MustCompile(`^` + regexp.QuoteMeta(session.GetContainerPrefix()) + `[a-f0-9]{8}-\d+$`)
 
-// IsContainerName returns true if the argument looks like an exact container name.
+// IsContainerName returns true if the argument looks like a container name
+// (either exact match or starts with the container prefix).
+// Names starting with the container prefix are never treated as aliases.
 func IsContainerName(arg string) bool {
-	return containerNamePattern.MatchString(arg)
+	return containerNamePattern.MatchString(arg) || strings.HasPrefix(arg, session.GetContainerPrefix())
 }
 
 // ResolveAliasForRunning resolves an alias (or alias-N) to a running container name.

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -75,6 +75,8 @@ func attachCommand(cmd *cobra.Command, args []string) error {
 			targetContainer = args[0]
 			if resolved, err := alias.ResolveAliasForRunning(targetContainer); err == nil {
 				targetContainer = resolved
+			} else if !alias.IsContainerName(targetContainer) {
+				return err
 			}
 			// Verify it exists and is running
 			found := false

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/session"
 	"github.com/mensfeld/code-on-incus/internal/terminal"
@@ -69,9 +70,12 @@ func attachCommand(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to list containers: %w", err)
 		}
 
-		// If container name provided, use it
+		// If container name provided, use it (with alias resolution)
 		if len(args) > 0 {
 			targetContainer = args[0]
+			if resolved, err := alias.ResolveAliasForRunning(targetContainer); err == nil {
+				targetContainer = resolved
+			}
 			// Verify it exists and is running
 			found := false
 			for _, c := range containers {

--- a/internal/cli/kill.go
+++ b/internal/cli/kill.go
@@ -82,8 +82,10 @@ func resolveContainerArgs(args []string, all bool, force bool, action string) ([
 		for _, arg := range args {
 			if resolved, err := alias.ResolveAliasForRunning(arg); err == nil {
 				containerNames = append(containerNames, resolved)
-			} else {
+			} else if alias.IsContainerName(arg) {
 				containerNames = append(containerNames, arg)
+			} else {
+				return nil, err
 			}
 		}
 

--- a/internal/cli/kill.go
+++ b/internal/cli/kill.go
@@ -39,48 +39,45 @@ func init() {
 	killCmd.Flags().BoolVarP(&killAll, "all", "a", false, "Kill all containers")
 }
 
-func killCommand(cmd *cobra.Command, args []string) error {
-	// Get container names to kill
+// resolveContainerArgs resolves container names from args (with alias support) or --all flag.
+// Returns the resolved container names, or nil if the user cancelled or there are no containers.
+// The action parameter is used in prompts (e.g., "Kill", "Shutdown").
+func resolveContainerArgs(args []string, all bool, force bool, action string) ([]string, error) {
 	var containerNames []string
 
-	if killAll {
-		// Get all containers
+	if all {
 		containers, err := listActiveContainers()
 		if err != nil {
-			return fmt.Errorf("failed to list containers: %w", err)
+			return nil, fmt.Errorf("failed to list containers: %w", err)
 		}
 
 		if len(containers) == 0 {
-			fmt.Println("No containers to kill")
-			return nil
+			fmt.Printf("No containers to %s\n", action)
+			return nil, nil
 		}
 
 		for _, c := range containers {
 			containerNames = append(containerNames, c.Name)
 		}
 
-		// Show what will be killed
 		fmt.Printf("Found %d container(s):\n", len(containerNames))
 		for _, name := range containerNames {
 			fmt.Printf("  - %s\n", name)
 		}
 
-		// Confirm unless --force
-		if !killForce {
-			fmt.Print("\nKill all these containers? [y/N]: ")
+		if !force {
+			fmt.Printf("\n%s all these containers? [y/N]: ", action)
 			var response string
 			_, _ = fmt.Scanln(&response)
 			if response != "y" && response != "Y" {
 				fmt.Println("Cancelled.")
-				return nil
+				return nil, nil
 			}
 		}
 	} else {
-		// Use containers from args
 		if len(args) == 0 {
-			return fmt.Errorf("no container names provided - use 'coi list' to see active containers")
+			return nil, fmt.Errorf("no container names provided - use 'coi list' to see active containers")
 		}
-		// Resolve aliases to container names
 		containerNames = make([]string, 0, len(args))
 		for _, arg := range args {
 			if resolved, err := alias.ResolveAliasForRunning(arg); err == nil {
@@ -90,16 +87,27 @@ func killCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Confirm unless --force
-		if !killForce && len(containerNames) > 1 {
-			fmt.Printf("Kill %d container(s)? [y/N]: ", len(containerNames))
+		if !force && len(containerNames) > 1 {
+			fmt.Printf("%s %d container(s)? [y/N]: ", action, len(containerNames))
 			var response string
 			_, _ = fmt.Scanln(&response)
 			if response != "y" && response != "Y" {
 				fmt.Println("Cancelled.")
-				return nil
+				return nil, nil
 			}
 		}
+	}
+
+	return containerNames, nil
+}
+
+func killCommand(cmd *cobra.Command, args []string) error {
+	containerNames, err := resolveContainerArgs(args, killAll, killForce, "Kill")
+	if err != nil {
+		return err
+	}
+	if containerNames == nil {
+		return nil
 	}
 
 	// Kill each container

--- a/internal/cli/kill.go
+++ b/internal/cli/kill.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/network"
 	"github.com/spf13/cobra"
@@ -79,7 +80,15 @@ func killCommand(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("no container names provided - use 'coi list' to see active containers")
 		}
-		containerNames = args
+		// Resolve aliases to container names
+		containerNames = make([]string, 0, len(args))
+		for _, arg := range args {
+			if resolved, err := alias.ResolveAliasForRunning(arg); err == nil {
+				containerNames = append(containerNames, resolved)
+			} else {
+				containerNames = append(containerNames, arg)
+			}
+		}
 
 		// Confirm unless --force
 		if !killForce && len(containerNames) > 1 {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -112,7 +112,8 @@ type ContainerInfo struct {
 	// Sourced from expanded_devices.root.pool in `incus list --format=json`,
 	// which already reflects profile defaults — so this is the actual pool
 	// being used, not the configured one.
-	Pool string
+	Pool  string
+	Alias string
 }
 
 // SessionInfo holds information about a saved session
@@ -144,9 +145,10 @@ func listActiveContainers() ([]ContainerInfo, error) {
 		status, _ := c["status"].(string)        // Type assertion, default to "" if fails
 		createdAt, _ := c["created_at"].(string) // Type assertion, default to "" if fails
 
-		// Get image info
-		config, _ := c["config"].(map[string]interface{}) // Type assertion
-		image, _ := config["image.description"].(string)  // Type assertion
+		// Get image info and alias
+		config, _ := c["config"].(map[string]interface{})     // Type assertion
+		image, _ := config["image.description"].(string)      // Type assertion
+		containerAlias, _ := config["user.coi.alias"].(string) // Alias metadata
 
 		// Parse created_at time
 		createdTime := ""
@@ -169,6 +171,7 @@ func listActiveContainers() ([]ContainerInfo, error) {
 			Image:     image,
 			IPv4:      ipv4,
 			Pool:      pool,
+			Alias:     containerAlias,
 		})
 	}
 
@@ -316,6 +319,7 @@ func outputJSON(containers []ContainerInfo, sessions []SessionInfo,
 			"persistent": persistent[c.Name],
 			"ipv4":       c.IPv4,
 			"pool":       c.Pool,
+			"alias":      c.Alias,
 		}
 		if ws, ok := workspaces[c.Name]; ok {
 			item["workspace"] = ws
@@ -354,12 +358,15 @@ func outputText(containers []ContainerInfo, sessions []SessionInfo,
 		fmt.Println("  (none)")
 	} else {
 		for _, c := range containers {
-			// Show container name with mode indicator from session metadata
-			// (not from Incus state, since all containers are now created as persistent in Incus)
+			// Show container name with alias and mode indicator
+			nameDisplay := c.Name
+			if c.Alias != "" {
+				nameDisplay = fmt.Sprintf("%s (%s)", c.Name, c.Alias)
+			}
 			if persistent[c.Name] {
-				fmt.Printf("  %s (persistent)\n", c.Name)
+				fmt.Printf("  %s (persistent)\n", nameDisplay)
 			} else {
-				fmt.Printf("  %s (ephemeral)\n", c.Name)
+				fmt.Printf("  %s (ephemeral)\n", nameDisplay)
 			}
 			fmt.Printf("    Status: %s\n", c.Status)
 			if c.IPv4 != "" {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -146,8 +146,8 @@ func listActiveContainers() ([]ContainerInfo, error) {
 		createdAt, _ := c["created_at"].(string) // Type assertion, default to "" if fails
 
 		// Get image info and alias
-		config, _ := c["config"].(map[string]interface{})     // Type assertion
-		image, _ := config["image.description"].(string)      // Type assertion
+		config, _ := c["config"].(map[string]interface{})      // Type assertion
+		image, _ := config["image.description"].(string)       // Type assertion
 		containerAlias, _ := config["user.coi.alias"].(string) // Alias metadata
 
 		// Parse created_at time

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/monitor"
@@ -125,9 +126,12 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 // 2. Check COI_CONTAINER environment variable
 // 3. Find container for current workspace
 func resolveMonitorContainer(args []string) (string, error) {
-	// 1. Use positional arg if provided
+	// 1. Use positional arg if provided (with alias resolution)
 	if len(args) > 0 {
 		name := args[0]
+		if resolved, err := alias.ResolveAliasForRunning(name); err == nil {
+			name = resolved
+		}
 		mgr := container.NewManager(name)
 		exists, err := mgr.Exists()
 		if err != nil {

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -131,6 +131,8 @@ func resolveMonitorContainer(args []string) (string, error) {
 		name := args[0]
 		if resolved, err := alias.ResolveAliasForRunning(name); err == nil {
 			name = resolved
+		} else if !alias.IsContainerName(name) {
+			return "", err
 		}
 		mgr := container.NewManager(name)
 		exists, err := mgr.Exists()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/limits"
@@ -80,6 +81,12 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Validate and prepare alias if configured
+	effectiveAlias, err := validateAndPrepareAlias(cfg.Container.Alias)
+	if err != nil {
+		return err
+	}
+
 	ensureBridgeTrustedZone()
 
 	fmt.Fprintf(os.Stderr, "Launching container %s from image %s...\n", containerName, img)
@@ -94,6 +101,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := launchOrReuseContainer(mgr, img, cfg.Container.StoragePool, containerExists, persistent); err != nil {
+		return err
+	}
+
+	// Set alias metadata on container and register in global registry
+	if err := applyContainerAlias(effectiveAlias, containerName, absWorkspace); err != nil {
 		return err
 	}
 
@@ -454,6 +466,45 @@ func filterWritableGitHooks(paths []string, cfg *config.Config) []string {
 		}
 	}
 	return filtered
+}
+
+// validateAndPrepareAlias validates the alias from config and returns it.
+// Returns ("", nil) if no alias is configured.
+func validateAndPrepareAlias(aliasStr string) (string, error) {
+	if aliasStr == "" {
+		return "", nil
+	}
+	if err := alias.ValidateAlias(aliasStr); err != nil {
+		return "", fmt.Errorf("invalid alias: %w", err)
+	}
+	return aliasStr, nil
+}
+
+// applyContainerAlias sets the user.coi.alias metadata on the container and
+// registers the alias in the global registry. No-op if alias is empty.
+func applyContainerAlias(effectiveAlias, containerName, absWorkspace string) error {
+	if effectiveAlias == "" {
+		return nil
+	}
+
+	if err := container.IncusExec("config", "set", containerName,
+		fmt.Sprintf("user.coi.alias=%s", effectiveAlias)); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to set alias metadata: %v\n", err)
+	}
+
+	reg, err := alias.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to load alias registry: %v\n", err)
+		return nil
+	}
+	if err := reg.Register(effectiveAlias, absWorkspace, ""); err != nil {
+		return fmt.Errorf("alias conflict: %w", err)
+	}
+	if err := reg.Save(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to save alias registry: %v\n", err)
+	}
+
+	return nil
 }
 
 // applyContainerTimezone resolves the timezone and configures it inside the container.

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -93,14 +93,23 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		}
 		// Override workspace from registry
 		absWorkspace = resolved.Workspace
+
+		// Reload project config from the resolved workspace so that mounts,
+		// network, storage_pool, alias, and other project-level settings from
+		// the target workspace are applied instead of the caller's CWD config.
+		if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+		}
+
 		// Apply profile if registry specifies one and user didn't override
 		if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
 			profile = resolved.Profile
 			if err := cfg.ApplyProfile(profile); err != nil {
 				return err
 			}
-			container.Configure(cfg.Incus.Project, cfg.Incus.Group, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
 		}
+		// Re-apply Incus configuration after config reload
+		container.Configure(cfg.Incus.Project, cfg.Incus.Group, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
 		if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
 			slot = resolved.Slot
 		}

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/monitor"
@@ -31,7 +32,7 @@ var (
 )
 
 var shellCmd = &cobra.Command{
-	Use:   "shell",
+	Use:   "shell [alias]",
 	Short: "Start an interactive AI coding session",
 	Long: `Start an interactive AI coding session in a container (always runs in tmux).
 
@@ -43,8 +44,13 @@ All sessions run in tmux for monitoring and detach/reattach support:
   - Detach anytime: Ctrl+B d (session keeps running)
   - Reattach: Run 'coi shell' again in same workspace
 
+An optional alias argument launches a session from the registered alias's workspace
+and profile, from any directory. Register an alias with [container] alias = "name"
+in .coi/config.toml.
+
 Examples:
   coi shell                         # Interactive session in tmux
+  coi shell myproject               # Launch session using alias (from any directory)
   coi shell --tool opencode         # Use opencode instead of configured tool
   coi shell --background            # Run in background (detached)
   coi shell --resume                # Resume latest session (auto)
@@ -53,6 +59,7 @@ Examples:
   coi shell --slot 2                # Use specific slot
   coi shell --debug                 # Launch bash for debugging
 `,
+	Args: cobra.MaximumNArgs(1),
 	RunE: shellCommand,
 }
 
@@ -66,15 +73,37 @@ func init() {
 
 //nolint:gocyclo // Sequential initialization with many configuration paths
 func shellCommand(cmd *cobra.Command, args []string) error {
-	// Validate no unexpected positional arguments
+	// Handle positional alias argument
+	var aliasArg string
 	if len(args) > 0 {
-		return fmt.Errorf("unexpected argument '%s' - did you mean --resume=%s? (note: use = when specifying session ID)", args[0], args[0])
+		aliasArg = args[0]
 	}
 
 	// Get absolute workspace path
 	absWorkspace, err := filepath.Abs(workspace)
 	if err != nil {
 		return fmt.Errorf("invalid workspace path: %w", err)
+	}
+
+	// If alias argument provided, resolve it from the registry
+	if aliasArg != "" {
+		resolved, err := alias.ResolveAliasForLaunch(aliasArg)
+		if err != nil {
+			return err
+		}
+		// Override workspace from registry
+		absWorkspace = resolved.Workspace
+		// Apply profile if registry specifies one and user didn't override
+		if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
+			profile = resolved.Profile
+			if err := cfg.ApplyProfile(profile); err != nil {
+				return err
+			}
+			container.Configure(cfg.Incus.Project, cfg.Incus.Group, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
+		}
+		if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
+			slot = resolved.Slot
+		}
 	}
 
 	// Check if Incus is available
@@ -283,6 +312,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		AutoContext:           cfg.Tool.AutoContext,
 		ContainerName:         containerName,
 		Timezone:              resolvedTimezone,
+		Alias:                 cfg.Container.Alias,
 	}
 
 	// Parse and validate mount configuration
@@ -298,6 +328,13 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 
 	setupOpts.MountConfig = mountConfig
 
+	// Validate alias before proceeding with setup
+	if cfg.Container.Alias != "" {
+		if err := alias.ValidateAlias(cfg.Container.Alias); err != nil {
+			return fmt.Errorf("invalid container alias: %w", err)
+		}
+	}
+
 	fmt.Fprintf(os.Stderr, "Setting up session %s...\n", sessionID)
 	result, err := session.Setup(setupOpts)
 	if err != nil {
@@ -307,6 +344,18 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	// Save metadata early so coi list shows correct persistent/ephemeral status
 	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, persistent); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
+	}
+
+	// Register alias in global registry for cross-directory resolution
+	if effectiveAlias := cfg.Container.Alias; effectiveAlias != "" {
+		if reg, err := alias.Load(); err == nil {
+			if err := reg.Register(effectiveAlias, absWorkspace, profile); err != nil {
+				return fmt.Errorf("alias conflict: %w", err)
+			}
+			if err := reg.Save(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to save alias registry: %v\n", err)
+			}
+		}
 	}
 
 	// Start monitoring daemons if enabled via config

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/network"
 	"github.com/spf13/cobra"
@@ -82,7 +83,15 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("no container names provided - use 'coi list' to see active containers")
 		}
-		containerNames = args
+		// Resolve aliases to container names
+		containerNames = make([]string, 0, len(args))
+		for _, arg := range args {
+			if resolved, err := alias.ResolveAliasForRunning(arg); err == nil {
+				containerNames = append(containerNames, resolved)
+			} else {
+				containerNames = append(containerNames, arg)
+			}
+		}
 
 		// Confirm unless --force
 		if !shutdownForce && len(containerNames) > 1 {

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/network"
 	"github.com/spf13/cobra"
@@ -43,66 +42,12 @@ func init() {
 }
 
 func shutdownCommand(cmd *cobra.Command, args []string) error {
-	// Get container names to shutdown
-	var containerNames []string
-
-	if shutdownAll {
-		// Get all containers
-		containers, err := listActiveContainers()
-		if err != nil {
-			return fmt.Errorf("failed to list containers: %w", err)
-		}
-
-		if len(containers) == 0 {
-			fmt.Println("No containers to shutdown")
-			return nil
-		}
-
-		for _, c := range containers {
-			containerNames = append(containerNames, c.Name)
-		}
-
-		// Show what will be shutdown
-		fmt.Printf("Found %d container(s):\n", len(containerNames))
-		for _, name := range containerNames {
-			fmt.Printf("  - %s\n", name)
-		}
-
-		// Confirm unless --force
-		if !shutdownForce {
-			fmt.Print("\nShutdown all these containers? [y/N]: ")
-			var response string
-			_, _ = fmt.Scanln(&response)
-			if response != "y" && response != "Y" {
-				fmt.Println("Cancelled.")
-				return nil
-			}
-		}
-	} else {
-		// Use containers from args
-		if len(args) == 0 {
-			return fmt.Errorf("no container names provided - use 'coi list' to see active containers")
-		}
-		// Resolve aliases to container names
-		containerNames = make([]string, 0, len(args))
-		for _, arg := range args {
-			if resolved, err := alias.ResolveAliasForRunning(arg); err == nil {
-				containerNames = append(containerNames, resolved)
-			} else {
-				containerNames = append(containerNames, arg)
-			}
-		}
-
-		// Confirm unless --force
-		if !shutdownForce && len(containerNames) > 1 {
-			fmt.Printf("Shutdown %d container(s)? [y/N]: ", len(containerNames))
-			var response string
-			_, _ = fmt.Scanln(&response)
-			if response != "y" && response != "Y" {
-				fmt.Println("Cancelled.")
-				return nil
-			}
-		}
+	containerNames, err := resolveContainerArgs(args, shutdownAll, shutdownForce, "Shutdown")
+	if err != nil {
+		return err
+	}
+	if containerNames == nil {
+		return nil
 	}
 
 	// Shutdown each container

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -171,6 +171,8 @@ func resolveContainer() (string, error) {
 		name := snapshotContainer
 		if resolved, err := alias.ResolveAliasForRunning(name); err == nil {
 			name = resolved
+		} else if !alias.IsContainerName(name) {
+			return "", err
 		}
 		// Verify container exists
 		mgr := container.NewManager(name)

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/session"
 	"github.com/spf13/cobra"
@@ -165,18 +166,22 @@ func init() {
 // 2. Check COI_CONTAINER environment variable
 // 3. Find container for current workspace
 func resolveContainer() (string, error) {
-	// 1. Use --container flag if provided
+	// 1. Use --container flag if provided (with alias resolution)
 	if snapshotContainer != "" {
+		name := snapshotContainer
+		if resolved, err := alias.ResolveAliasForRunning(name); err == nil {
+			name = resolved
+		}
 		// Verify container exists
-		mgr := container.NewManager(snapshotContainer)
+		mgr := container.NewManager(name)
 		exists, err := mgr.Exists()
 		if err != nil {
 			return "", fmt.Errorf("failed to check container: %w", err)
 		}
 		if !exists {
-			return "", fmt.Errorf("container '%s' not found", snapshotContainer)
+			return "", fmt.Errorf("container '%s' not found", name)
 		}
-		return snapshotContainer, nil
+		return name, nil
 	}
 
 	// 2. Check COI_CONTAINER environment variable

--- a/internal/cli/unfreeze.go
+++ b/internal/cli/unfreeze.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/spf13/cobra"
 )
@@ -26,8 +27,11 @@ Examples:
 
 func runUnfreeze(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
-		// Unfreeze specific container
+		// Unfreeze specific container (with alias resolution)
 		containerName := args[0]
+		if resolved, err := alias.ResolveAliasForRunning(containerName); err == nil {
+			containerName = resolved
+		}
 		return unfreezeContainer(containerName)
 	}
 

--- a/internal/cli/unfreeze.go
+++ b/internal/cli/unfreeze.go
@@ -31,6 +31,8 @@ func runUnfreeze(cmd *cobra.Command, args []string) error {
 		containerName := args[0]
 		if resolved, err := alias.ResolveAliasForRunning(containerName); err == nil {
 			containerName = resolved
+		} else if !alias.IsContainerName(containerName) {
+			return err
 		}
 		return unfreezeContainer(containerName)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type ContainerConfig struct {
 	Image       string      `toml:"image"`
 	Persistent  *bool       `toml:"persistent"`
 	StoragePool string      `toml:"storage_pool"`
+	Alias       string      `toml:"alias"`
 	Build       BuildConfig `toml:"build"`
 }
 
@@ -56,6 +57,7 @@ func (c *ContainerConfig) HasContainerConfig() bool {
 	return c.Image != "" ||
 		c.Persistent != nil ||
 		c.StoragePool != "" ||
+		c.Alias != "" ||
 		c.Build.HasBuildConfig()
 }
 
@@ -840,6 +842,9 @@ func applyContainerConfig(dst *ContainerConfig, src *ContainerConfig) {
 	}
 	if src.StoragePool != "" {
 		dst.StoragePool = src.StoragePool
+	}
+	if src.Alias != "" {
+		dst.Alias = src.Alias
 	}
 	mergeBuildInto(&dst.Build, &src.Build)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -72,6 +72,14 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
+// OverlayProjectConfig loads the project config from the given workspace directory
+// and merges it into cfg. This is used when launching via alias from a different
+// directory, so the resolved workspace's .coi/config.toml is applied.
+func (c *Config) OverlayProjectConfig(workspaceDir string) error {
+	path := filepath.Join(workspaceDir, ".coi", "config.toml")
+	return loadConfigFile(c, path)
+}
+
 // loadConfigFile loads a TOML config file and merges it into cfg
 func loadConfigFile(cfg *Config, path string) error {
 	// Check if file exists

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -46,6 +46,7 @@ type SetupOptions struct {
 	Timezone              string               // Resolved IANA timezone name (e.g., "America/New_York"), empty for UTC
 	AutoContext           *bool                // Auto-inject sandbox context into tool's native system (default: true)
 	HostImmutable         bool                 // Apply chattr +i on host-side protected paths (set by CLI from config)
+	Alias                 string               // Human-friendly alias for this container (set user.coi.alias)
 	Logger                func(string)
 	ContainerName         string // Use existing container (for testing) - skips container creation
 }
@@ -378,6 +379,14 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 		// Disable guest API to prevent host topology leaks (FLAWS Finding 3)
 		if err := container.DisableGuestAPI(result.ContainerName); err != nil {
 			return nil, fmt.Errorf("failed to disable guest API: %w", err)
+		}
+
+		// Set alias metadata on container (for running-container lookup)
+		if opts.Alias != "" {
+			if err := container.IncusExec("config", "set", result.ContainerName,
+				fmt.Sprintf("user.coi.alias=%s", opts.Alias)); err != nil {
+				opts.Logger(fmt.Sprintf("Warning: Failed to set alias metadata: %v", err))
+			}
 		}
 
 		// Block privileged containers — they defeat all isolation

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -381,14 +381,6 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 			return nil, fmt.Errorf("failed to disable guest API: %w", err)
 		}
 
-		// Set alias metadata on container (for running-container lookup)
-		if opts.Alias != "" {
-			if err := container.IncusExec("config", "set", result.ContainerName,
-				fmt.Sprintf("user.coi.alias=%s", opts.Alias)); err != nil {
-				opts.Logger(fmt.Sprintf("Warning: Failed to set alias metadata: %v", err))
-			}
-		}
-
 		// Block privileged containers — they defeat all isolation
 		if err := container.CheckNotPrivileged(result.ContainerName); err != nil {
 			return nil, err
@@ -398,6 +390,15 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 		opts.Logger("Starting container...")
 		if err := result.Manager.Start(); err != nil {
 			return nil, fmt.Errorf("failed to start container: %w", err)
+		}
+	}
+
+	// Set/update alias metadata on container (for running-container lookup).
+	// This runs for both new and reused containers so alias changes are propagated.
+	if opts.Alias != "" {
+		if err := container.IncusExec("config", "set", result.ContainerName,
+			fmt.Sprintf("user.coi.alias=%s", opts.Alias)); err != nil {
+			opts.Logger(fmt.Sprintf("Warning: Failed to set alias metadata: %v", err))
 		}
 	}
 

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -52,7 +52,9 @@ def get_aliases_registry():
 class TestAliasStoredOnContainer:
     """Test that alias metadata is set on the container."""
 
-    def test_alias_stored_on_container(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_stored_on_container(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Launch session with alias, verify user.coi.alias is set."""
         write_alias_config(workspace_dir, "testalias")
         container_name = calculate_container_name(workspace_dir, 1)
@@ -94,16 +96,16 @@ class TestAliasInRegistry:
         assert result.returncode == 0, f"coi run failed: {result.stderr}"
 
         registry = get_aliases_registry()
-        assert "registrytest" in registry, (
-            f"Alias 'registrytest' not found in registry: {registry}"
-        )
+        assert "registrytest" in registry, f"Alias 'registrytest' not found in registry: {registry}"
         assert registry["registrytest"]["workspace"] == os.path.abspath(workspace_dir)
 
 
 class TestAliasShownInList:
     """Test that aliases are displayed in coi list output."""
 
-    def test_alias_shown_in_list_json(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_shown_in_list_json(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Launch container with alias, verify it appears in JSON list output."""
         write_alias_config(workspace_dir, "listalias")
 
@@ -125,7 +127,9 @@ class TestAliasShownInList:
             for c in containers:
                 assert "alias" in c, f"Missing 'alias' key in container: {c}"
 
-    def test_alias_shown_in_list_text(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_shown_in_list_text(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Launch container with alias, verify (alias) appears in text output."""
         write_alias_config(workspace_dir, "textalias")
 
@@ -168,7 +172,10 @@ class TestAttachByAlias:
         # It should either succeed or fail with a container-level error, NOT "not found"
         # Alias resolution means it found the container
         if result.returncode != 0:
-            assert "not found" not in result.stderr.lower() or "no running container found with alias" in result.stderr.lower()
+            assert (
+                "not found" not in result.stderr.lower()
+                or "no running container found with alias" in result.stderr.lower()
+            )
 
 
 class TestKillByAlias:
@@ -257,7 +264,9 @@ class TestUnfreezeByAlias:
 class TestAliasSlotSuffix:
     """Test alias with slot suffixes (e.g. myproject-2)."""
 
-    def test_alias_with_slot_suffix(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_with_slot_suffix(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Launch two containers, kill slot 2 by alias suffix."""
         write_alias_config(workspace_dir, "slotalias")
 
@@ -297,7 +306,9 @@ class TestAliasSlotSuffix:
 class TestAliasConflict:
     """Test alias conflict detection."""
 
-    def test_alias_conflict_different_workspace(self, coi_binary, workspace_dir, cleanup_containers, dummy_image, tmp_path):
+    def test_alias_conflict_different_workspace(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image, tmp_path
+    ):
         """Register alias for workspace A, try to use same alias from workspace B."""
         write_alias_config(workspace_dir, "conflictalias")
 
@@ -323,7 +334,9 @@ class TestAliasConflict:
         assert result.returncode != 0, "Should fail with alias conflict"
         assert "conflict" in result.stderr.lower() or "already registered" in result.stderr.lower()
 
-    def test_alias_same_workspace_idempotent(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_same_workspace_idempotent(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Running twice from same workspace with same alias should not conflict."""
         write_alias_config(workspace_dir, "idempotentalias")
 
@@ -372,7 +385,9 @@ class TestShellAlias:
 class TestAliasEdgeCases:
     """Test alias edge cases."""
 
-    def test_alias_exact_container_name_passthrough(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_exact_container_name_passthrough(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Exact container name format should pass through without alias resolution."""
         write_alias_config(workspace_dir, "edgealias")
 
@@ -385,7 +400,9 @@ class TestAliasEdgeCases:
         if result.returncode != 0:
             assert "alias" not in result.stderr.lower()
 
-    def test_alias_invalid_characters(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_invalid_characters(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Invalid alias characters should be rejected."""
         write_alias_config(workspace_dir, "my project!")
 
@@ -397,7 +414,9 @@ class TestAliasEdgeCases:
         assert result.returncode != 0
         assert "invalid" in result.stderr.lower()
 
-    def test_alias_starts_with_digit(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+    def test_alias_starts_with_digit(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
         """Alias starting with digit should be rejected."""
         write_alias_config(workspace_dir, "123project")
 
@@ -407,7 +426,10 @@ class TestAliasEdgeCases:
             workspace_dir=workspace_dir,
         )
         assert result.returncode != 0
-        assert "invalid" in result.stderr.lower() or "must start with a letter" in result.stderr.lower()
+        assert (
+            "invalid" in result.stderr.lower()
+            or "must start with a letter" in result.stderr.lower()
+        )
 
     def test_alias_empty_string(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
         """Empty alias should work normally (no alias set)."""

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -1,0 +1,443 @@
+"""
+Integration tests for container alias support (#304).
+
+Tests alias registration, resolution, conflict detection, and cross-command support.
+"""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from support.helpers import calculate_container_name, get_container_list
+
+
+def write_alias_config(workspace_dir, alias_name):
+    """Create .coi/config.toml with alias in the workspace."""
+    config_dir = os.path.join(workspace_dir, ".coi")
+    os.makedirs(config_dir, exist_ok=True)
+    with open(os.path.join(config_dir, "config.toml"), "w") as f:
+        f.write(f'[container]\nalias = "{alias_name}"\n')
+
+
+def run_coi(coi_binary, args, workspace_dir=None, env_extra=None, timeout=120):
+    """Run a coi command and return the result."""
+    env = os.environ.copy()
+    env["COI_USE_DUMMY"] = "1"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [coi_binary] + args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=workspace_dir,
+        env=env,
+    )
+
+
+def get_aliases_registry():
+    """Read and return the aliases.json registry."""
+    path = os.path.join(os.path.expanduser("~"), ".coi", "aliases.json")
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return json.load(f)
+
+
+# ============================================================
+# Core alias tests
+# ============================================================
+
+
+class TestAliasStoredOnContainer:
+    """Test that alias metadata is set on the container."""
+
+    def test_alias_stored_on_container(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch session with alias, verify user.coi.alias is set."""
+        write_alias_config(workspace_dir, "testalias")
+        container_name = calculate_container_name(workspace_dir, 1)
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        # Container may have been cleaned up, but check if it ran
+        assert result.returncode == 0, f"coi run failed: {result.stderr}"
+
+        # Check if container still exists to verify alias
+        containers = get_container_list()
+        if container_name in containers:
+            check = subprocess.run(
+                ["incus", "config", "get", container_name, "user.coi.alias"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert check.stdout.strip() == "testalias", (
+                f"Expected alias 'testalias', got '{check.stdout.strip()}'"
+            )
+
+
+class TestAliasInRegistry:
+    """Test that alias is registered in ~/.coi/aliases.json."""
+
+    def test_alias_in_registry(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch session with alias, verify it appears in registry."""
+        write_alias_config(workspace_dir, "registrytest")
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode == 0, f"coi run failed: {result.stderr}"
+
+        registry = get_aliases_registry()
+        assert "registrytest" in registry, (
+            f"Alias 'registrytest' not found in registry: {registry}"
+        )
+        assert registry["registrytest"]["workspace"] == os.path.abspath(workspace_dir)
+
+
+class TestAliasShownInList:
+    """Test that aliases are displayed in coi list output."""
+
+    def test_alias_shown_in_list_json(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, verify it appears in JSON list output."""
+        write_alias_config(workspace_dir, "listalias")
+
+        # Launch a persistent container so it stays running
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
+            workspace_dir=workspace_dir,
+        )
+        # Run might still be running; check list
+        list_result = run_coi(coi_binary, ["list", "--format=json"])
+        assert list_result.returncode == 0
+
+        data = json.loads(list_result.stdout)
+        containers = data.get("active_containers", [])
+        aliased = [c for c in containers if c.get("alias") == "listalias"]
+        # May or may not find it depending on timing, but structure should be correct
+        if containers:
+            # At minimum, all containers should have the alias key
+            for c in containers:
+                assert "alias" in c, f"Missing 'alias' key in container: {c}"
+
+    def test_alias_shown_in_list_text(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, verify (alias) appears in text output."""
+        write_alias_config(workspace_dir, "textalias")
+
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
+            workspace_dir=workspace_dir,
+        )
+        list_result = run_coi(coi_binary, ["list"])
+        # Check text output contains the alias in parentheses
+        if "textalias" in list_result.stdout:
+            assert "(textalias)" in list_result.stdout
+
+
+# ============================================================
+# Alias resolution for action commands
+# ============================================================
+
+
+class TestAttachByAlias:
+    """Test that coi attach resolves aliases."""
+
+    def test_attach_by_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, attempt to attach by alias."""
+        write_alias_config(workspace_dir, "attachalias")
+
+        # Start a persistent container
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+
+        # Try attaching by alias with --bash (will timeout quickly, but should not error with "not found")
+        result = run_coi(
+            coi_binary,
+            ["attach", "attachalias", "--bash"],
+            timeout=10,
+        )
+        # It should either succeed or fail with a container-level error, NOT "not found"
+        # Alias resolution means it found the container
+        if result.returncode != 0:
+            assert "not found" not in result.stderr.lower() or "no running container found with alias" in result.stderr.lower()
+
+
+class TestKillByAlias:
+    """Test that coi kill resolves aliases."""
+
+    def test_kill_by_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, kill it by alias."""
+        write_alias_config(workspace_dir, "killalias")
+
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+
+        result = run_coi(
+            coi_binary,
+            ["kill", "killalias", "--force"],
+        )
+        # Should succeed (exit 0) or at least resolve the alias
+        assert result.returncode == 0 or "no running container found" in result.stderr.lower()
+
+
+class TestShutdownByAlias:
+    """Test that coi shutdown resolves aliases."""
+
+    def test_shutdown_by_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, shutdown by alias."""
+        write_alias_config(workspace_dir, "shutdownalias")
+
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+
+        result = run_coi(
+            coi_binary,
+            ["shutdown", "shutdownalias", "--force"],
+        )
+        assert result.returncode == 0 or "no running container found" in result.stderr.lower()
+
+
+class TestUnfreezeByAlias:
+    """Test that coi unfreeze resolves aliases."""
+
+    def test_unfreeze_by_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch container with alias, freeze it, unfreeze by alias."""
+        write_alias_config(workspace_dir, "unfreezealias")
+        container_name = calculate_container_name(workspace_dir, 1)
+
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+
+        # Pause the container
+        subprocess.run(
+            ["incus", "pause", container_name],
+            capture_output=True,
+            timeout=10,
+        )
+
+        # Unfreeze by alias
+        result = run_coi(
+            coi_binary,
+            ["unfreeze", "unfreezealias"],
+        )
+        if result.returncode == 0:
+            # Verify container is running again
+            check = subprocess.run(
+                ["incus", "list", container_name, "--format=csv", "-c", "s"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert "RUNNING" in check.stdout.upper()
+
+
+# ============================================================
+# Slot suffix tests
+# ============================================================
+
+
+class TestAliasSlotSuffix:
+    """Test alias with slot suffixes (e.g. myproject-2)."""
+
+    def test_alias_with_slot_suffix(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Launch two containers, kill slot 2 by alias suffix."""
+        write_alias_config(workspace_dir, "slotalias")
+
+        # Launch slot 1
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "--slot", "1", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+        # Launch slot 2
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "--slot", "2", "sleep", "60"],
+            workspace_dir=workspace_dir,
+        )
+
+        container1 = calculate_container_name(workspace_dir, 1)
+        container2 = calculate_container_name(workspace_dir, 2)
+
+        # Kill slot 2 by alias suffix
+        result = run_coi(
+            coi_binary,
+            ["kill", "slotalias-2", "--force"],
+        )
+        if result.returncode == 0:
+            containers = get_container_list()
+            assert container2 not in containers, "Slot 2 container should be deleted"
+            # Slot 1 should still exist
+            assert container1 in containers, "Slot 1 container should still exist"
+
+
+# ============================================================
+# Conflict detection tests
+# ============================================================
+
+
+class TestAliasConflict:
+    """Test alias conflict detection."""
+
+    def test_alias_conflict_different_workspace(self, coi_binary, workspace_dir, cleanup_containers, dummy_image, tmp_path):
+        """Register alias for workspace A, try to use same alias from workspace B."""
+        write_alias_config(workspace_dir, "conflictalias")
+
+        # Register alias from workspace A
+        run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+
+        # Create workspace B with same alias
+        workspace_b = str(tmp_path / "workspace_b")
+        os.makedirs(workspace_b)
+        write_alias_config(workspace_b, "conflictalias")
+
+        # Try to run from workspace B
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_b,
+        )
+        # Should fail with alias conflict
+        assert result.returncode != 0, "Should fail with alias conflict"
+        assert "conflict" in result.stderr.lower() or "already registered" in result.stderr.lower()
+
+    def test_alias_same_workspace_idempotent(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Running twice from same workspace with same alias should not conflict."""
+        write_alias_config(workspace_dir, "idempotentalias")
+
+        result1 = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "first"],
+            workspace_dir=workspace_dir,
+        )
+        assert result1.returncode == 0
+
+        result2 = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "second"],
+            workspace_dir=workspace_dir,
+        )
+        assert result2.returncode == 0, f"Second run should succeed: {result2.stderr}"
+
+
+# ============================================================
+# Shell launch-by-alias tests
+# ============================================================
+
+
+class TestShellAlias:
+    """Test coi shell <alias> positional argument."""
+
+    def test_shell_positional_arg_unknown_alias(self, coi_binary, tmp_path):
+        """Running coi shell with unknown alias should show clear error."""
+        other_dir = str(tmp_path / "other")
+        os.makedirs(other_dir)
+
+        result = run_coi(
+            coi_binary,
+            ["shell", "nonexistentalias"],
+            workspace_dir=other_dir,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+
+# ============================================================
+# Edge case tests
+# ============================================================
+
+
+class TestAliasEdgeCases:
+    """Test alias edge cases."""
+
+    def test_alias_exact_container_name_passthrough(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Exact container name format should pass through without alias resolution."""
+        write_alias_config(workspace_dir, "edgealias")
+
+        # Try to kill a container with exact name format (even if it doesn't exist)
+        result = run_coi(
+            coi_binary,
+            ["kill", "coi-abc12345-1", "--force"],
+        )
+        # Should NOT error with "alias not found" — should pass through as container name
+        if result.returncode != 0:
+            assert "alias" not in result.stderr.lower()
+
+    def test_alias_invalid_characters(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Invalid alias characters should be rejected."""
+        write_alias_config(workspace_dir, "my project!")
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode != 0
+        assert "invalid" in result.stderr.lower()
+
+    def test_alias_starts_with_digit(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Alias starting with digit should be rejected."""
+        write_alias_config(workspace_dir, "123project")
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode != 0
+        assert "invalid" in result.stderr.lower() or "must start with a letter" in result.stderr.lower()
+
+    def test_alias_empty_string(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Empty alias should work normally (no alias set)."""
+        write_alias_config(workspace_dir, "")
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode == 0, f"Empty alias should work: {result.stderr}"
+
+    def test_list_no_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
+        """Container without alias should show empty alias in JSON output."""
+        # No alias config — just launch normally
+        result = run_coi(
+            coi_binary,
+            ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
+            workspace_dir=workspace_dir,
+        )
+
+        list_result = run_coi(coi_binary, ["list", "--format=json"])
+        if list_result.returncode == 0:
+            data = json.loads(list_result.stdout)
+            containers = data.get("active_containers", [])
+            for c in containers:
+                assert "alias" in c, f"Missing 'alias' key in container: {c}"
+                # No alias configured, so it should be empty
+                if c["name"] == calculate_container_name(workspace_dir, 1):
+                    assert c["alias"] == "", f"Expected empty alias, got '{c['alias']}'"

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -186,7 +186,7 @@ class TestAttachByAlias:
         if result.returncode != 0:
             assert (
                 "not found" not in result.stderr.lower()
-                or "no running container found with alias" in result.stderr.lower()
+                or "container or alias" in result.stderr.lower()
             )
 
 

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -55,30 +55,32 @@ class TestAliasStoredOnContainer:
     def test_alias_stored_on_container(
         self, coi_binary, workspace_dir, cleanup_containers, dummy_image
     ):
-        """Launch session with alias, verify user.coi.alias is set."""
+        """Launch persistent session with alias, verify user.coi.alias is set."""
         write_alias_config(workspace_dir, "testalias")
         container_name = calculate_container_name(workspace_dir, 1)
 
         result = run_coi(
             coi_binary,
-            ["run", "--image", dummy_image, "echo", "ok"],
+            ["run", "--persistent", "--image", dummy_image, "sleep", "30"],
             workspace_dir=workspace_dir,
         )
-        # Container may have been cleaned up, but check if it ran
         assert result.returncode == 0, f"coi run failed: {result.stderr}"
 
-        # Check if container still exists to verify alias
+        # Container is persistent, so it should still exist
         containers = get_container_list()
-        if container_name in containers:
-            check = subprocess.run(
-                ["incus", "config", "get", container_name, "user.coi.alias"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            assert check.stdout.strip() == "testalias", (
-                f"Expected alias 'testalias', got '{check.stdout.strip()}'"
-            )
+        assert container_name in containers, (
+            f"Expected persistent container '{container_name}' to exist for alias verification"
+        )
+
+        check = subprocess.run(
+            ["incus", "config", "get", container_name, "user.coi.alias"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert check.stdout.strip() == "testalias", (
+            f"Expected alias 'testalias', got '{check.stdout.strip()}'"
+        )
 
 
 class TestAliasInRegistry:
@@ -108,6 +110,7 @@ class TestAliasShownInList:
     ):
         """Launch container with alias, verify it appears in JSON list output."""
         write_alias_config(workspace_dir, "listalias")
+        container_name = calculate_container_name(workspace_dir, 1)
 
         # Launch a persistent container so it stays running
         run_coi(
@@ -115,23 +118,30 @@ class TestAliasShownInList:
             ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
             workspace_dir=workspace_dir,
         )
-        # Run might still be running; check list
+
         list_result = run_coi(coi_binary, ["list", "--format=json"])
         assert list_result.returncode == 0
 
         data = json.loads(list_result.stdout)
         containers = data.get("active_containers", [])
-        # May or may not find it depending on timing, but structure should be correct
-        if containers:
-            # At minimum, all containers should have the alias key
-            for c in containers:
-                assert "alias" in c, f"Missing 'alias' key in container: {c}"
+
+        # Find our container and verify alias
+        found = [c for c in containers if c.get("name") == container_name]
+        assert len(found) > 0, (
+            f"Expected container '{container_name}' in list output, "
+            f"got: {[c.get('name') for c in containers]}"
+        )
+        assert "alias" in found[0], f"Missing 'alias' key in container: {found[0]}"
+        assert found[0]["alias"] == "listalias", (
+            f"Expected alias 'listalias', got '{found[0].get('alias')}'"
+        )
 
     def test_alias_shown_in_list_text(
         self, coi_binary, workspace_dir, cleanup_containers, dummy_image
     ):
         """Launch container with alias, verify (alias) appears in text output."""
         write_alias_config(workspace_dir, "textalias")
+        container_name = calculate_container_name(workspace_dir, 1)
 
         run_coi(
             coi_binary,
@@ -139,9 +149,11 @@ class TestAliasShownInList:
             workspace_dir=workspace_dir,
         )
         list_result = run_coi(coi_binary, ["list"])
-        # Check text output contains the alias in parentheses
-        if "textalias" in list_result.stdout:
-            assert "(textalias)" in list_result.stdout
+        # Container should be in the list since it's persistent
+        assert container_name in list_result.stdout, (
+            f"Expected container '{container_name}' in text output"
+        )
+        assert "(textalias)" in list_result.stdout, "Expected '(textalias)' in text output"
 
 
 # ============================================================
@@ -444,6 +456,8 @@ class TestAliasEdgeCases:
 
     def test_list_no_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
         """Container without alias should show empty alias in JSON output."""
+        container_name = calculate_container_name(workspace_dir, 1)
+
         # No alias config — just launch normally
         run_coi(
             coi_binary,
@@ -452,11 +466,11 @@ class TestAliasEdgeCases:
         )
 
         list_result = run_coi(coi_binary, ["list", "--format=json"])
-        if list_result.returncode == 0:
-            data = json.loads(list_result.stdout)
-            containers = data.get("active_containers", [])
-            for c in containers:
-                assert "alias" in c, f"Missing 'alias' key in container: {c}"
-                # No alias configured, so it should be empty
-                if c["name"] == calculate_container_name(workspace_dir, 1):
-                    assert c["alias"] == "", f"Expected empty alias, got '{c['alias']}'"
+        assert list_result.returncode == 0
+
+        data = json.loads(list_result.stdout)
+        containers = data.get("active_containers", [])
+        found = [c for c in containers if c.get("name") == container_name]
+        assert len(found) > 0, f"Expected container '{container_name}' in list output"
+        assert "alias" in found[0], f"Missing 'alias' key in container: {found[0]}"
+        assert found[0]["alias"] == "", f"Expected empty alias, got '{found[0]['alias']}'"

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -8,8 +8,6 @@ import json
 import os
 import subprocess
 
-import pytest
-
 from support.helpers import calculate_container_name, get_container_list
 
 
@@ -28,7 +26,7 @@ def run_coi(coi_binary, args, workspace_dir=None, env_extra=None, timeout=120):
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
-        [coi_binary] + args,
+        [coi_binary, *args],
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -110,7 +108,7 @@ class TestAliasShownInList:
         write_alias_config(workspace_dir, "listalias")
 
         # Launch a persistent container so it stays running
-        result = run_coi(
+        run_coi(
             coi_binary,
             ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
             workspace_dir=workspace_dir,
@@ -121,7 +119,6 @@ class TestAliasShownInList:
 
         data = json.loads(list_result.stdout)
         containers = data.get("active_containers", [])
-        aliased = [c for c in containers if c.get("alias") == "listalias"]
         # May or may not find it depending on timing, but structure should be correct
         if containers:
             # At minimum, all containers should have the alias key
@@ -426,7 +423,7 @@ class TestAliasEdgeCases:
     def test_list_no_alias(self, coi_binary, workspace_dir, cleanup_containers, dummy_image):
         """Container without alias should show empty alias in JSON output."""
         # No alias config — just launch normally
-        result = run_coi(
+        run_coi(
             coi_binary,
             ["run", "--image", dummy_image, "--persistent", "sleep", "30"],
             workspace_dir=workspace_dir,


### PR DESCRIPTION
## Summary

- Adds human-friendly container aliases via `[container] alias = "myproject"` in project/profile config
- Three-layer storage: config (source of truth), Incus `user.coi.alias` metadata (running-container lookup), `~/.coi/aliases.json` registry (cross-directory resolution)
- `coi shell myproject` launches from any directory using registry lookup; `coi attach/kill/shutdown/unfreeze myproject` resolves aliases on running containers
- Slot suffixes work naturally: `coi attach myproject-2` targets slot 2
- Alias validation (must start with letter, alphanumeric + hyphens/underscores, max 64 chars), conflict detection (same alias for different workspaces errors)
- Aliases displayed in `coi list` output (text shows `(myproject)`, JSON includes `"alias"` key)
- Alias resolution added to: attach, kill, shutdown, unfreeze, monitor, snapshot

## New files
- `internal/alias/registry.go` — Registry CRUD + atomic JSON persistence
- `internal/alias/resolve.go` — Centralized alias resolution (running containers + launch-from-anywhere)
- `internal/alias/registry_test.go` — 14 Go unit tests
- `tests/cli/test_alias.py` — Python integration tests

## Modified files
- `internal/config/config.go` — `Alias` field in `ContainerConfig`
- `internal/session/setup.go` — Set `user.coi.alias` on container creation
- `internal/cli/shell.go` — Accept positional `[alias]` arg, register alias in registry
- `internal/cli/attach.go`, `kill.go`, `shutdown.go`, `unfreeze.go`, `monitor.go`, `snapshot.go` — Alias resolution
- `internal/cli/list.go` — Display aliases in text/JSON output
- `CHANGELOG.md`, `README.md` — Documentation

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/alias/ -v` — all 14 unit tests pass
- [ ] `pytest tests/cli/test_alias.py -v` — integration tests (requires Incus)

Closes #304