### PR TITLE
fix(profile/default): use npm backend for pnpm in mise install

### DIFF
--- a/profiles/default/build.sh
+++ b/profiles/default/build.sh
@@ -155,7 +155,7 @@ MISE_PROFILE_EOF
     # This sets ~/.config/mise/config.toml with global tool versions.
     local attempt
     for attempt in 1 2 3; do
-        if su - "$CODE_USER" -c 'mise use --global python@3 pnpm@latest npm:typescript@latest npm:tsx@latest'; then
+        if su - "$CODE_USER" -c 'mise use --global python@3 npm:pnpm@latest npm:typescript@latest npm:tsx@latest'; then
             break
         fi
         if [ "$attempt" -eq 3 ]; then


### PR DESCRIPTION
## Summary

`profiles/default/build.sh` installs pnpm via mise's bare `pnpm@latest`, which resolves to the **aqua** backend. The aqua-registry entry for pnpm still expects assets named `pnpm-linux-x64` (no extension), but pnpm now publishes only `.tar.gz` archives, so `coi build` fails:

```
mise ERROR Failed to install aqua:pnpm/pnpm@latest: no asset found: pnpm-linux-x64
Available assets:
  pnpm-linux-x64.tar.gz
  pnpm-linux-x64-musl.tar.gz
  ...
[coi] ERROR: mise tool installation failed after 3 attempts.
```

Switching to the **npm** backend (`npm:pnpm@latest`) — same backend already used on the same line for `typescript` and `tsx` — pulls pnpm reliably from the npm registry and avoids the aqua-registry mismatch.

## Test plan

- [x] Reproduce the failure on Ubuntu 22.04 base with mise 2026.4.25
- [x] `coi build --profile <patched-profile>` succeeds end-to-end
- [x] `mise exec -- which pnpm` resolves correctly inside the built image (`pnpm` 10.33.2)
- [x] Existing verify loop (`for bin in python3 pnpm tsc tsx`) still passes — same binary name, same install location, just a different mise backend