### PR TITLE
Fix alias resolution: auto-register from CWD + prevent profile override

### DIFF
--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -89,10 +89,17 @@ func ResolveAliasForLaunch(arg string) (*ResolvedAlias, error) {
 		cwd, cwdErr := os.Getwd()
 		if cwdErr == nil {
 			if projectAlias := loadProjectAlias(cwd); projectAlias == alias {
-				absWorkspace, _ := filepath.Abs(cwd)
+				absWorkspace, err := filepath.Abs(cwd)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve workspace path for alias %q: %w", alias, err)
+				}
 				// Auto-register so subsequent lookups succeed.
-				_ = reg.Register(alias, absWorkspace, "")
-				_ = reg.Save()
+				if err := reg.Register(alias, absWorkspace, ""); err != nil {
+					return nil, fmt.Errorf("failed to auto-register alias %q: %w", alias, err)
+				}
+				if err := reg.Save(); err != nil {
+					return nil, fmt.Errorf("failed to persist auto-registered alias %q: %w", alias, err)
+				}
 				return &ResolvedAlias{Workspace: absWorkspace, Slot: slotNum}, nil
 			}
 		}

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -3,10 +3,13 @@ package alias
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/session"
 )
@@ -80,6 +83,19 @@ func ResolveAliasForLaunch(arg string) (*ResolvedAlias, error) {
 
 	entry := reg.Lookup(alias)
 	if entry == nil {
+		// Fallback: check CWD project config for matching alias.
+		// This handles the chicken-and-egg case where the user runs
+		// `coi shell <alias> --profile X` before the alias has been registered.
+		cwd, cwdErr := os.Getwd()
+		if cwdErr == nil {
+			if projectAlias := loadProjectAlias(cwd); projectAlias == alias {
+				absWorkspace, _ := filepath.Abs(cwd)
+				// Auto-register so subsequent lookups succeed.
+				_ = reg.Register(alias, absWorkspace, "")
+				_ = reg.Save()
+				return &ResolvedAlias{Workspace: absWorkspace, Slot: slotNum}, nil
+			}
+		}
 		return nil, fmt.Errorf("alias %q not found — register it by adding [container] alias = %q to .coi/config.toml and running a session", alias, alias)
 	}
 
@@ -88,6 +104,20 @@ func ResolveAliasForLaunch(arg string) (*ResolvedAlias, error) {
 		Profile:   entry.Profile,
 		Slot:      slotNum,
 	}, nil
+}
+
+// loadProjectAlias reads only the [container] alias field from a project's
+// .coi/config.toml.  Returns "" if the file doesn't exist or has no alias.
+func loadProjectAlias(dir string) string {
+	var cfg struct {
+		Container struct {
+			Alias string `toml:"alias"`
+		} `toml:"container"`
+	}
+	if _, err := toml.DecodeFile(filepath.Join(dir, ".coi", "config.toml"), &cfg); err != nil {
+		return ""
+	}
+	return cfg.Container.Alias
 }
 
 // FindContainersByAlias queries Incus for COI containers whose user.coi.alias

--- a/internal/alias/resolve_test.go
+++ b/internal/alias/resolve_test.go
@@ -3,6 +3,7 @@ package alias
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -80,7 +81,20 @@ func TestLoadProjectAlias(t *testing.T) {
 	})
 }
 
+// withTempHome sets HOME to a temp directory so Load() uses an isolated
+// aliases.json. Returns a cleanup function to restore the original HOME.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpHome)
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+	return tmpHome
+}
+
 func TestResolveAliasForLaunch_CWDFallback(t *testing.T) {
+	tmpHome := withTempHome(t)
+
 	// Create a workspace directory with .coi/config.toml
 	workspace := t.TempDir()
 	coiDir := filepath.Join(workspace, ".coi")
@@ -88,15 +102,6 @@ func TestResolveAliasForLaunch_CWDFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"testfallback\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Set up a temporary registry file
-	regPath := filepath.Join(t.TempDir(), "aliases.json")
-
-	// Override the registry path for this test by saving an empty registry
-	reg := &Registry{path: regPath, entries: make(map[string]AliasEntry)}
-	if err := reg.Save(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -110,37 +115,36 @@ func TestResolveAliasForLaunch_CWDFallback(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chdir(origDir) })
 
-	// We can't easily test ResolveAliasForLaunch directly because it uses Load()
-	// which reads from the default path. Instead, test the fallback logic directly.
-	projectAlias := loadProjectAlias(workspace)
-	if projectAlias != "testfallback" {
-		t.Fatalf("loadProjectAlias() = %q, want %q", projectAlias, "testfallback")
-	}
-
-	// Simulate the fallback: register and save
-	absWorkspace, _ := filepath.Abs(workspace)
-	if err := reg.Register("testfallback", absWorkspace, ""); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
-	if err := reg.Save(); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	// Verify it was persisted
-	reg2, err := LoadFrom(regPath)
+	// Call the production function — alias is not in registry, so
+	// CWD fallback should kick in and auto-register it.
+	resolved, err := ResolveAliasForLaunch("testfallback")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("ResolveAliasForLaunch() returned error: %v", err)
 	}
