### PR TITLE
Strengthen git identity discovery instructions in SANDBOX_CONTEXT.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.1 (Unreleased)
 
+### Improvements
+
+- **Stronger git identity discovery instructions in SANDBOX_CONTEXT.md** — The git auth hints injected into the container context file are now much more directive: they mandate identity discovery before the first commit with a clear priority-ordered sequence (SSH agent → `gh api user` → git log → ask user), explicitly forbid fabricated identities like "code@example.com", and mention that `user.useConfigOnly=true` will block commits without a real identity. This addresses AI tools taking the path of least resistance and committing as "code" despite having SSH agent and/or GitHub token available.
+
 ### Bug Fixes
 
 - **Secure env-var forwarding in tmux sessions** — Forwarded environment variables (e.g. `GITHUB_TOKEN`) are now passed via `tmux new-session -e KEY=VAL` and `tmux set-environment` instead of being inlined as `export KEY=VAL; ...` in the command string. This fixes two issues: secrets no longer appear in `ps auxww` output, and variables now propagate to new tmux windows/panes. (contributed by @SimonArnu, #352)

--- a/internal/tool/templates/sandbox_context.md.tmpl
+++ b/internal/tool/templates/sandbox_context.md.tmpl
@@ -84,7 +84,110 @@ These paths are available alongside the workspace and persist changes to the hos
 
 ## Git Configuration
 
-{{.GitAuthDesc}}
+{{if and .SSHAgentForwarded .GHCLIAuthenticated -}}
+**Prefer SSH for git push/pull** — the forwarded SSH agent provides full authentication, while the forwarded GH_TOKEN/GITHUB_TOKEN may have limited scope or permissions (e.g., read-only, or restricted to specific repos).
+
+### MANDATORY — Discover your git identity BEFORE the first commit
+
+`user.useConfigOnly=true` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. SSH agent (preferred)**
+```bash
+# Determine which host the repo uses:
+ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
+
+# Test SSH and capture the greeting:
+ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+echo "$ssh_output"
+# GitHub  → "Hi <user>! You've successfully authenticated..."
+# GitLab  → "Welcome to GitLab, @<user>!"
+```
+Parse the username from the greeting and look up the full name/email via the platform API (e.g. `gh api user`).
+
+**2. GitHub CLI fallback**
+```bash
+gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
+```
+If `.email` is null, try: `gh api user/emails --jq '.[0].email'`
+
+**3. Existing git log fallback**
+```bash
+git log --format='%aN <%aE>' -1 2>/dev/null
+```
+
+**4. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+```bash
+git config user.name "<real name>"
+git config user.email "<real email>"
+```
+{{- else if .SSHAgentForwarded -}}
+**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., `git@<host>:org/repo.git`).
+
+### MANDATORY — Discover your git identity BEFORE the first commit
+
+`user.useConfigOnly=true` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. SSH agent (preferred)**
+```bash
+# Determine which host the repo uses:
+ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
+
+# Test SSH and capture the greeting:
+ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+echo "$ssh_output"
+# GitHub  → "Hi <user>! You've successfully authenticated..."
+# GitLab  → "Welcome to GitLab, @<user>!"
+```
+Parse the username from the greeting and look up the full name/email via the platform API.
+
+**2. Existing git log fallback**
+```bash
+git log --format='%aN <%aE>' -1 2>/dev/null
+```
+
+**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+```bash
+git config user.name "<real name>"
+git config user.email "<real email>"
+```
+{{- else if .GHCLIAuthenticated -}}
+**Token-based git authentication is available** via the forwarded GH_TOKEN/GITHUB_TOKEN. Note that this token may have limited scope or permissions (e.g., read-only, restricted to specific repos, or no push access).
+
+### MANDATORY — Discover your git identity BEFORE the first commit
+
+`user.useConfigOnly=true` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. GitHub CLI (preferred)**
+```bash
+gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
+```
+If `.email` is null, try: `gh api user/emails --jq '.[0].email'`
+
+**2. Existing git log fallback**
+```bash
+git log --format='%aN <%aE>' -1 2>/dev/null
+```
+
+**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+```bash
+git config user.name "<real name>"
+git config user.email "<real email>"
+```
+{{- end}}
 {{- end}}
 
 ## Limitations

