### PR TITLE
docs(sandbox): add sudo ownership guidance to sandbox context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.2 (Unreleased)
 
+### Improvements
+
+- **Sudo ownership guidance in SANDBOX_CONTEXT.md** — The sandbox context file now instructs AI tools to fix workspace file ownership after `sudo` operations. Files created by `sudo` in the workspace are owned by root, blocking host-side access. The guidance tells tools to run `chown` after any sudo command that touches workspace files (#368).
+
 ### Bug Fixes
 
 - **Fix double `v` prefix in version display** — `coi update` and `coi version` showed `vv0.8.x` instead of `v0.8.x` because `git describe --tags` already includes the `v` prefix and the Go code added another. The Makefile now strips the leading `v` from the injected version string.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Incus is a modern Linux container and virtual machine manager, forked from LXD. 
 
 - **System containers, not containers-in-VMs.** Incus system containers run a full OS with systemd and native Docker support inside - one clean isolation layer. Docker Sandboxes nests application containers inside microVMs, adding architectural complexity.
 
-- **No permission hell.** Incus automatic UID/GID shifting means files created by agents have correct ownership on the host. No `chown`, no mapping hacks.
+- **No permission hell.** Incus automatic UID/GID shifting means files created by agents have correct ownership on the host. No mapping hacks needed. (Note: files created via `sudo` in the workspace will be root-owned — the sandbox context file instructs AI tools to fix ownership after sudo operations.)
 
 - **Credential isolation by default.** Host environment variables, SSH keys, and Git credentials are never exposed to AI tools unless explicitly mounted.
 

--- a/internal/tool/templates/sandbox_context.md.tmpl
+++ b/internal/tool/templates/sandbox_context.md.tmpl
@@ -216,7 +216,7 @@ git config user.email "<real email>"
 ## Troubleshooting
 
 - **Network errors**: Check the Network policy in the table above — some connections may be blocked by firewall rules
-- **Permission denied on workspace files**: Use `sudo chown -R $(whoami) .` in the workspace directory
+- **Permission denied on workspace files**: Files may have been created by a `sudo` command and are now owned by root. Fix with `sudo chown -R $(whoami):$(whoami) .` in the workspace directory. Always fix ownership after any `sudo` command that creates or modifies workspace files.
 - **Docker not responding**: Run `sudo systemctl start docker` — the daemon may not have started yet
 - **Package not found**: Run `sudo apt-get update` first to refresh package lists
 - **SSH authentication fails**: Check the SSH agent row above — if not forwarded, SSH keys are not available
@@ -229,6 +229,7 @@ git config user.email "<real email>"
 - Use `pip install` for Python packages and `pnpm install` (preferred) or `npm install` for Node packages
 - Use `mise use --global <tool>@<version>` to install new runtimes (Python, Ruby, Go, etc.) instead of apt when possible
 - Create a `.mise.toml` in your project root to pin runtime versions per-project
+- **Fix file ownership after using sudo in the workspace**: When you run `sudo` commands that create or modify files inside {{.WorkspacePath}} (e.g., `sudo bundle install`, `sudo gem install`, `sudo pip install`), those files become owned by root — which blocks the host user from editing them. Always fix ownership afterwards: `sudo chown -R $(whoami):$(whoami) {{.WorkspacePath}}` (or target just the affected subdirectory for speed)
 {{- if .HasProfileContext}}
 
 # User-Provided Profile Context

--- a/internal/tool/templates/sandbox_context.md.tmpl
+++ b/internal/tool/templates/sandbox_context.md.tmpl
@@ -216,7 +216,7 @@ git config user.email "<real email>"
 ## Troubleshooting
 
 - **Network errors**: Check the Network policy in the table above — some connections may be blocked by firewall rules
-- **Permission denied on workspace files**: Files may have been created by a `sudo` command and are now owned by root. Fix with `sudo chown -R $(whoami):$(whoami) .` in the workspace directory. Always fix ownership after any `sudo` command that creates or modifies workspace files.
+- **Permission denied on workspace files**: Files may have been created by a `sudo` command and are now owned by root. Fix with `sudo chown -R "$(id -u):$(id -g)" .` in the workspace directory. Always fix ownership after any `sudo` command that creates or modifies workspace files.
 - **Docker not responding**: Run `sudo systemctl start docker` — the daemon may not have started yet
 - **Package not found**: Run `sudo apt-get update` first to refresh package lists
 - **SSH authentication fails**: Check the SSH agent row above — if not forwarded, SSH keys are not available
@@ -229,7 +229,7 @@ git config user.email "<real email>"
 - Use `pip install` for Python packages and `pnpm install` (preferred) or `npm install` for Node packages
 - Use `mise use --global <tool>@<version>` to install new runtimes (Python, Ruby, Go, etc.) instead of apt when possible
 - Create a `.mise.toml` in your project root to pin runtime versions per-project
-- **Fix file ownership after using sudo in the workspace**: When you run `sudo` commands that create or modify files inside {{.WorkspacePath}} (e.g., `sudo bundle install`, `sudo gem install`, `sudo pip install`), those files become owned by root — which blocks the host user from editing them. Always fix ownership afterwards: `sudo chown -R $(whoami):$(whoami) {{.WorkspacePath}}` (or target just the affected subdirectory for speed)
+- **Fix file ownership after using sudo in the workspace**: When you run `sudo` commands that create or modify files inside {{.WorkspacePath}} (e.g., `sudo bundle install`, `sudo gem install`, `sudo pip install`), those files become owned by root — which blocks the host user from editing them. Always fix ownership afterwards: `sudo chown -R "$(id -u):$(id -g)" "{{.WorkspacePath}}"` (or target just the affected subdirectory for speed)
 {{- if .HasProfileContext}}
 
 # User-Provided Profile Context


### PR DESCRIPTION
## Summary

- Adds guidance to `SANDBOX_CONTEXT.md` template instructing AI tools to fix workspace file ownership after `sudo` operations (e.g., `sudo bundle install`)
- Enhances the troubleshooting entry for "Permission denied on workspace files" with root-cause explanation and fix
- Adds a caveat to README.md's "No permission hell" claim about sudo-created files
- Adds CHANGELOG entry under 0.8.2 Improvements

Closes #368

## Context

When `sudo` creates/modifies files in the workspace, those files end up owned by root on both container and host side (due to `shift=true` mapping container UID 0 → host UID 0). This blocks host-side editing in real time. The fix instructs AI tools to always run `chown` after sudo operations that touch workspace files.

## Test plan

- [x] `go build ./...` — compiles (template is embedded)
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/session/...` — passes (only pre-existing flaky `TestSetupGitIdentityGuard` fails, unrelated)