### PR TITLE
fix(container): make sg usage conditional on availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **Make `sg` usage conditional on availability** — On Linux distros where `sg`/`newgrp` is restricted to root (e.g., ALT Linux with `rwx------` permissions), COI now detects `sg` unavailability at startup and falls back to running `incus` directly, the same code path used on macOS. Also fixes a bug where `coi image list --all` hardcoded the `incus-admin` group name instead of using the configurable `IncusGroup` variable. (#349)
 - **Secure env-var forwarding in tmux sessions** — Forwarded environment variables (e.g. `GITHUB_TOKEN`) are now passed via `tmux new-session -e KEY=VAL` and `tmux set-environment` instead of being inlined as `export KEY=VAL; ...` in the command string. This fixes two issues: secrets no longer appear in `ps auxww` output, and variables now propagate to new tmux windows/panes. (contributed by @SimonArnu, #352)
 
 ### New Features

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -321,8 +321,14 @@ func imageListCommand(cmd *cobra.Command, args []string) error {
 func listAllImages() error {
 	mgr := container.NewManager("temp")
 
-	// Get list of images using incus image list with sg wrapper
-	output, err := mgr.ExecHostCommand("sg incus-admin -c 'incus image list --format=csv -c l,s,u'", true)
+	// Get list of images using incus image list, with sg wrapper when available
+	var imgCmd string
+	if container.CanUseSg() {
+		imgCmd = fmt.Sprintf("sg %s -c 'incus image list --format=csv -c l,s,u'", container.IncusGroup)
+	} else {
+		imgCmd = "incus image list --format=csv -c l,s,u"
+	}
+	output, err := mgr.ExecHostCommand(imgCmd, true)
 	if err != nil {
 		return fmt.Errorf("failed to list images: %w", err)
 	}

--- a/internal/container/commands.go
+++ b/internal/container/commands.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -29,30 +30,50 @@ func Configure(project, group, codeUser string, codeUID int) {
 	CodeUID = codeUID
 }
 
+var (
+	sgUsable     bool
+	sgUsableOnce sync.Once
+)
+
+// canUseSg reports whether the sg binary is available and executable.
+// The result is cached after the first call.
+func canUseSg() bool {
+	sgUsableOnce.Do(func() {
+		_, err := exec.LookPath("sg")
+		sgUsable = err == nil
+	})
+	return sgUsable
+}
+
+// CanUseSg is the exported form of canUseSg for use by other packages.
+func CanUseSg() bool {
+	return canUseSg()
+}
+
 // execIncusCommand creates an exec.Cmd for running incus commands.
-// On Linux, it wraps the command with sg for group permissions.
-// On macOS, it runs incus directly (no incus-admin group).
+// On Linux with sg available, it wraps the command with sg for group permissions.
+// On macOS or when sg is unavailable, it runs incus directly via sh.
 func execIncusCommand(cmdArgs []string) *exec.Cmd {
-	if runtime.GOOS == "darwin" {
-		// macOS: run incus directly without sg wrapper
+	if runtime.GOOS == "darwin" || !canUseSg() {
+		// Run incus directly without sg wrapper.
 		// cmdArgs is in format: [IncusGroup, "-c", "incus --project ... command"]
-		// Extract the actual incus command from the third element
+		// Extract the actual incus command from the third element.
 		incusCmd := cmdArgs[2] // "incus --project ... command"
 		return exec.Command("sh", "-c", incusCmd)
 	}
-	// Linux: use sg for group permissions
+	// Linux with sg available: use sg for group permissions
 	return exec.Command("sg", cmdArgs...)
 }
 
 // execIncusCommandContext creates a context-aware exec.Cmd for running incus commands.
-// On Linux, it wraps the command with sg for group permissions.
-// On macOS, it runs incus directly (no incus-admin group).
+// On Linux with sg available, it wraps the command with sg for group permissions.
+// On macOS or when sg is unavailable, it runs incus directly via sh.
 //
 // WaitDelay is set so that when the context is cancelled, cmd.Wait returns
 // promptly instead of blocking until all child-process pipes are closed.
 func execIncusCommandContext(ctx context.Context, cmdArgs []string) *exec.Cmd {
 	var cmd *exec.Cmd
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || !canUseSg() {
 		incusCmd := cmdArgs[2]
 		cmd = exec.CommandContext(ctx, "sh", "-c", incusCmd)
 	} else {

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -524,13 +524,12 @@ func Available() bool {
 		return false
 	}
 
-	// On macOS, run incus directly without sg group switching
-	// macOS doesn't have the incus-admin group like Linux
+	// On macOS or when sg is unavailable, run incus directly.
+	// On Linux with sg available, use sg for group permissions.
 	var cmd *exec.Cmd
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || !canUseSg() {
 		cmd = exec.Command("incus", "--project", IncusProject, "info")
 	} else {
-		// Linux - use sg to run with group permissions
 		cmd = exec.Command("sg", IncusGroup, "-c", fmt.Sprintf("incus --project %s info", IncusProject))
 	}
 

--- a/tests/integration/test_sg_fallback.py
+++ b/tests/integration/test_sg_fallback.py
@@ -13,7 +13,6 @@ These tests verify:
 
 import os
 import subprocess
-import tempfile
 import time
 
 import pytest

--- a/tests/integration/test_sg_fallback.py
+++ b/tests/integration/test_sg_fallback.py
@@ -1,0 +1,184 @@
+"""
+Integration tests for sg fallback behavior.
+
+Tests that COI works correctly when `sg` is unavailable, falling back to
+running incus directly (same as the macOS code path).
+
+These tests verify:
+1. `coi container launch` works without `sg` (via PATH manipulation)
+2. `coi container exec` works without `sg`
+3. `coi image list` works without `sg`
+4. Normal operation with `sg` available is unaffected
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+from support.helpers import (
+    calculate_container_name,
+)
+
+
+def _env_without_sg():
+    """Return an environment where `sg` is not discoverable via PATH.
+
+    Creates a temporary directory with symlinks to all PATH entries'
+    binaries EXCEPT `sg`, effectively hiding it from exec.LookPath.
+    We achieve this more simply by prepending a directory that shadows
+    `sg` with a non-executable file, but the cleanest approach is just
+    to remove dirs that contain `sg` ... except that's fragile.
+
+    Instead we set a special env var and use a wrapper: we simply
+    restrict PATH to not include the directory containing `sg`.
+    """
+    import shutil
+
+    sg_path = shutil.which("sg")
+    if sg_path is None:
+        pytest.skip("sg is not available on this system — fallback is already the default path")
+
+    # Remove the directory containing sg from PATH
+    sg_dir = os.path.dirname(sg_path)
+    env = os.environ.copy()
+    path_dirs = env.get("PATH", "").split(os.pathsep)
+    filtered = [d for d in path_dirs if os.path.normpath(d) != os.path.normpath(sg_dir)]
+
+    # Make sure we didn't accidentally remove ALL of PATH
+    assert len(filtered) > 0, "Filtering sg from PATH removed all entries"
+
+    # Verify incus is still reachable on the filtered PATH
+    incus_found = any(
+        os.path.isfile(os.path.join(d, "incus")) and os.access(os.path.join(d, "incus"), os.X_OK)
+        for d in filtered
+    )
+    if not incus_found:
+        pytest.skip("incus lives in the same directory as sg — cannot test independently")
+
+    env["PATH"] = os.pathsep.join(filtered)
+    return env
+
+
+def test_launch_without_sg(coi_binary, cleanup_containers, workspace_dir):
+    """Container launch succeeds when sg is not on PATH."""
+    env = _env_without_sg()
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # Launch container without sg
+    result = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+    assert result.returncode == 0, f"Launch should succeed without sg. stderr: {result.stderr}"
+
+    time.sleep(3)
+
+    # Verify container is running (use normal env for checking)
+    result = subprocess.run(
+        [coi_binary, "container", "running", container_name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Container {container_name} should be running"
+
+    # Cleanup
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_exec_without_sg(coi_binary, cleanup_containers, workspace_dir):
+    """Command execution works when sg is not on PATH."""
+    env = _env_without_sg()
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # Launch container (with sg so we know it works)
+    result = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"Launch failed. stderr: {result.stderr}"
+    time.sleep(3)
+
+    # Exec command without sg
+    result = subprocess.run(
+        [coi_binary, "container", "exec", container_name, "--", "echo", "sg-fallback-test"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode == 0, f"Exec should succeed without sg. stderr: {result.stderr}"
+    combined = result.stdout + result.stderr
+    assert "sg-fallback-test" in combined, f"Output should contain echo text. Got:\n{combined}"
+
+    # Cleanup
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_image_list_without_sg(coi_binary):
+    """Image listing works when sg is not on PATH."""
+    env = _env_without_sg()
+
+    result = subprocess.run(
+        [coi_binary, "image", "list", "--all"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    # Should succeed (exit 0) regardless of whether images exist
+    assert result.returncode == 0, f"Image list should succeed without sg. stderr: {result.stderr}"
+
+
+def test_launch_with_sg(coi_binary, cleanup_containers, workspace_dir):
+    """Container launch still works normally when sg IS available (regression check)."""
+    import shutil
+
+    if shutil.which("sg") is None:
+        pytest.skip("sg is not available — nothing to regression-test")
+
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    result = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"Launch with sg should succeed. stderr: {result.stderr}"
+
+    time.sleep(3)
+
+    result = subprocess.run(
+        [coi_binary, "container", "running", container_name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Container {container_name} should be running"
+
+    # Cleanup
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -571,14 +571,25 @@ def assert_clean_exit(clean_exit, child):
     assert child.exitstatus == 0, f"Expected exit code 0, got {child.exitstatus}"
 
 
+def _has_sg():
+    """Check if the sg binary is available and executable."""
+    import shutil
+
+    return shutil.which("sg") is not None
+
+
 def get_container_list():
     """
     Get list of all running containers.
     Returns list of container names.
     """
     try:
+        if _has_sg():
+            cmd = ["sg", "incus-admin", "-c", "incus list --format=csv -c n"]
+        else:
+            cmd = ["incus", "list", "--format=csv", "-c", "n"]
         result = subprocess.run(
-            ["sg", "incus-admin", "-c", "incus list --format=csv -c n"],
+            cmd,
             capture_output=True,
             text=True,
             check=True,
@@ -609,8 +620,12 @@ def cleanup_all_test_containers(pattern="coi-test-"):
 
     for container in test_containers:
         try:
+            if _has_sg():
+                cmd = ["sg", "incus-admin", "-c", f"incus delete -f {container}"]
+            else:
+                cmd = ["incus", "delete", "-f", container]
             subprocess.run(
-                ["sg", "incus-admin", "-c", f"incus delete -f {container}"],
+                cmd,
                 capture_output=True,
                 timeout=10,
             )


### PR DESCRIPTION
## Summary

- Detect `sg` availability at startup via `exec.LookPath` and cache the result with `sync.Once`
- When `sg` is unavailable (restricted permissions, missing binary), fall back to running `incus` directly via `sh -c` — the same code path already used on macOS
- Fix `coi image list --all` hardcoding `"incus-admin"` instead of using the configurable `IncusGroup` variable
- Update Python test helpers (`get_container_list`, `cleanup_all_test_containers`) to also fall back when `sg` is unavailable

Fixes #349

## Files Changed

- `internal/container/commands.go` — Add `canUseSg()`/`CanUseSg()` with `sync.Once` caching; update `execIncusCommand` and `execIncusCommandContext` conditions
- `internal/container/manager.go` — Update `Available()` to use `canUseSg()` 
- `internal/cli/images.go` — Replace hardcoded `sg incus-admin` with conditional logic using `CanUseSg()` and `IncusGroup`
- `tests/integration/test_sg_fallback.py` — Integration tests verifying launch, exec, and image list work with and without `sg`
- `tests/support/helpers.py` — Add `_has_sg()` helper; update `get_container_list` and `cleanup_all_test_containers`
- `CHANGELOG.md` — Document the fix

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./internal/container/... ./internal/cli/... ./internal/health/...` — existing tests pass
- [ ] `pytest tests/integration/test_sg_fallback.py` — new integration tests pass
- [ ] On a system with `sg` available, behavior is unchanged
- [ ] On a system without `sg`, COI falls back to direct `incus` execution