-	entry := reg2.Lookup("testfallback")
+
+	absWorkspace, _ := filepath.Abs(workspace)
+	if resolved.Workspace != absWorkspace {
+		t.Errorf("Workspace = %q, want %q", resolved.Workspace, absWorkspace)
+	}
+
+	// Verify the alias was persisted to the registry
+	regPath := filepath.Join(tmpHome, ".coi", "aliases.json")
+	reg, err := LoadFrom(regPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+	entry := reg.Lookup("testfallback")
 	if entry == nil {
-		t.Fatal("alias not found in registry after CWD fallback registration")
+		t.Fatal("alias not found in registry after CWD fallback auto-registration")
 	}
 	if entry.Workspace != absWorkspace {
-		t.Errorf("Workspace = %q, want %q", entry.Workspace, absWorkspace)
+		t.Errorf("persisted Workspace = %q, want %q", entry.Workspace, absWorkspace)
 	}
 }
 
 func TestResolveAliasForLaunch_CWDFallback_NoMatch(t *testing.T) {
+	withTempHome(t)
+
 	// Create a workspace directory with a different alias
 	workspace := t.TempDir()
 	coiDir := filepath.Join(workspace, ".coi")
@@ -161,9 +165,39 @@ func TestResolveAliasForLaunch_CWDFallback_NoMatch(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chdir(origDir) })
 
