### PR TITLE
fix(cli): strip double v prefix from version display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.8.2 (Unreleased)
+
+### Bug Fixes
+
+- **Fix double `v` prefix in version display** — `coi update` and `coi version` showed `vv0.8.x` instead of `v0.8.x` because `git describe --tags` already includes the `v` prefix and the Go code added another. The Makefile now strips the leading `v` from the injected version string.
+
 ## 0.8.1 (2026-05-07)
 
 ### Improvements

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOFMT=$(GOCMD) fmt
 GOVET=$(GOCMD) vet
 
 # Version injection
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "dev")
+VERSION ?= $(shell (git describe --tags --always --dirty 2>/dev/null || echo "dev") | sed 's/^v//')
 LDFLAGS=-ldflags "-X github.com/mensfeld/code-on-incus/internal/cli.Version=$(VERSION)"
 
 # Check required system build dependencies.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOFMT=$(GOCMD) fmt
 GOVET=$(GOCMD) vet
 
 # Version injection
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "dev")
 LDFLAGS=-ldflags "-X github.com/mensfeld/code-on-incus/internal/cli.Version=$(VERSION)"
 
 # Check required system build dependencies.

--- a/tests/version/version_no_double_v_prefix.py
+++ b/tests/version/version_no_double_v_prefix.py
@@ -1,0 +1,64 @@
+"""
+Test for coi version - no double v prefix regression.
+
+Tests that:
+1. Run coi version
+2. Verify version line does NOT contain "vv" (double v prefix)
+3. Run coi update --check
+4. Verify "Current version:" line does NOT contain "vv"
+"""
+
+import subprocess
+
+
+def test_version_no_double_v(coi_binary):
+    """
+    Regression test: version output must not show "vv" prefix.
+
+    git describe --tags produces a v-prefixed string (e.g. v0.8.1).
+    The Go code adds another "v" for display. If the Makefile does not
+    strip the leading v, the output becomes "vv0.8.1".
+
+    Flow:
+    1. Run coi version
+    2. Assert output does not contain "vv"
+    """
+    result = subprocess.run(
+        [coi_binary, "version"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, f"Version command should succeed. stderr: {result.stderr}"
+    assert "vv" not in result.stdout, (
+        f"Version output must not contain double 'vv' prefix. Got:\n{result.stdout}"
+    )
+
+
+def test_update_check_no_double_v(coi_binary):
+    """
+    Regression test: update --check must not show "vv" in current version.
+
+    Flow:
+    1. Run coi update --check
+    2. Assert "Current version:" line does not contain "vv"
+    """
+    result = subprocess.run(
+        [coi_binary, "update", "--check"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"Update check should succeed. stderr: {result.stderr}"
+
+    for line in result.stdout.splitlines():
+        if "Current version:" in line:
+            assert "vv" not in line, (
+                f"Current version must not contain double 'vv' prefix. Got: {line}"
+            )
+            break
+    else:
+        # If dev build, "Current version:" may still appear — just skip
+        pass

--- a/tests/version/version_no_double_v_prefix.py
+++ b/tests/version/version_no_double_v_prefix.py
@@ -53,12 +53,15 @@ def test_update_check_no_double_v(coi_binary):
 
     assert result.returncode == 0, f"Update check should succeed. stderr: {result.stderr}"
 
+    found = False
     for line in result.stdout.splitlines():
         if "Current version:" in line:
+            found = True
             assert "vv" not in line, (
                 f"Current version must not contain double 'vv' prefix. Got: {line}"
             )
             break
-    else:
-        # If dev build, "Current version:" may still appear — just skip
-        pass
+
+    assert found, (
+        f"Expected 'Current version:' line in output. Got:\n{result.stdout}"
+    )

--- a/tests/version/version_no_double_v_prefix.py
+++ b/tests/version/version_no_double_v_prefix.py
@@ -62,6 +62,4 @@ def test_update_check_no_double_v(coi_binary):
             )
             break
 
-    assert found, (
-        f"Expected 'Current version:' line in output. Got:\n{result.stdout}"
-    )
+    assert found, f"Expected 'Current version:' line in output. Got:\n{result.stdout}"


### PR DESCRIPTION
## Summary

- `coi update` and `coi version` displayed `vv0.8.x` instead of `v0.8.x` because `git describe --tags` already includes the `v` prefix and the Go format strings added another
- Fix: strip the leading `v` in the Makefile's `VERSION` variable so all consumers receive a clean version string

## Test plan

- [ ] `make build && ./coi version` shows `v0.8.1` (not `vv0.8.1`)
- [ ] `./coi update --check` shows `Current version: v0.8.1` (single `v`)