### PR TITLE
Persist profile name in session metadata for auto-resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- **Profile auto-resume** — `coi shell --resume` now automatically restores the profile used when the session was originally created. No need to pass `--profile` again. Explicitly passing `--profile` on resume overrides the saved profile. (#342)
 - Added `close` command inside containers as an alias for `poweroff`. This provides a safe alternative that doesn't exist on the host machine, preventing accidental host shutdowns when typed outside the container.
 - **Better git auth hints in SANDBOX_CONTEXT.md** — When SSH agent and/or GH_TOKEN is forwarded, the context file now includes a `Git Configuration` section that guides AI tools to: prefer SSH over token-based auth for git operations, derive commit identity from the SSH key instead of using "code" as author, and warns that forwarded tokens may have limited scope/permissions. (#337)
 - **Git identity guard** — Containers now set `git config --global user.useConfigOnly true` during setup, which forces git to refuse commits until `user.name` and `user.email` are explicitly configured. This prevents AI tools from accidentally committing as the container's default "code" user.

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -201,6 +201,19 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	if resumeID != "" && !isWorkspaceSessionTool {
 		metadataPath := filepath.Join(sessionsDir, resumeID, "metadata.json")
 		if metadata, err := session.LoadSessionMetadata(metadataPath); err == nil {
+			// Inherit profile if not explicitly set by user
+			if !cmd.Flags().Changed("profile") && metadata.ProfileName != "" {
+				profile = metadata.ProfileName
+				if err := cfg.ApplyProfile(profile); err != nil {
+					return fmt.Errorf("failed to apply saved profile '%s': %w", profile, err)
+				}
+				// Re-apply persistent from config since profile may override it
+				if !cmd.Flags().Changed("persistent") {
+					persistent = config.BoolVal(cfg.Container.Persistent)
+				}
+				fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", profile)
+			}
+
 			// Inherit persistent flag if not explicitly set by user
 			if !cmd.Flags().Changed("persistent") {
 				persistent = metadata.Persistent
@@ -351,7 +364,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save metadata early so coi list shows correct persistent/ephemeral status
-	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, persistent); err != nil {
+	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, persistent, profile); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
 	}
 
@@ -416,6 +429,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 				ContainerName:  result.ContainerName,
 				SessionID:      sessionID,
 				Persistent:     persistent,
+				ProfileName:    profile,
 				SessionsDir:    sessionsDir,
 				SaveSession:    true, // Always save session data
 				Workspace:      absWorkspace,

--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -18,6 +18,7 @@ type CleanupOptions struct {
 	ContainerName  string
 	SessionID      string    // COI session ID for saving tool config data
 	Persistent     bool      // If true, stop but don't delete container
+	ProfileName    string    // Profile used for this session (saved in metadata for --resume)
 	SessionsDir    string    // e.g., ~/.coi/sessions-claude
 	SaveSession    bool      // Whether to save tool config directory
 	Workspace      string    // Workspace directory path
@@ -61,7 +62,7 @@ func Cleanup(opts CleanupOptions) error {
 	// This ensures --resume works regardless of how the user exited (including sudo shutdown 0)
 	// Skip if tool uses ENV-based auth (no config directory to save)
 	if opts.SaveSession && exists && opts.SessionID != "" && opts.SessionsDir != "" && opts.Tool != nil && opts.Tool.ConfigDirName() != "" {
-		if err := saveSessionData(mgr, opts.SessionID, opts.Persistent, opts.Workspace, opts.SessionsDir, opts.Tool, opts.Logger); err != nil {
+		if err := saveSessionData(mgr, opts.SessionID, opts.Persistent, opts.ProfileName, opts.Workspace, opts.SessionsDir, opts.Tool, opts.Logger); err != nil {
 			opts.Logger(fmt.Sprintf("Warning: Failed to save session data: %v", err))
 		}
 	}
@@ -133,7 +134,7 @@ func Cleanup(opts CleanupOptions) error {
 }
 
 // saveSessionData saves the tool config directory from the container
-func saveSessionData(mgr *container.Manager, sessionID string, persistent bool, workspace string, sessionsDir string, t tool.Tool, logger func(string)) error {
+func saveSessionData(mgr *container.Manager, sessionID string, persistent bool, profileName string, workspace string, sessionsDir string, t tool.Tool, logger func(string)) error {
 	// Determine home directory
 	// For coi images, we always use /home/code
 	// For other images, we use /root
@@ -182,6 +183,7 @@ func saveSessionData(mgr *container.Manager, sessionID string, persistent bool, 
 		SessionID:     sessionID,
 		ContainerName: mgr.ContainerName,
 		Persistent:    persistent,
+		ProfileName:   profileName,
 		Workspace:     workspace,
 		SavedAt:       getCurrentTime(),
 	}
@@ -201,6 +203,7 @@ type SessionMetadata struct {
 	SessionID     string `json:"session_id"`
 	ContainerName string `json:"container_name"`
 	Persistent    bool   `json:"persistent"`
+	ProfileName   string `json:"profile_name"`
 	Workspace     string `json:"workspace"`
 	SavedAt       string `json:"saved_at"`
 }
@@ -212,10 +215,11 @@ func saveMetadata(path string, metadata SessionMetadata) error {
   "session_id": "%s",
   "container_name": "%s",
   "persistent": %t,
+  "profile_name": "%s",
   "workspace": "%s",
   "saved_at": "%s"
 }
-`, metadata.SessionID, metadata.ContainerName, metadata.Persistent, metadata.Workspace, metadata.SavedAt)
+`, metadata.SessionID, metadata.ContainerName, metadata.Persistent, metadata.ProfileName, metadata.Workspace, metadata.SavedAt)
 
 	return os.WriteFile(path, []byte(content), 0o644)
 }
@@ -226,7 +230,7 @@ func getCurrentTime() string {
 }
 
 // SaveMetadataEarly saves session metadata at session start so coi list can show correct status
-func SaveMetadataEarly(sessionsDir, sessionID, containerName, workspace string, persistent bool) error {
+func SaveMetadataEarly(sessionsDir, sessionID, containerName, workspace string, persistent bool, profileName string) error {
 	// Create session directory if it doesn't exist
 	sessionDir := filepath.Join(sessionsDir, sessionID)
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
@@ -237,6 +241,7 @@ func SaveMetadataEarly(sessionsDir, sessionID, containerName, workspace string, 
 		SessionID:     sessionID,
 		ContainerName: containerName,
 		Persistent:    persistent,
+		ProfileName:   profileName,
 		Workspace:     workspace,
 		SavedAt:       getCurrentTime(),
 	}
@@ -388,6 +393,8 @@ func LoadSessionMetadata(path string) (*SessionMetadata, error) {
 			metadata.ContainerName = extractJSONValue(line)
 		} else if strings.Contains(line, "\"persistent\"") {
 			metadata.Persistent = strings.Contains(line, "true")
+		} else if strings.Contains(line, "\"profile_name\"") {
+			metadata.ProfileName = extractJSONValue(line)
 		} else if strings.Contains(line, "\"workspace\"") {
 			metadata.Workspace = extractJSONValue(line)
 		} else if strings.Contains(line, "\"saved_at\"") {

--- a/tests/shell/ephemeral/resume_with_profile_ephemeral.py
+++ b/tests/shell/ephemeral/resume_with_profile_ephemeral.py
@@ -1,0 +1,143 @@
+"""
+Test for coi shell --resume with profile auto-restore (#342).
+
+Tests that:
+1. Create a profile with a distinguishable setting (persistent = true)
+2. Start session with --profile testprofile
+3. Poweroff to save session
+4. Resume with --resume (no --profile)
+5. Verify output contains "Inherited profile 'testprofile' from session"
+6. Verify inherited persistent mode from the profile
+"""
+
+import os
+import time
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_text_on_screen,
+)
+
+
+def test_resume_with_profile(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Test that --resume automatically restores the profile from the original session.
+
+    Flow:
+    1. Create a profile directory with persistent = true
+    2. Start session with --profile testprofile
+    3. Poweroff to save session (with profile in metadata)
+    4. Resume with --resume (no --profile flag)
+    5. Verify "Inherited profile 'testprofile' from session" appears
+    6. Verify "Inherited persistent mode from session" appears (from profile config)
+    7. Cleanup
+    """
+    env = {"COI_USE_DUMMY": "1"}
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # === Phase 1: Create profile with persistent = true ===
+    profile_dir = os.path.join(workspace_dir, ".coi", "profiles", "testprofile")
+    os.makedirs(profile_dir, exist_ok=True)
+
+    config_path = os.path.join(profile_dir, "config.toml")
+    with open(config_path, "w") as f:
+        f.write("[container]\npersistent = true\n")
+
+    # === Phase 2: Start session with --profile testprofile ===
+
+    child1 = spawn_coi(
+        coi_binary,
+        ["shell", "--profile", "testprofile"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child1, timeout=60)
+    wait_for_prompt(child1, timeout=90)
+
+    # Exit dummy, then poweroff to save session
+    child1.send("exit")
+    time.sleep(0.3)
+    child1.send("\x0d")
+    time.sleep(2)
+    child1.send("sudo poweroff")
+    time.sleep(0.3)
+    child1.send("\x0d")
+
+    try:
+        child1.expect(EOF, timeout=60)
+    except TIMEOUT:
+        pass
+
+    try:
+        child1.close(force=False)
+    except Exception:
+        child1.close(force=True)
+
+    time.sleep(5)
+
+    # === Phase 3: Resume with --resume (no --profile) ===
+
+    child2 = spawn_coi(
+        coi_binary,
+        ["shell", "--resume"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    # Check for profile inheritance message
+    try:
+        wait_for_text_on_screen(child2, "Inherited profile 'testprofile' from session", timeout=30)
+        profile_inherited = True
+    except TimeoutError:
+        profile_inherited = False
+
+    # Check for persistent mode inheritance (comes from the profile's persistent = true)
+    try:
+        wait_for_text_on_screen(child2, "Inherited persistent mode from session", timeout=10)
+        persistent_inherited = True
+    except TimeoutError:
+        persistent_inherited = False
+
+    wait_for_container_ready(child2, timeout=60)
+
+    # === Phase 4: Cleanup ===
+
+    child2.send("exit")
+    time.sleep(0.3)
+    child2.send("\x0d")
+    time.sleep(2)
+    child2.send("sudo poweroff")
+    time.sleep(0.3)
+    child2.send("\x0d")
+
+    try:
+        child2.expect(EOF, timeout=60)
+    except TIMEOUT:
+        pass
+
+    try:
+        child2.close(force=False)
+    except Exception:
+        child2.close(force=True)
+
+    time.sleep(3)
+
+    import subprocess
+
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )
+
+    # Assert profile was inherited
+    assert profile_inherited, "Should inherit profile 'testprofile' from session on resume"
+    assert persistent_inherited, "Should inherit persistent mode from profile on resume"


### PR DESCRIPTION
## Summary

- Saves the `--profile` name in `metadata.json` when a session is created or saved
- On `--resume`, automatically restores the saved profile (applies config overrides including `persistent`, mounts, etc.)
- Explicitly passing `--profile` on resume overrides the saved profile
- Backward-compatible: old metadata files without `profile_name` work fine (empty string = no profile)

Closes #342

## Test plan

- [ ] `go test ./internal/session/...` — existing unit tests pass (backward compatible metadata parsing)
- [ ] `go test ./internal/cli/...` — existing CLI tests pass
- [ ] `go build ./...` — compiles cleanly
- [ ] New integration test `tests/shell/ephemeral/resume_with_profile_ephemeral.py` validates end-to-end flow:
  - Creates a profile with `persistent = true`
  - Starts session with `--profile testprofile`
  - Resumes with `--resume` (no `--profile`)
  - Verifies "Inherited profile 'testprofile' from session" message
  - Verifies persistent mode inherited from profile