### PR TITLE
Fix README inconsistencies for 0.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Security-Hardened Container Runtime for AI Coding Agents with Real-Time Threat Detection**
 
-Run AI coding assistants (Claude Code, opencode, Aider, and more) in isolated, production-grade Incus containers with zero permission headaches, perfect file ownership, and true multi-session support.
+Run AI coding assistants (Claude Code, opencode, and more) in isolated, production-grade Incus containers with zero permission headaches, perfect file ownership, and true multi-session support.
 
 **Limited Blast Radius:** Prepare your workspace upfront, let the AI agent run in isolation, validate the outcome. No SSH keys, no environment variables, no credentials exposed. If compromised, damage is contained to your workspace. Network isolation helps prevent data exfiltration. Your host system stays protected.
 
@@ -206,7 +206,7 @@ coi build --compression none
 
 # Build a custom image via a profile
 coi profile create my-image --image my-image
-# Edit .coi/profiles/my-image/config.toml to add a [build] section
+# Edit .coi/profiles/my-image/config.toml to add a [container.build] section
 coi build --profile my-image
 ```
 

--- a/README.md
+++ b/README.md
@@ -397,10 +397,12 @@ Profiles are reusable container configurations bundling image, tool, limits, mou
 Example profile config (`.coi/profiles/rust-dev/config.toml`):
 
 ```toml
-image = "coi-rust"
-persistent = true
 context = "CONTEXT.md"
 forward_env = ["CARGO_HOME"]
+
+[container]
+image = "coi-rust"
+persistent = true
 
 [environment]
 RUST_BACKTRACE = "1"
@@ -418,6 +420,8 @@ count = "4"
 ```toml
 # .coi/profiles/rust-dev-nightly/config.toml
 inherits = "rust-dev"
+
+[container]
 image = "coi-rust-nightly"
 
 [environment]
@@ -493,6 +497,7 @@ coi shell --resume            # Resume previous conversation
 coi attach                    # Reconnect to running container
 coi persist                   # Convert ephemeral session to persistent
 coi unfreeze <name>           # Unfreeze paused/frozen container
+coi unfreeze                  # Unfreeze all frozen COI containers
 sudo poweroff                 # Properly stop container (inside)
 coi shutdown <name>           # Graceful stop (outside)
 ```
@@ -571,6 +576,7 @@ See the [Troubleshooting guide](https://github.com/mensfeld/code-on-incus/wiki/T
 - **DNS issues during build** - COI automatically fixes systemd-resolved conflicts
 - Run `coi health` to diagnose setup problems
 - Check the troubleshooting guide for detailed solutions
+
 ## Frequently Asked Questions
 
 See the [FAQ](https://github.com/mensfeld/code-on-incus/wiki/FAQ) for answers to common questions.


### PR DESCRIPTION
## Summary

- Profile examples: migrate deprecated top-level `image`/`persistent` to `[container]` nesting (0.8.0 rejects the old format with a fatal error)
- Add `coi unfreeze` (no args) form to quick reference section
- Fix missing blank line before FAQ heading (markdown rendering)

**Wiki counterpart already pushed** — fixes profile examples, phantom config keys, FAQ Aider claim, wrong paths, undocumented commands, and more across 7 wiki pages.

## Test plan
- [ ] Verify profile TOML examples in README match the `[container]` nesting required by `internal/config/deprecated.go`
- [ ] Confirm markdown renders correctly (blank line before heading)