--- a/internal/tool/templates/sandbox_context.md.tmpl
+++ b/internal/tool/templates/sandbox_context.md.tmpl
@@ -95,12 +95,14 @@ Run the following commands **in order** and stop at the first one that succeeds:
 
 **1. SSH agent (preferred)**
 ```bash
-# Determine which host the repo uses:
-ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+# Determine which host the repo uses (handles scp-style, ssh://, and https:// URLs):
+remote_url=$(git remote get-url origin 2>/dev/null)
+ssh_host=$(echo "$remote_url" | sed -n 's|.*@\([^:/]*\)[:/].*|\1|p')
+[ -z "$ssh_host" ] && ssh_host=$(echo "$remote_url" | sed -n 's|https\{0,1\}://\([^/]*\)/.*|\1|p')
 [ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
 
 # Test SSH and capture the greeting:
-ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+ssh_output=$(ssh -T -o StrictHostKeyChecking=accept-new -o BatchMode=yes "git@${ssh_host}" 2>&1 || true)
 echo "$ssh_output"
 # GitHub  → "Hi <user>! You've successfully authenticated..."
 # GitLab  → "Welcome to GitLab, @<user>!"
@@ -111,7 +113,7 @@ Parse the username from the greeting and look up the full name/email via the pla
 ```bash
 gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
 ```
-If `.email` is null, try: `gh api user/emails --jq '.[0].email'`
+If `.email` is null, try: `gh api user/emails --jq '.[] | select(.primary and .verified) | .email'`
 
 **3. Existing git log fallback**
 ```bash
@@ -136,12 +138,14 @@ Run the following commands **in order** and stop at the first one that succeeds:
 
 **1. SSH agent (preferred)**
 ```bash
-# Determine which host the repo uses:
-ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+# Determine which host the repo uses (handles scp-style, ssh://, and https:// URLs):
+remote_url=$(git remote get-url origin 2>/dev/null)
+ssh_host=$(echo "$remote_url" | sed -n 's|.*@\([^:/]*\)[:/].*|\1|p')
+[ -z "$ssh_host" ] && ssh_host=$(echo "$remote_url" | sed -n 's|https\{0,1\}://\([^/]*\)/.*|\1|p')
 [ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
 
 # Test SSH and capture the greeting:
-ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+ssh_output=$(ssh -T -o StrictHostKeyChecking=accept-new -o BatchMode=yes "git@${ssh_host}" 2>&1 || true)
 echo "$ssh_output"
 # GitHub  → "Hi <user>! You've successfully authenticated..."
 # GitLab  → "Welcome to GitLab, @<user>!"
@@ -173,7 +177,7 @@ Run the following commands **in order** and stop at the first one that succeeds:
 ```bash
 gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
 ```
-If `.email` is null, try: `gh api user/emails --jq '.[0].email'`
+If `.email` is null, try: `gh api user/emails --jq '.[] | select(.primary and .verified) | .email'`
 
 **2. Existing git log fallback**
 ```bash

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -316,8 +316,9 @@ type contextTemplateData struct {
 	ContainerName       string
 	ProfileContext      string
 	HasProfileContext   bool
-	GitAuthDesc         string
 	HasGitAuth          bool
+	SSHAgentForwarded   bool
+	GHCLIAuthenticated  bool
 }
 
 // RenderContextFileContent renders the embedded sandbox context template with
@@ -371,121 +372,11 @@ func RenderContextFileContent(info ContextInfo) string {
 		data.GitHubCLIDesc = "Authenticated via forwarded token (gh CLI ready to use; note: token may have limited scope/permissions)"
 	}
 
