### PR TITLE
Set git user.useConfigOnly=true to prevent bad commit identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `close` command inside containers as an alias for `poweroff`. This provides a safe alternative that doesn't exist on the host machine, preventing accidental host shutdowns when typed outside the container.
 - **Better git auth hints in SANDBOX_CONTEXT.md** — When SSH agent and/or GH_TOKEN is forwarded, the context file now includes a `Git Configuration` section that guides AI tools to: prefer SSH over token-based auth for git operations, derive commit identity from the SSH key instead of using "code" as author, and warns that forwarded tokens may have limited scope/permissions. (#337)
+- **Git identity guard** — Containers now set `git config --global user.useConfigOnly true` during setup, which forces git to refuse commits until `user.name` and `user.email` are explicitly configured. This prevents AI tools from accidentally committing as the container's default "code" user.
 
 ## 0.8.0 (2026-04-16)
 

--- a/internal/session/context_file_integration_test.go
+++ b/internal/session/context_file_integration_test.go
@@ -374,6 +374,58 @@ func TestContextFile_GitHubCLIAuthenticated(t *testing.T) {
 	t.Logf("Authenticated context file content:\n%s", content)
 }
 
+// TestSetupGitIdentityGuard verifies that SetupGitIdentityGuard configures
+// user.useConfigOnly=true globally and that git refuses to commit without
+// explicit user.name and user.email.
+func TestSetupGitIdentityGuard(t *testing.T) {
+	skipUnlessContextFileTestable(t)
+
+	containerName := "coi-test-git-identity"
+	mgr := launchContextTestContainer(t, containerName)
+
+	homeDir := "/home/" + container.CodeUser
+	logger := func(msg string) { t.Logf("[git-identity] %s", msg) }
+	user := container.CodeUID
+
+	// Apply the guard
+	SetupGitIdentityGuard(mgr, homeDir, logger)
+
+	// Verify the config value is set
+	out, err := mgr.ExecCommand(
+		"HOME="+homeDir+" git config --global user.useConfigOnly",
+		container.ExecCommandOptions{Capture: true, User: &user},
+	)
+	if err != nil {
+		t.Fatalf("Failed to read git config: %v", err)
+	}
+	if strings.TrimSpace(out) != "true" {
+		t.Errorf("Expected user.useConfigOnly=true, got %q", strings.TrimSpace(out))
+	}
+
+	// Create a test repo and try to commit without setting identity — should fail
+	initCmd := "HOME=" + homeDir + " bash -c 'cd /tmp && mkdir testrepo && cd testrepo && git init && touch file && git add file && git commit -m test 2>&1; echo EXIT:$?'"
+	commitOut, err := mgr.ExecCommand(initCmd, container.ExecCommandOptions{Capture: true, User: &user})
+	if err != nil {
+		t.Logf("Command error (expected): %v", err)
+	}
+	if !strings.Contains(commitOut, "EXIT:128") && !strings.Contains(commitOut, "user.useConfigOnly") && !strings.Contains(commitOut, "tell me who you are") {
+		// Git should fail with a message about needing identity
+		if strings.Contains(commitOut, "EXIT:0") {
+			t.Errorf("Expected git commit to fail without identity, but it succeeded.\nOutput: %s", commitOut)
+		}
+	}
+
+	// Now set identity and verify commit succeeds
+	fixCmd := "HOME=" + homeDir + " bash -c 'cd /tmp/testrepo && git config user.name \"Test User\" && git config user.email \"test@example.com\" && git commit -m test 2>&1; echo EXIT:$?'"
+	fixOut, err := mgr.ExecCommand(fixCmd, container.ExecCommandOptions{Capture: true, User: &user})
+	if err != nil {
+		t.Fatalf("Failed to run git commit with identity: %v", err)
+	}
+	if !strings.Contains(fixOut, "EXIT:0") {
+		t.Errorf("Expected git commit to succeed after setting identity.\nOutput: %s", fixOut)
+	}
+}
+
 // TestContextFile_ForwardedEnvVars verifies that forwarded environment variable
 // names appear in the context file when provided.
 func TestContextFile_ForwardedEnvVars(t *testing.T) {

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -452,6 +452,12 @@ func Setup(opts SetupOptions) (*SetupResult, error) {
 		}
 	}
 
+	// 6.6.1. Prevent git from guessing commit identity from the container user.
+	// Setting user.useConfigOnly=true forces git to refuse commits until
+	// user.name and user.email are explicitly configured, which ensures AI
+	// tools discover and set the real developer identity.
+	SetupGitIdentityGuard(result.Manager, result.HomeDir, opts.Logger)
+
 	// 6.7. Configure timezone inside container
 	// Always set result.Timezone so the TZ env var is applied even if the
 	// filesystem configuration fails (some programs only check TZ).

--- a/internal/session/setup_helpers.go
+++ b/internal/session/setup_helpers.go
@@ -63,6 +63,21 @@ func SetupMiseTrust(mgr *container.Manager, containerWorkspacePath string, logge
 	}
 }
 
+// SetupGitIdentityGuard configures git to require explicit user.name and
+// user.email before allowing commits. This prevents AI tools from committing
+// as the container's default "code" user. The setting is applied globally
+// (--global) so it covers all repos inside the container.
+// Non-fatal: logs a warning on failure.
+func SetupGitIdentityGuard(mgr *container.Manager, homeDir string, logger func(string)) {
+	cmd := fmt.Sprintf(
+		`HOME=%s git config --global user.useConfigOnly true`,
+		homeDir,
+	)
+	if _, err := mgr.ExecCommand(cmd, container.ExecCommandOptions{Capture: true}); err != nil {
+		logger(fmt.Sprintf("Warning: Failed to set git user.useConfigOnly: %v", err))
+	}
+}
+
 // hasLimits checks if any limits are configured
 func hasLimits(cfg *config.LimitsConfig) bool {
 	if cfg == nil {


### PR DESCRIPTION
## Summary

Adds a git identity guard during container setup that sets `git config --global user.useConfigOnly true`. This makes git **refuse to commit** until `user.name` and `user.email` are explicitly configured, preventing AI tools from accidentally committing as the container's default "code" user.

- New `SetupGitIdentityGuard()` helper in `setup_helpers.go`
- Called during container setup (step 6.6.1, after SSH agent forwarding)
- Non-fatal: logs a warning if the config command fails

Complements #339 which added SANDBOX_CONTEXT.md hints — this PR enforces the behavior at the git level so bad commits are impossible even if the AI ignores the hints.

## Test plan

- [x] `go build ./...` passes
- [x] Integration test `TestSetupGitIdentityGuard` verifies:
  - `user.useConfigOnly` is set to `true` in global git config
  - `git commit` fails without explicit identity
  - `git commit` succeeds after setting `user.name` and `user.email`
- [x] All existing session tests pass