-	// Querying a non-matching alias should not trigger the fallback
-	projectAlias := loadProjectAlias(workspace)
-	if projectAlias == "nonexistent" {
-		t.Error("loadProjectAlias should not match a different alias name")
+	// Querying a non-matching alias should fail — CWD has "differentalias"
+	// but we ask for "nonexistent".
+	_, err = ResolveAliasForLaunch("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-matching alias, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestResolveAliasForLaunch_CWDFallback_SlotSuffix(t *testing.T) {
+	withTempHome(t)
+
+	workspace := t.TempDir()
+	coiDir := filepath.Join(workspace, ".coi")
+	if err := os.MkdirAll(coiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"slottest\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(workspace)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Alias with slot suffix should resolve via CWD fallback
+	resolved, err := ResolveAliasForLaunch("slottest-3")
+	if err != nil {
+		t.Fatalf("ResolveAliasForLaunch(\"slottest-3\") returned error: %v", err)
+	}
+	if resolved.Slot != 3 {
+		t.Errorf("Slot = %d, want 3", resolved.Slot)
 	}
 }

--- a/internal/alias/resolve_test.go
+++ b/internal/alias/resolve_test.go
@@ -1,0 +1,169 @@
+package alias
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadProjectAlias(t *testing.T) {
+	t.Run("valid config with alias", func(t *testing.T) {
+		dir := t.TempDir()
+		coiDir := filepath.Join(dir, ".coi")
+		if err := os.MkdirAll(coiDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"myproject\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := loadProjectAlias(dir)
+		if got != "myproject" {
+			t.Errorf("loadProjectAlias() = %q, want %q", got, "myproject")
+		}
+	})
+
+	t.Run("no config file", func(t *testing.T) {
+		dir := t.TempDir()
+		got := loadProjectAlias(dir)
+		if got != "" {
+			t.Errorf("loadProjectAlias() = %q, want empty", got)
+		}
+	})
+
+	t.Run("config without alias", func(t *testing.T) {
+		dir := t.TempDir()
+		coiDir := filepath.Join(dir, ".coi")
+		if err := os.MkdirAll(coiDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nimage = \"ubuntu\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := loadProjectAlias(dir)
+		if got != "" {
+			t.Errorf("loadProjectAlias() = %q, want empty", got)
+		}
+	})
+
+	t.Run("empty alias", func(t *testing.T) {
+		dir := t.TempDir()
+		coiDir := filepath.Join(dir, ".coi")
+		if err := os.MkdirAll(coiDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := loadProjectAlias(dir)
+		if got != "" {
+			t.Errorf("loadProjectAlias() = %q, want empty", got)
+		}
+	})
+
+	t.Run("malformed toml", func(t *testing.T) {
+		dir := t.TempDir()
+		coiDir := filepath.Join(dir, ".coi")
+		if err := os.MkdirAll(coiDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("not valid toml [[["), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := loadProjectAlias(dir)
+		if got != "" {
+			t.Errorf("loadProjectAlias() = %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveAliasForLaunch_CWDFallback(t *testing.T) {
+	// Create a workspace directory with .coi/config.toml
+	workspace := t.TempDir()
+	coiDir := filepath.Join(workspace, ".coi")
+	if err := os.MkdirAll(coiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"testfallback\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up a temporary registry file
+	regPath := filepath.Join(t.TempDir(), "aliases.json")
+
+	// Override the registry path for this test by saving an empty registry
+	reg := &Registry{path: regPath, entries: make(map[string]AliasEntry)}
+	if err := reg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change CWD to the workspace to trigger the fallback
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// We can't easily test ResolveAliasForLaunch directly because it uses Load()
+	// which reads from the default path. Instead, test the fallback logic directly.
+	projectAlias := loadProjectAlias(workspace)
+	if projectAlias != "testfallback" {
+		t.Fatalf("loadProjectAlias() = %q, want %q", projectAlias, "testfallback")
+	}
+
+	// Simulate the fallback: register and save
+	absWorkspace, _ := filepath.Abs(workspace)
+	if err := reg.Register("testfallback", absWorkspace, ""); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if err := reg.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify it was persisted
+	reg2, err := LoadFrom(regPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := reg2.Lookup("testfallback")
+	if entry == nil {
+		t.Fatal("alias not found in registry after CWD fallback registration")
+	}
+	if entry.Workspace != absWorkspace {
+		t.Errorf("Workspace = %q, want %q", entry.Workspace, absWorkspace)
+	}
+}
+
+func TestResolveAliasForLaunch_CWDFallback_NoMatch(t *testing.T) {
+	// Create a workspace directory with a different alias
+	workspace := t.TempDir()
+	coiDir := filepath.Join(workspace, ".coi")
+	if err := os.MkdirAll(coiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coiDir, "config.toml"), []byte("[container]\nalias = \"differentalias\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change CWD to the workspace
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Querying a non-matching alias should not trigger the fallback
+	projectAlias := loadProjectAlias(workspace)
+	if projectAlias == "nonexistent" {
+		t.Error("loadProjectAlias should not match a different alias name")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -761,7 +761,14 @@ func (c *Config) ApplyProfile(name string) error {
 		return err
 	}
 
+	// Save the project-level alias before merging — profiles must not
+	// override it because aliases are workspace-specific and a profile
+	// used across multiple projects must not stamp them with a single name.
+	projectAlias := c.Container.Alias
 	applyContainerConfig(&c.Container, &profile.Container)
+	if projectAlias != "" {
+		c.Container.Alias = projectAlias
+	}
 	if profile.Model != "" {
 		c.Defaults.Model = profile.Model
 	}
@@ -843,10 +850,7 @@ func applyContainerConfig(dst *ContainerConfig, src *ContainerConfig) {
 	if src.StoragePool != "" {
 		dst.StoragePool = src.StoragePool
 	}
-	// Profiles should not override project-level aliases — aliases are
-	// workspace-specific and a profile used across multiple projects
-	// must not stamp them with a single name.
-	if src.Alias != "" && dst.Alias == "" {
+	if src.Alias != "" {
 		dst.Alias = src.Alias
 	}
 	mergeBuildInto(&dst.Build, &src.Build)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -843,7 +843,10 @@ func applyContainerConfig(dst *ContainerConfig, src *ContainerConfig) {
 	if src.StoragePool != "" {
 		dst.StoragePool = src.StoragePool
 	}
-	if src.Alias != "" {
+	// Profiles should not override project-level aliases — aliases are
+	// workspace-specific and a profile used across multiple projects
+	// must not stamp them with a single name.
+	if src.Alias != "" && dst.Alias == "" {
 		dst.Alias = src.Alias
 	}
 	mergeBuildInto(&dst.Build, &src.Build)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1153,3 +1153,32 @@ func TestPreserveWorkspacePathMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyContainerConfig_AliasPreservation(t *testing.T) {
+	t.Run("profile alias does not override project alias", func(t *testing.T) {
+		dst := &ContainerConfig{Alias: "project-alias"}
+		src := &ContainerConfig{Alias: "profile-alias"}
+		applyContainerConfig(dst, src)
+		if dst.Alias != "project-alias" {
+			t.Errorf("Alias = %q, want %q (project alias should win)", dst.Alias, "project-alias")
+		}
+	})
+
+	t.Run("profile alias applied when project has no alias", func(t *testing.T) {
+		dst := &ContainerConfig{Alias: ""}
+		src := &ContainerConfig{Alias: "profile-alias"}
+		applyContainerConfig(dst, src)
+		if dst.Alias != "profile-alias" {
+			t.Errorf("Alias = %q, want %q (profile alias should apply when project has none)", dst.Alias, "profile-alias")
+		}
+	})
+
+	t.Run("no alias in either", func(t *testing.T) {
+		dst := &ContainerConfig{Alias: ""}
+		src := &ContainerConfig{Alias: ""}
+		applyContainerConfig(dst, src)
+		if dst.Alias != "" {
+			t.Errorf("Alias = %q, want empty", dst.Alias)
+		}
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1154,31 +1154,52 @@ func TestPreserveWorkspacePathMerge(t *testing.T) {
 	}
 }
 
-func TestApplyContainerConfig_AliasPreservation(t *testing.T) {
+func TestApplyProfile_AliasPreservation(t *testing.T) {
 	t.Run("profile alias does not override project alias", func(t *testing.T) {
-		dst := &ContainerConfig{Alias: "project-alias"}
-		src := &ContainerConfig{Alias: "profile-alias"}
-		applyContainerConfig(dst, src)
-		if dst.Alias != "project-alias" {
-			t.Errorf("Alias = %q, want %q (project alias should win)", dst.Alias, "project-alias")
+		cfg := GetDefaultConfig()
+		cfg.Container.Alias = "project-alias"
+		cfg.Profiles["test"] = ProfileConfig{
+			Container: ContainerConfig{Alias: "profile-alias"},
+		}
+		if err := cfg.ApplyProfile("test"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Container.Alias != "project-alias" {
+			t.Errorf("Alias = %q, want %q (project alias should win)", cfg.Container.Alias, "project-alias")
 		}
 	})
 
 	t.Run("profile alias applied when project has no alias", func(t *testing.T) {
-		dst := &ContainerConfig{Alias: ""}
-		src := &ContainerConfig{Alias: "profile-alias"}
-		applyContainerConfig(dst, src)
-		if dst.Alias != "profile-alias" {
-			t.Errorf("Alias = %q, want %q (profile alias should apply when project has none)", dst.Alias, "profile-alias")
+		cfg := GetDefaultConfig()
+		cfg.Profiles["test"] = ProfileConfig{
+			Container: ContainerConfig{Alias: "profile-alias"},
+		}
+		if err := cfg.ApplyProfile("test"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Container.Alias != "profile-alias" {
+			t.Errorf("Alias = %q, want %q (profile alias should apply when project has none)", cfg.Container.Alias, "profile-alias")
 		}
 	})
 
 	t.Run("no alias in either", func(t *testing.T) {
-		dst := &ContainerConfig{Alias: ""}
-		src := &ContainerConfig{Alias: ""}
-		applyContainerConfig(dst, src)
-		if dst.Alias != "" {
-			t.Errorf("Alias = %q, want empty", dst.Alias)
+		cfg := GetDefaultConfig()
+		cfg.Profiles["test"] = ProfileConfig{}
+		if err := cfg.ApplyProfile("test"); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Container.Alias != "" {
+			t.Errorf("Alias = %q, want empty", cfg.Container.Alias)
+		}
+	})
+
+	t.Run("Merge still allows alias override", func(t *testing.T) {
+		cfg := GetDefaultConfig()
+		cfg.Container.Alias = "base-alias"
+		other := &Config{Container: ContainerConfig{Alias: "override-alias"}}
+		cfg.Merge(other)
+		if cfg.Container.Alias != "override-alias" {
+			t.Errorf("Alias = %q, want %q (Merge should allow override)", cfg.Container.Alias, "override-alias")
 		}
 	})
 }

--- a/tests/cli/test_alias.py
+++ b/tests/cli/test_alias.py
@@ -474,3 +474,178 @@ class TestAliasEdgeCases:
         assert len(found) > 0, f"Expected container '{container_name}' in list output"
         assert "alias" in found[0], f"Missing 'alias' key in container: {found[0]}"
         assert found[0]["alias"] == "", f"Expected empty alias, got '{found[0]['alias']}'"
+
+
+# ============================================================
+# CWD alias auto-registration tests (chicken-and-egg fix)
+# ============================================================
+
+
+def write_profile_config(workspace_dir, profile_name, alias=None, image=None):
+    """Create a profile with optional alias and image in the workspace."""
+    profile_dir = os.path.join(workspace_dir, ".coi", "profiles", profile_name)
+    os.makedirs(profile_dir, exist_ok=True)
+    lines = ["[container]"]
+    if alias:
+        lines.append(f'alias = "{alias}"')
+    if image:
+        lines.append(f'image = "{image}"')
+    with open(os.path.join(profile_dir, "config.toml"), "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+class TestAliasCWDAutoRegister:
+    """Test that aliases from CWD config are auto-registered on first use."""
+
+    def test_shell_alias_auto_registers_from_cwd(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
+        """coi shell <alias> should work when CWD config has matching alias, even without prior registration."""
+        write_alias_config(workspace_dir, "cwdauto")
+
+        # Clear any existing registry entry for this alias
+        registry = get_aliases_registry()
+        if "cwdauto" in registry:
+            # Remove it so we test the fallback
+            del registry["cwdauto"]
+            reg_path = os.path.join(os.path.expanduser("~"), ".coi", "aliases.json")
+            with open(reg_path, "w") as f:
+                json.dump(registry, f)
+
+        # Run coi shell <alias> from the workspace dir — should auto-register
+        result = run_coi(
+            coi_binary,
+            ["shell", "cwdauto", "--image", dummy_image, "--", "echo", "hello"],
+            workspace_dir=workspace_dir,
+        )
+        # Should succeed (alias resolved via CWD fallback)
+        assert result.returncode == 0, (
+            f"Expected coi shell cwdauto to succeed via CWD fallback, "
+            f"got rc={result.returncode}\nstderr: {result.stderr}\nstdout: {result.stdout}"
+        )
+
+        # Verify alias was auto-registered in the registry
+        registry = get_aliases_registry()
+        assert "cwdauto" in registry, (
+            f"Alias 'cwdauto' should have been auto-registered, registry: {registry}"
+        )
+        assert registry["cwdauto"]["workspace"] == os.path.abspath(workspace_dir)
+
+    def test_shell_alias_cwd_mismatch_still_fails(self, coi_binary, tmp_path):
+        """coi shell <alias> should still fail when CWD config has a different alias."""
+        workspace = str(tmp_path / "mismatch_workspace")
+        os.makedirs(workspace)
+        write_alias_config(workspace, "actualname")
+
+        result = run_coi(
+            coi_binary,
+            ["shell", "wrongname"],
+            workspace_dir=workspace,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+    def test_shell_alias_no_cwd_config_still_fails(self, coi_binary, tmp_path):
+        """coi shell <alias> should still fail when CWD has no .coi/config.toml."""
+        workspace = str(tmp_path / "no_config_workspace")
+        os.makedirs(workspace)
+
+        result = run_coi(
+            coi_binary,
+            ["shell", "nosuchproject"],
+            workspace_dir=workspace,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+
+# ============================================================
+# Profile alias override prevention tests
+# ============================================================
+
+
+class TestProfileAliasNoOverride:
+    """Test that profile aliases don't stomp project-level aliases."""
+
+    def test_profile_alias_does_not_override_project_alias(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
+        """When project has alias and profile has alias, project alias wins."""
+        # Project config with its own alias
+        write_alias_config(workspace_dir, "projectalias")
+
+        # Profile with a different alias
+        write_profile_config(workspace_dir, "testprofile", alias="profilealias", image=dummy_image)
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--profile", "testprofile", "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode == 0, f"coi run failed: {result.stderr}"
+
+        # Verify the registry has the project alias, not the profile alias
+        registry = get_aliases_registry()
+        assert "projectalias" in registry, (
+            f"Project alias 'projectalias' should be in registry: {registry}"
+        )
+        # The profile alias should NOT have replaced the project alias
+        assert registry["projectalias"]["workspace"] == os.path.abspath(workspace_dir)
+
+    def test_profile_alias_applied_when_project_has_none(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image
+    ):
+        """When project has no alias but profile does, profile alias is used."""
+        # Project config WITHOUT alias
+        config_dir = os.path.join(workspace_dir, ".coi")
+        os.makedirs(config_dir, exist_ok=True)
+        with open(os.path.join(config_dir, "config.toml"), "w") as f:
+            f.write("[container]\n")  # no alias
+
+        # Profile with an alias
+        write_profile_config(workspace_dir, "withalias", alias="fromsprofile", image=dummy_image)
+
+        result = run_coi(
+            coi_binary,
+            ["run", "--profile", "withalias", "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result.returncode == 0, f"coi run failed: {result.stderr}"
+
+        # Verify the profile's alias was applied
+        registry = get_aliases_registry()
+        assert "fromsprofile" in registry, (
+            f"Profile alias 'fromsprofile' should be in registry when project has no alias: {registry}"
+        )
+
+    def test_same_profile_two_projects_no_conflict(
+        self, coi_binary, workspace_dir, cleanup_containers, dummy_image, tmp_path
+    ):
+        """Two projects with own aliases using same profile (which has alias) should not conflict."""
+        # Project A with its own alias
+        write_alias_config(workspace_dir, "projectA")
+        write_profile_config(workspace_dir, "shared", alias="sharedname", image=dummy_image)
+
+        result_a = run_coi(
+            coi_binary,
+            ["run", "--profile", "shared", "echo", "ok"],
+            workspace_dir=workspace_dir,
+        )
+        assert result_a.returncode == 0, f"Project A run failed: {result_a.stderr}"
+
+        # Project B with its own alias
+        workspace_b = str(tmp_path / "workspace_b")
+        os.makedirs(workspace_b)
+        write_alias_config(workspace_b, "projectB")
+        write_profile_config(workspace_b, "shared", alias="sharedname", image=dummy_image)
+
+        result_b = run_coi(
+            coi_binary,
+            ["run", "--profile", "shared", "echo", "ok"],
+            workspace_dir=workspace_b,
+        )
+        # Should NOT conflict because project aliases are preserved (not overridden by profile)
+        assert result_b.returncode == 0, (
+            f"Project B should not conflict with project A when both use same profile. "
+            f"rc={result_b.returncode}\nstderr: {result_b.stderr}"
+        )


### PR DESCRIPTION
## Summary

- **CWD alias auto-registration**: `ResolveAliasForLaunch()` now falls back to checking the CWD's `.coi/config.toml` for a matching alias when the registry lookup fails, fixing the chicken-and-egg problem where `coi shell <alias> --profile X` required a prior plain `coi shell` run
- **Profile alias no longer overrides project alias**: `applyContainerConfig()` only applies profile alias when the project has no alias set, preventing conflicts when the same profile is used across multiple projects
- Adds Go unit tests for `loadProjectAlias()`, CWD fallback logic, and alias preservation in `applyContainerConfig()`
- Adds Python integration tests for CWD auto-registration and profile alias override prevention

## Test plan

- [ ] `go test ./internal/alias/... ./internal/config/...` — all pass
- [ ] `coi shell karafka2 --profile rdkafka` from karafka2 dir with `[container] alias = "karafka2"` — works without prior registration
- [ ] `coi shell nonexistent` — still fails with "not found" error
- [ ] Profile with alias applied to project WITHOUT its own alias — profile alias still works
- [ ] Profile with alias applied to project WITH its own alias — project alias wins
- [ ] Two projects with own aliases using same profile (which has alias) — no conflict
- [ ] `pytest tests/cli/test_alias.py` — integration tests pass