-	// Git auth hints based on SSH + token availability.
-	//
-	// These instructions are deliberately forceful — AI tools running inside
-	// the container tend to fabricate git identities ("code@example.com")
-	// instead of discovering the real developer. The guard
-	// `user.useConfigOnly=true` is set globally so that git refuses to
-	// commit without an explicit identity; these instructions tell the AI
-	// exactly how to obtain one.
-	switch {
-	case info.SSHAgentForwarded && info.GHCLIAuthenticated:
+	// Git auth flags — the template renders conditional instructions based on these.
+	if info.SSHAgentForwarded || info.GHCLIAuthenticated {
 		data.HasGitAuth = true
-		data.GitAuthDesc = `**Prefer SSH for git push/pull** — the forwarded SSH agent provides full authentication, while the forwarded GH_TOKEN/GITHUB_TOKEN may have limited scope or permissions (e.g., read-only, or restricted to specific repos).
-
-### MANDATORY — Discover your git identity BEFORE the first commit
-
-` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
-
-Run the following commands **in order** and stop at the first one that succeeds:
-
-**1. SSH agent (preferred)**
-` + "```bash" + `
-# Determine which host the repo uses:
-ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
-[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
-
-# Test SSH and capture the greeting:
-ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
-echo "$ssh_output"
-# GitHub  → "Hi <user>! You've successfully authenticated..."
-# GitLab  → "Welcome to GitLab, @<user>!"
-` + "```" + `
-Parse the username from the greeting and look up the full name/email via the platform API (e.g. ` + "`gh api user`" + `).
-
-**2. GitHub CLI fallback**
-` + "```bash" + `
-gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
-` + "```" + `
-If ` + "`.email`" + ` is null, try: ` + "`gh api user/emails --jq '.[0].email'`" + `
-
-**3. Existing git log fallback**
-` + "```bash" + `
-git log --format='%aN <%aE>' -1 2>/dev/null
-` + "```" + `
-
-**4. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
-
-Once you have the real identity, configure git:
-` + "```bash" + `
-git config user.name "<real name>"
-git config user.email "<real email>"
-` + "```"
-	case info.SSHAgentForwarded:
-		data.HasGitAuth = true
-		data.GitAuthDesc = `**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., ` + "`git@<host>:org/repo.git`" + `).
-
-### MANDATORY — Discover your git identity BEFORE the first commit
-
-` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
-
-Run the following commands **in order** and stop at the first one that succeeds:
-
-**1. SSH agent (preferred)**
-` + "```bash" + `
-# Determine which host the repo uses:
-ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
-[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
-
-# Test SSH and capture the greeting:
-ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
-echo "$ssh_output"
-# GitHub  → "Hi <user>! You've successfully authenticated..."
-# GitLab  → "Welcome to GitLab, @<user>!"
-` + "```" + `
-Parse the username from the greeting and look up the full name/email via the platform API.
-
-**2. Existing git log fallback**
-` + "```bash" + `
-git log --format='%aN <%aE>' -1 2>/dev/null
-` + "```" + `
-
-**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
-
-Once you have the real identity, configure git:
-` + "```bash" + `
-git config user.name "<real name>"
-git config user.email "<real email>"
-` + "```"
-	case info.GHCLIAuthenticated:
-		data.HasGitAuth = true
-		data.GitAuthDesc = `**Token-based git authentication is available** via the forwarded GH_TOKEN/GITHUB_TOKEN. Note that this token may have limited scope or permissions (e.g., read-only, restricted to specific repos, or no push access).
-
-### MANDATORY — Discover your git identity BEFORE the first commit
-
-` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
-
-Run the following commands **in order** and stop at the first one that succeeds:
-
-**1. GitHub CLI (preferred)**
-` + "```bash" + `
-gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
-` + "```" + `
-If ` + "`.email`" + ` is null, try: ` + "`gh api user/emails --jq '.[0].email'`" + `
-
-**2. Existing git log fallback**
-` + "```bash" + `
-git log --format='%aN <%aE>' -1 2>/dev/null
-` + "```" + `
-
-**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
-
-Once you have the real identity, configure git:
-` + "```bash" + `
-git config user.name "<real name>"
-git config user.email "<real email>"
-` + "```"
+		data.SSHAgentForwarded = info.SSHAgentForwarded
+		data.GHCLIAuthenticated = info.GHCLIAuthenticated
 	}
 
 	if len(info.ForwardedEnvVars) > 0 {

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -371,24 +371,54 @@ func RenderContextFileContent(info ContextInfo) string {
 		data.GitHubCLIDesc = "Authenticated via forwarded token (gh CLI ready to use; note: token may have limited scope/permissions)"
 	}
 
-	// Git auth hints based on SSH + token availability
+	// Git auth hints based on SSH + token availability.
+	//
+	// These instructions are deliberately forceful — AI tools running inside
+	// the container tend to fabricate git identities ("code@example.com")
+	// instead of discovering the real developer. The guard
+	// `user.useConfigOnly=true` is set globally so that git refuses to
+	// commit without an explicit identity; these instructions tell the AI
+	// exactly how to obtain one.
 	switch {
 	case info.SSHAgentForwarded && info.GHCLIAuthenticated:
 		data.HasGitAuth = true
 		data.GitAuthDesc = `**Prefer SSH for git push/pull** — the forwarded SSH agent provides full authentication, while the forwarded GH_TOKEN/GITHUB_TOKEN may have limited scope or permissions (e.g., read-only, or restricted to specific repos).
 
-**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, check the remote URL of the repository and test against the appropriate host:
-` + "```" + `
-# Check which host the repo uses:
-git remote get-url origin
+### MANDATORY — Discover your git identity BEFORE the first commit
 
-# Then test SSH against that host, e.g.:
-ssh -T git@github.com 2>&1    # GitHub
-ssh -T git@gitlab.com 2>&1    # GitLab
-ssh -T git@bitbucket.org 2>&1 # Bitbucket
+` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. SSH agent (preferred)**
+` + "```bash" + `
+# Determine which host the repo uses:
+ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
+
+# Test SSH and capture the greeting:
+ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+echo "$ssh_output"
+# GitHub  → "Hi <user>! You've successfully authenticated..."
+# GitLab  → "Welcome to GitLab, @<user>!"
 ` + "```" + `
-Use the identity from the SSH response to configure git:
+Parse the username from the greeting and look up the full name/email via the platform API (e.g. ` + "`gh api user`" + `).
+
+**2. GitHub CLI fallback**
+` + "```bash" + `
+gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
 ` + "```" + `
+If ` + "`.email`" + ` is null, try: ` + "`gh api user/emails --jq '.[0].email'`" + `
+
+**3. Existing git log fallback**
+` + "```bash" + `
+git log --format='%aN <%aE>' -1 2>/dev/null
+` + "```" + `
+
+**4. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+` + "```bash" + `
 git config user.name "<real name>"
 git config user.email "<real email>"
 ` + "```"
@@ -396,18 +426,35 @@ git config user.email "<real email>"
 		data.HasGitAuth = true
 		data.GitAuthDesc = `**Use SSH for git operations** — the forwarded SSH agent provides authentication for git push/pull/clone via SSH URLs (e.g., ` + "`git@<host>:org/repo.git`" + `).
 
-**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. To discover the correct identity, check the remote URL of the repository and test against the appropriate host:
-` + "```" + `
-# Check which host the repo uses:
-git remote get-url origin
+### MANDATORY — Discover your git identity BEFORE the first commit
 
-# Then test SSH against that host, e.g.:
-ssh -T git@github.com 2>&1    # GitHub
-ssh -T git@gitlab.com 2>&1    # GitLab
-ssh -T git@bitbucket.org 2>&1 # Bitbucket
+` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. SSH agent (preferred)**
+` + "```bash" + `
+# Determine which host the repo uses:
+ssh_host=$(git remote get-url origin 2>/dev/null | sed -n 's|.*@\([^:]*\):.*|\1|p')
+[ -z "$ssh_host" ] && ssh_host="github.com"   # sensible default
+
+# Test SSH and capture the greeting:
+ssh_output=$(ssh -T "git@${ssh_host}" 2>&1 || true)
+echo "$ssh_output"
+# GitHub  → "Hi <user>! You've successfully authenticated..."
+# GitLab  → "Welcome to GitLab, @<user>!"
 ` + "```" + `
-Use the identity from the SSH response to configure git:
+Parse the username from the greeting and look up the full name/email via the platform API.
+
+**2. Existing git log fallback**
+` + "```bash" + `
+git log --format='%aN <%aE>' -1 2>/dev/null
 ` + "```" + `
+
+**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+` + "```bash" + `
 git config user.name "<real name>"
 git config user.email "<real email>"
 ` + "```"
@@ -415,12 +462,27 @@ git config user.email "<real email>"
 		data.HasGitAuth = true
 		data.GitAuthDesc = `**Token-based git authentication is available** via the forwarded GH_TOKEN/GITHUB_TOKEN. Note that this token may have limited scope or permissions (e.g., read-only, restricted to specific repos, or no push access).
 
-**Commit identity**: Do NOT use "code" as the git author — this is the container's default user, not the actual developer. If the token has sufficient permissions, you can discover the correct identity by running:
+### MANDATORY — Discover your git identity BEFORE the first commit
+
+` + "`user.useConfigOnly=true`" + ` is set globally, so git will **refuse to commit** until you configure a real identity. **NEVER fabricate** an identity — values like "code", "Code", "code@example.com", or any made-up name/email are WRONG and FORBIDDEN because "code" is just the container's default OS user.
+
+Run the following commands **in order** and stop at the first one that succeeds:
+
+**1. GitHub CLI (preferred)**
+` + "```bash" + `
+gh api user --jq '"Name: \(.name // .login)\nEmail: \(.email // empty)"'
 ` + "```" + `
-gh api user --jq '"Name: \(.name)\nEmail: \(.email)"'
+If ` + "`.email`" + ` is null, try: ` + "`gh api user/emails --jq '.[0].email'`" + `
+
+**2. Existing git log fallback**
+` + "```bash" + `
+git log --format='%aN <%aE>' -1 2>/dev/null
 ` + "```" + `
-Use the result to set:
-` + "```" + `
+
+**3. Ask the user** — if none of the above works, ask the user for their name and email. Do NOT guess or make up values.
+
+Once you have the real identity, configure git:
+` + "```bash" + `
 git config user.name "<real name>"
 git config user.email "<real email>"
 ` + "```"

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -534,7 +534,7 @@ func TestRenderContextFileContent(t *testing.T) {
 		{"act autonomously guidance", "Act autonomously"},
 		{"git configuration section", "Git Configuration"},
 		{"git ssh recommendation", "Use SSH for git operations"},
-		{"git identity warning", `Do NOT use "code" as the git author`},
+		{"git identity warning", `NEVER fabricate`},
 	}
 
 	for _, check := range checks {
@@ -706,20 +706,17 @@ func TestRenderContextFileContent_GitAuthHints_SSHOnly(t *testing.T) {
 	if !strings.Contains(content, "Use SSH for git operations") {
 		t.Error("Expected SSH recommendation for git operations")
 	}
-	if !strings.Contains(content, "ssh -T git@github.com") {
-		t.Error("Expected ssh -T github example for identity discovery")
-	}
-	if !strings.Contains(content, "ssh -T git@gitlab.com") {
-		t.Error("Expected ssh -T gitlab example for identity discovery")
-	}
-	if !strings.Contains(content, "ssh -T git@bitbucket.org") {
-		t.Error("Expected ssh -T bitbucket example for identity discovery")
+	if !strings.Contains(content, `ssh -T "git@${ssh_host}"`) {
+		t.Error("Expected ssh -T command for identity discovery")
 	}
 	if !strings.Contains(content, "git remote get-url origin") {
 		t.Error("Expected guidance to check remote URL")
 	}
-	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
-		t.Error("Expected warning against using 'code' as git author")
+	if !strings.Contains(content, "NEVER fabricate") {
+		t.Error("Expected warning against fabricating git identity")
+	}
+	if !strings.Contains(content, "code@example.com") {
+		t.Error("Expected explicit mention of forbidden code@example.com")
 	}
 	if strings.Contains(content, "token may have limited scope") {
 		t.Error("Should not mention token scope when only SSH is available")
@@ -746,8 +743,8 @@ func TestRenderContextFileContent_GitAuthHints_TokenOnly(t *testing.T) {
 	if !strings.Contains(content, "gh api user") {
 		t.Error("Expected gh api command for identity discovery")
 	}
-	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
-		t.Error("Expected warning against using 'code' as git author")
+	if !strings.Contains(content, "NEVER fabricate") {
+		t.Error("Expected warning against fabricating git identity")
 	}
 	// GitHubCLIDesc in the environment table should also have scope warning
 	if !strings.Contains(content, "token may have limited scope/permissions") {
@@ -773,11 +770,11 @@ func TestRenderContextFileContent_GitAuthHints_BothSSHAndToken(t *testing.T) {
 	if !strings.Contains(content, "GH_TOKEN/GITHUB_TOKEN may have limited scope") {
 		t.Error("Expected token scope warning")
 	}
-	if !strings.Contains(content, "ssh -T git@github.com") {
+	if !strings.Contains(content, `ssh -T "git@${ssh_host}"`) {
 		t.Error("Expected ssh -T command for identity discovery")
 	}
-	if !strings.Contains(content, `Do NOT use "code" as the git author`) {
-		t.Error("Expected warning against using 'code' as git author")
+	if !strings.Contains(content, "NEVER fabricate") {
+		t.Error("Expected warning against fabricating git identity")
 	}
 }
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -706,7 +706,7 @@ func TestRenderContextFileContent_GitAuthHints_SSHOnly(t *testing.T) {
 	if !strings.Contains(content, "Use SSH for git operations") {
 		t.Error("Expected SSH recommendation for git operations")
 	}
-	if !strings.Contains(content, `ssh -T "git@${ssh_host}"`) {
+	if !strings.Contains(content, `ssh -T -o StrictHostKeyChecking=accept-new -o BatchMode=yes "git@${ssh_host}"`) {
 		t.Error("Expected ssh -T command for identity discovery")
 	}
 	if !strings.Contains(content, "git remote get-url origin") {
@@ -746,6 +746,9 @@ func TestRenderContextFileContent_GitAuthHints_TokenOnly(t *testing.T) {
 	if !strings.Contains(content, "NEVER fabricate") {
 		t.Error("Expected warning against fabricating git identity")
 	}
+	if !strings.Contains(content, "code@example.com") {
+		t.Error("Expected explicit mention of forbidden code@example.com")
+	}
 	// GitHubCLIDesc in the environment table should also have scope warning
 	if !strings.Contains(content, "token may have limited scope/permissions") {
 		t.Error("Expected scope/permissions warning in GitHub CLI table row")
@@ -770,11 +773,14 @@ func TestRenderContextFileContent_GitAuthHints_BothSSHAndToken(t *testing.T) {
 	if !strings.Contains(content, "GH_TOKEN/GITHUB_TOKEN may have limited scope") {
 		t.Error("Expected token scope warning")
 	}
-	if !strings.Contains(content, `ssh -T "git@${ssh_host}"`) {
+	if !strings.Contains(content, `ssh -T -o StrictHostKeyChecking=accept-new -o BatchMode=yes "git@${ssh_host}"`) {
 		t.Error("Expected ssh -T command for identity discovery")
 	}
 	if !strings.Contains(content, "NEVER fabricate") {
 		t.Error("Expected warning against fabricating git identity")
+	}
+	if !strings.Contains(content, "code@example.com") {
+		t.Error("Expected explicit mention of forbidden code@example.com")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Rewrites the three `GitAuthDesc` variants (SSH+Token, SSH-only, Token-only) to be much more directive about identity discovery
- Adds a **MANDATORY** heading with a clear priority-ordered sequence: SSH agent → `gh api user` → git log → ask user
- Explicitly forbids fabricated identities like "code", "Code", "code@example.com"
- Mentions `user.useConfigOnly=true` so the AI knows commits will fail without a real identity
- Provides exact copy-pasteable bash commands instead of vague reference documentation
- Updates test assertions to match the rewritten text

## Context

AI tools running in COI containers were ignoring the existing discovery hints and taking the path of least resistance — setting fake git identities like `code@example.com` / `Code` despite having SSH agent forwarding and/or GitHub tokens available. The `user.useConfigOnly=true` guard exists but AI just overrides it with a fabricated identity.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tool/...` passes
- [ ] Integration tests with actual container (manual)