### PR TITLE
docs(readme): document v0.8.1 features and sg removal impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ See the [Supported Tools wiki page](https://github.com/mensfeld/code-on-incus/wi
 - Network isolation - Firewalld-based restricted/allowlist/open modes block private network access and prevent exfiltration
 - Protected paths - `.git/hooks`, `.git/config`, `.husky`, `.vscode` mounted read-only to prevent supply-chain attacks
 - Host-side immutable protection - Protected paths are locked with `chattr +i` during sessions, preventing `unshare -m` + `umount` bypass of read-only mounts (opt out: `[security] host_immutable = false`)
+- Git identity guard - Containers enforce `user.useConfigOnly=true`, preventing AI tools from committing as the default "code" user
 - Guest API disabled - Incus guest API (`/dev/incus`) disabled by default, preventing host path and topology leaks
 - System containers - Full OS isolation with unprivileged containers, better than Docker privileged mode
 - Automatic UID mapping - No permission hell, files owned correctly
@@ -198,7 +199,7 @@ curl -fsSL https://raw.githubusercontent.com/mensfeld/code-on-incus/master/insta
 # - Show next steps
 ```
 
-**Manual installation:** Download the binary from [GitHub Releases](https://github.com/mensfeld/code-on-incus/releases), make it executable, and move to `/usr/local/bin/`. Requires Linux with Incus installed and user in the `incus-admin` group. See the [Incus installation guide](https://linuxcontainers.org/incus/docs/main/installing/) for setting up Incus.
+**Manual installation:** Download the binary from [GitHub Releases](https://github.com/mensfeld/code-on-incus/releases), make it executable, and move to `/usr/local/bin/`. Requires Linux with Incus installed and user in the `incus-admin` group. **You must log out and back in** (or run `newgrp incus-admin`) after adding your user to the group — COI runs `incus` directly and requires the group to be active in your session. See the [Incus installation guide](https://linuxcontainers.org/incus/docs/main/installing/) for setting up Incus.
 
 ### Build Images
 
@@ -327,7 +328,7 @@ coi shell --resume=<session-id> # Resume specific session
 coi list --all                  # List available sessions
 ```
 
-**What's restored:** Full conversation history, tool credentials, user settings, and project context. Sessions are workspace-scoped — `--resume` only finds sessions from the current workspace directory.
+**What's restored:** Full conversation history, tool credentials, user settings, and project context. The profile used when the session was created is also automatically restored — no need to pass `--profile` again (explicitly passing `--profile` overrides the saved one). Sessions are workspace-scoped — `--resume` only finds sessions from the current workspace directory.
 
 See the [Container Lifecycle and Sessions guide](https://github.com/mensfeld/code-on-incus/wiki/Container-Lifecycle-and-Sessions) for details on how session persistence works.
 
@@ -470,7 +471,7 @@ coi attach                    # Reconnect to running container
 coi persist                   # Convert ephemeral session to persistent
 coi unfreeze <name>           # Unfreeze paused/frozen container
 coi unfreeze                  # Unfreeze all frozen COI containers
-sudo poweroff                 # Properly stop container (inside)
+close                         # Properly stop container (inside, safe alias for poweroff)
 coi shutdown <name>           # Graceful stop (outside)
 ```
 


### PR DESCRIPTION
## Summary

- **Installation**: Add re-login/`newgrp` requirement after `usermod -aG incus-admin` — now that `sg` no longer handles group activation transparently, users must have the group active in their session
- **Security features**: Add git identity guard (`user.useConfigOnly=true`) to the security bullet list
- **Container lifecycle**: Replace `sudo poweroff` with the new `close` command in the quick reference
- **Session resume**: Document profile auto-restore on `--resume`

Companion wiki updates already pushed directly (auto-build claim fix, re-login requirement on all distro sections, profile auto-resume, `close` command, git identity guard, mise auto-trust, secure env-var forwarding, built-in default profile in `coi profile list` example, `coi-default` image name fix).

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all wiki links still resolve