### PR TITLE
Add git auth hints to SANDBOX_CONTEXT.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - Added `close` command inside containers as an alias for `poweroff`. This provides a safe alternative that doesn't exist on the host machine, preventing accidental host shutdowns when typed outside the container.
+- **Better git auth hints in SANDBOX_CONTEXT.md** — When SSH agent and/or GH_TOKEN is forwarded, the context file now includes a `Git Configuration` section that guides AI tools to: prefer SSH over token-based auth for git operations, derive commit identity from the SSH key instead of using "code" as author, and warns that forwarded tokens may have limited scope/permissions. (#337)
 
 ## 0.8.0 (2026-04-16)
 

--- a/internal/session/context_file_integration_test.go
+++ b/internal/session/context_file_integration_test.go
@@ -342,6 +342,9 @@ func TestContextFile_GitHubCLIAuthenticated(t *testing.T) {
 	if !strings.Contains(content, "Authenticated via forwarded token") {
 		t.Error("Context file should indicate GitHub CLI is authenticated")
 	}
+	if !strings.Contains(content, "token may have limited scope/permissions") {
+		t.Error("Context file should include scope warning for forwarded token")
+	}
 	if strings.Contains(content, "Not authenticated") {
 		t.Error("Context file should not say 'Not authenticated' when GH CLI is authenticated")
 	}

--- a/internal/tool/templates/sandbox_context.md.tmpl
+++ b/internal/tool/templates/sandbox_context.md.tmpl
@@ -80,6 +80,12 @@ The following extra directories are also mounted into this container: {{.ExtraMo
 
 These paths are available alongside the workspace and persist changes to the host.
 {{- end}}
+{{- if .HasGitAuth}}
+
+## Git Configuration
+
+{{.GitAuthDesc}}
+{{- end}}
 
 ## Limitations
 {{if .NetworkLimitation}}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -316,6 +316,8 @@ type contextTemplateData struct {
 	ContainerName       string
 	ProfileContext      string
 	HasProfileContext   bool
+	GitAuthDesc         string
+	HasGitAuth          bool
 }
 
 // RenderContextFileContent renders the embedded sandbox context template with
@@ -366,7 +368,50 @@ func RenderContextFileContent(info ContextInfo) string {
 	}
 
 	if info.GHCLIAuthenticated {
-		data.GitHubCLIDesc = "Authenticated via forwarded token (gh CLI ready to use)"
+		data.GitHubCLIDesc = "Authenticated via forwarded token (gh CLI ready to use; note: token may have limited scope/permissions)"
+	}
+
+	// Git auth hints based on SSH + token availability
+	switch {
+	case info.SSHAgentForwarded && info.GHCLIAuthenticated:
+		data.HasGitAuth = true
+		data.GitAuthDesc = `**Prefer SSH for git push/pull** — the forwarded SSH agent provides full authentication, while the forwarded GH_TOKEN/GITHUB_TOKEN may have limited scope or permissions (e.g., read-only, or restricted to specific repos).
+
+**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, run:
+` + "```" + `
+ssh -T git@github.com 2>&1
+` + "```" + `
+This will print the GitHub username associated with the SSH key. Use it to set:
+` + "```" + `
+git config user.name "<name from SSH identity>"
+git config user.email "<username>@users.noreply.github.com"
+` + "```"
+	case info.SSHAgentForwarded:
+		data.HasGitAuth = true
+		data.GitAuthDesc = `**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., ` + "`git@github.com:org/repo.git`" + `).
+
+**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, run:
+` + "```" + `
+ssh -T git@github.com 2>&1
+` + "```" + `
+This will print the GitHub username associated with the SSH key. Use it to set:
+` + "```" + `
+git config user.name "<name from SSH identity>"
+git config user.email "<username>@users.noreply.github.com"
+` + "```"
+	case info.GHCLIAuthenticated:
+		data.HasGitAuth = true
+		data.GitAuthDesc = `**Token-based git authentication is available** via the forwarded GH_TOKEN/GITHUB_TOKEN. Note that this token may have limited scope or permissions (e.g., read-only, restricted to specific repos, or no push access).
+
+**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. If the token has sufficient permissions, you can discover the correct identity by running:
+` + "```" + `
+gh api user --jq '.login'
+` + "```" + `
+Use the result to set:
+` + "```" + `
+git config user.name "<name>"
+git config user.email "<username>@users.noreply.github.com"
+` + "```"
 	}
 
 	if len(info.ForwardedEnvVars) > 0 {

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -377,27 +377,39 @@ func RenderContextFileContent(info ContextInfo) string {
 		data.HasGitAuth = true
 		data.GitAuthDesc = `**Prefer SSH for git push/pull** — the forwarded SSH agent provides full authentication, while the forwarded GH_TOKEN/GITHUB_TOKEN may have limited scope or permissions (e.g., read-only, or restricted to specific repos).
 
-**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, run:
+**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, check the remote URL of the repository and test against the appropriate host:
 ` + "```" + `
-ssh -T git@github.com 2>&1
+# Check which host the repo uses:
+git remote get-url origin
+
+# Then test SSH against that host, e.g.:
+ssh -T git@github.com 2>&1    # GitHub
+ssh -T git@gitlab.com 2>&1    # GitLab
+ssh -T git@bitbucket.org 2>&1 # Bitbucket
 ` + "```" + `
-This will print the GitHub username associated with the SSH key. Use it to set:
+Use the identity from the SSH response to configure git:
 ` + "```" + `
-git config user.name "<name from SSH identity>"
-git config user.email "<username>@users.noreply.github.com"
+git config user.name "<real name>"
+git config user.email "<real email>"
 ` + "```"
 	case info.SSHAgentForwarded:
 		data.HasGitAuth = true
-		data.GitAuthDesc = `**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., ` + "`git@github.com:org/repo.git`" + `).
+		data.GitAuthDesc = `**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., ` + "`git@<host>:org/repo.git`" + `).
 
-**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, run:
+**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, check the remote URL of the repository and test against the appropriate host:
 ` + "```" + `
-ssh -T git@github.com 2>&1
+# Check which host the repo uses:
+git remote get-url origin
+
+# Then test SSH against that host, e.g.:
+ssh -T git@github.com 2>&1    # GitHub
+ssh -T git@gitlab.com 2>&1    # GitLab
+ssh -T git@bitbucket.org 2>&1 # Bitbucket
 ` + "```" + `
-This will print the GitHub username associated with the SSH key. Use it to set:
+Use the identity from the SSH response to configure git:
 ` + "```" + `
-git config user.name "<name from SSH identity>"
-git config user.email "<username>@users.noreply.github.com"
+git config user.name "<real name>"
+git config user.email "<real email>"
 ` + "```"
 	case info.GHCLIAuthenticated:
 		data.HasGitAuth = true
@@ -405,12 +417,12 @@ git config user.email "<username>@users.noreply.github.com"
 
 **Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. If the token has sufficient permissions, you can discover the correct identity by running:
 ` + "```" + `
-gh api user --jq '.login'
+gh api user --jq '"Name: \(.name)\nEmail: \(.email)"'
 ` + "```" + `
 Use the result to set:
 ` + "```" + `
-git config user.name "<name>"
-git config user.email "<username>@users.noreply.github.com"
+git config user.name "<real name>"
+git config user.email "<real email>"
 ` + "```"
 	}
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -532,6 +532,9 @@ func TestRenderContextFileContent(t *testing.T) {
 		{"autonomous operation section", "Autonomous Operation"},
 		{"never ask confirmation", "Never ask for confirmation"},
 		{"act autonomously guidance", "Act autonomously"},
+		{"git configuration section", "Git Configuration"},
+		{"git ssh recommendation", "Use SSH for git operations"},
+		{"git identity warning", `Do NOT use "code" as the git author`},
 	}
 
 	for _, check := range checks {
@@ -686,6 +689,98 @@ func TestRenderContextFileContent_NoOptionalSections(t *testing.T) {
 	}
 	if strings.Contains(content, "Additional Mounts") {
 		t.Error("Should not contain 'Additional Mounts' when no extra mounts configured")
+	}
+}
+
+func TestRenderContextFileContent_GitAuthHints_SSHOnly(t *testing.T) {
+	info := ContextInfo{
+		WorkspacePath:     "/workspace",
+		HomeDir:           "/home/code",
+		SSHAgentForwarded: true,
+	}
+	content := RenderContextFileContent(info)
+
+	if !strings.Contains(content, "Git Configuration") {
+		t.Error("Expected 'Git Configuration' section when SSH is forwarded")
+	}
+	if !strings.Contains(content, "Use SSH for git operations") {
+		t.Error("Expected SSH recommendation for git operations")
+	}
+	if !strings.Contains(content, "ssh -T git@github.com") {
+		t.Error("Expected ssh -T command for identity discovery")
+	}
+	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
+		t.Error("Expected warning against using 'code' as git author")
+	}
+	if strings.Contains(content, "token may have limited scope") {
+		t.Error("Should not mention token scope when only SSH is available")
+	}
+}
+
+func TestRenderContextFileContent_GitAuthHints_TokenOnly(t *testing.T) {
+	info := ContextInfo{
+		WorkspacePath:      "/workspace",
+		HomeDir:            "/home/code",
+		GHCLIAuthenticated: true,
+	}
+	content := RenderContextFileContent(info)
+
+	if !strings.Contains(content, "Git Configuration") {
+		t.Error("Expected 'Git Configuration' section when token is available")
+	}
+	if !strings.Contains(content, "Token-based git authentication is available") {
+		t.Error("Expected token-based auth description")
+	}
+	if !strings.Contains(content, "token may have limited scope") {
+		t.Error("Expected scope warning for forwarded token")
+	}
+	if !strings.Contains(content, "gh api user") {
+		t.Error("Expected gh api command for identity discovery")
+	}
+	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
+		t.Error("Expected warning against using 'code' as git author")
+	}
+	// GitHubCLIDesc in the environment table should also have scope warning
+	if !strings.Contains(content, "token may have limited scope/permissions") {
+		t.Error("Expected scope/permissions warning in GitHub CLI table row")
+	}
+}
+
+func TestRenderContextFileContent_GitAuthHints_BothSSHAndToken(t *testing.T) {
+	info := ContextInfo{
+		WorkspacePath:      "/workspace",
+		HomeDir:            "/home/code",
+		SSHAgentForwarded:  true,
+		GHCLIAuthenticated: true,
+	}
+	content := RenderContextFileContent(info)
+
+	if !strings.Contains(content, "Git Configuration") {
+		t.Error("Expected 'Git Configuration' section when both SSH and token are available")
+	}
+	if !strings.Contains(content, "Prefer SSH for git push/pull") {
+		t.Error("Expected SSH preference recommendation")
+	}
+	if !strings.Contains(content, "GH_TOKEN/GITHUB_TOKEN may have limited scope") {
+		t.Error("Expected token scope warning")
+	}
+	if !strings.Contains(content, "ssh -T git@github.com") {
+		t.Error("Expected ssh -T command for identity discovery")
+	}
+	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
+		t.Error("Expected warning against using 'code' as git author")
+	}
+}
+
+func TestRenderContextFileContent_GitAuthHints_Neither(t *testing.T) {
+	info := ContextInfo{
+		WorkspacePath: "/workspace",
+		HomeDir:       "/home/code",
+	}
+	content := RenderContextFileContent(info)
+
+	if strings.Contains(content, "Git Configuration") {
+		t.Error("Should not contain 'Git Configuration' section when neither SSH nor token is available")
 	}
 }
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -707,7 +707,16 @@ func TestRenderContextFileContent_GitAuthHints_SSHOnly(t *testing.T) {
 		t.Error("Expected SSH recommendation for git operations")
 	}
 	if !strings.Contains(content, "ssh -T git@github.com") {
-		t.Error("Expected ssh -T command for identity discovery")
+		t.Error("Expected ssh -T github example for identity discovery")
+	}
+	if !strings.Contains(content, "ssh -T git@gitlab.com") {
+		t.Error("Expected ssh -T gitlab example for identity discovery")
+	}
+	if !strings.Contains(content, "ssh -T git@bitbucket.org") {
+		t.Error("Expected ssh -T bitbucket example for identity discovery")
+	}
+	if !strings.Contains(content, "git remote get-url origin") {
+		t.Error("Expected guidance to check remote URL")
 	}
 	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
 		t.Error("Expected warning against using 'code' as git author")


### PR DESCRIPTION
## Summary

Closes #337

- Adds a conditional **Git Configuration** section to `SANDBOX_CONTEXT.md` that guides AI tools on proper git auth and commit identity when SSH agent and/or GH_TOKEN is forwarded
- Adapts guidance to all four auth combinations: SSH-only (use SSH URLs, derive identity via `ssh -T`), token-only (warns about limited scope, discover identity via `gh api user`), both (prefer SSH over token), neither (section omitted)
- Adds scope/permissions warning to the GitHub CLI row in the environment table when token is forwarded
- Warns AI tools not to use "code" as the git commit author

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tool/ -run TestRenderContext -v` — all 13 tests pass (4 new git auth tests + 9 existing)
- [ ] Integration test `TestContextFile_GitHubCLIAuthenticated` updated to verify scope warning