### PR TITLE
fix(tool): don't lock effort level when not configured in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- **Effort level no longer locked when not configured** — `coi shell` was always injecting `effortLevel = "medium"` and `CLAUDE_CODE_EFFORT_LEVEL=medium` into Claude's `settings.json`, even when `effort_level` was not set in config. Claude treats `CLAUDE_CODE_EFFORT_LEVEL` as authoritative and refuses interactive overrides, making it impossible for users to change the effort level during a session. COI now only injects these settings when `effort_level` is explicitly set in `[tool.claude]`. The documented valid values have also been updated to include `xhigh`, `max`, and `auto`. (#376)
+
 - **`coi run` now applies network isolation and SSH agent forwarding from config** — `coi run` was silently ignoring the `[network]` and `[ssh]` sections of `.coi/config.toml`. Network isolation (`mode = "restricted"`) is now applied before the command runs, and `ssh.forward_agent = true` now forwards the host SSH agent socket into the container via `SSH_AUTH_SOCK`, matching the behaviour of `coi shell`. (#373)
 
 - **Fix double `v` prefix in version display** — `coi update` and `coi version` showed `vv0.8.x` instead of `v0.8.x` because `git describe --tags` already includes the `v` prefix and the Go code added another. The Makefile now strips the leading `v` from the injected version string.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,7 +204,7 @@ type ToolConfig struct {
 
 // ClaudeToolConfig contains Claude Code-specific settings
 type ClaudeToolConfig struct {
-	EffortLevel string `toml:"effort_level"` // Effort level: "low", "medium", "high" (default: "medium")
+	EffortLevel string `toml:"effort_level"` // Effort level: "low", "medium", "high", "xhigh", "max", "auto" (unset = user controls interactively)
 }
 
 // MountEntry represents a single directory mount configuration

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -434,7 +434,7 @@ writable_hooks = false
 #   permission_mode = "bypass"
 #
 #   [tool.claude]
-#   effort_level = "high"
+#   effort_level = "high"  # valid: "low", "medium", "high", "xhigh", "max", "auto" (unset = user controls interactively)
 #
 #   [[mounts]]
 #   host = "~/.cargo"

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -74,7 +74,7 @@ type ToolWithConfigDirFiles interface {
 
 // ClaudeTool implements Tool for Claude Code
 type ClaudeTool struct {
-	effortLevel    string // "low", "medium", "high" - defaults to "medium" if empty
+	effortLevel    string // "low", "medium", "high", "xhigh", "max", "auto" — empty means unset (user controls interactively)
 	permissionMode string // "bypass" (default) or "interactive"
 }
 
@@ -155,22 +155,19 @@ func (c *ClaudeTool) GetSandboxSettings() map[string]interface{} {
 		}
 	}
 
-	// Set effort level (default to "medium" if not configured)
-	// We set both effortLevel directly AND via env var for maximum compatibility
-	effortLevel := c.effortLevel
-	if effortLevel == "" {
-		effortLevel = "medium"
-	}
-	settings["effortLevel"] = effortLevel
-
-	// Effort prompt suppression flags (discovered by examining .claude.json after manual selection)
+	// Suppress the effort-level startup prompt without locking the level itself.
 	settings["effortLevelAccepted"] = true
 	settings["hasSeenEffortPrompt"] = true
 	settings["effortCalloutDismissed"] = true
 
-	// Also set via env section (CLAUDE_CODE_EFFORT_LEVEL) as documented
-	settings["env"] = map[string]string{
-		"CLAUDE_CODE_EFFORT_LEVEL": effortLevel,
+	// Only inject the effort level when explicitly configured. Without this,
+	// Claude uses its own default and the user can change it interactively.
+	// Setting CLAUDE_CODE_EFFORT_LEVEL locks the level and prevents changes.
+	if c.effortLevel != "" {
+		settings["effortLevel"] = c.effortLevel
+		settings["env"] = map[string]string{
+			"CLAUDE_CODE_EFFORT_LEVEL": c.effortLevel,
+		}
 	}
 
 	return settings
@@ -197,8 +194,9 @@ func (c *ClaudeTool) AlwaysSetupConfig() bool { return false }
 func (c *ClaudeTool) AutoContextFile() string { return ".claude/CLAUDE.md" }
 
 // SetEffortLevel sets the effort level for Claude Code.
-// Valid values: "low", "medium", "high".
-// This prevents the interactive effort prompt during autonomous sessions.
+// Valid values: "low", "medium", "high", "xhigh", "max", "auto".
+// When set, CLAUDE_CODE_EFFORT_LEVEL is injected and locks the level for the session.
+// When empty (default), the user can change the effort level interactively inside Claude.
 func (c *ClaudeTool) SetEffortLevel(level string) {
 	c.effortLevel = level
 }

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -175,12 +175,7 @@ func TestClaudeGetSandboxSettings(t *testing.T) {
 		t.Errorf("Expected skipDangerousModePermissionPrompt true, got '%v'", permissions["skipDangerousModePermissionPrompt"])
 	}
 
-	// Check effortLevel defaults to "medium"
-	if settings["effortLevel"] != "medium" {
-		t.Errorf("Expected default effortLevel 'medium', got '%v'", settings["effortLevel"])
-	}
-
-	// Check effort acceptance flags
+	// Prompt suppression flags must always be present
 	if settings["effortLevelAccepted"] != true {
 		t.Error("Expected effortLevelAccepted to be true")
 	}
@@ -191,54 +186,49 @@ func TestClaudeGetSandboxSettings(t *testing.T) {
 		t.Error("Expected effortCalloutDismissed to be true")
 	}
 
-	// Check env section has CLAUDE_CODE_EFFORT_LEVEL
-	env, ok := settings["env"].(map[string]string)
-	if !ok {
-		t.Fatal("Expected env to be map[string]string")
+	// When effort level is not configured, effortLevel and env must be absent
+	if _, ok := settings["effortLevel"]; ok {
+		t.Error("Expected effortLevel to be absent when not configured")
 	}
-	if env["CLAUDE_CODE_EFFORT_LEVEL"] != "medium" {
-		t.Errorf("Expected CLAUDE_CODE_EFFORT_LEVEL 'medium', got '%s'", env["CLAUDE_CODE_EFFORT_LEVEL"])
+	if _, ok := settings["env"]; ok {
+		t.Error("Expected env (CLAUDE_CODE_EFFORT_LEVEL) to be absent when effort level not configured")
 	}
 }
 
 func TestClaudeSetEffortLevel(t *testing.T) {
-	tool := NewClaude()
-
-	// Cast to ToolWithEffortLevel
-	twel, ok := tool.(ToolWithEffortLevel)
+	twel, ok := NewClaude().(ToolWithEffortLevel)
 	if !ok {
 		t.Fatal("Claude tool should implement ToolWithEffortLevel")
 	}
 
-	// Test setting to "high"
-	twel.SetEffortLevel("high")
-	settings := tool.GetSandboxSettings()
-	if settings["effortLevel"] != "high" {
-		t.Errorf("Expected effortLevel 'high', got '%v'", settings["effortLevel"])
-	}
+	for _, level := range []string{"low", "medium", "high", "xhigh", "max", "auto"} {
+		twel.SetEffortLevel(level)
+		settings := twel.(interface{ GetSandboxSettings() map[string]interface{} }).GetSandboxSettings()
 
-	// Test setting to "low"
-	twel.SetEffortLevel("low")
-	settings = tool.GetSandboxSettings()
-	if settings["effortLevel"] != "low" {
-		t.Errorf("Expected effortLevel 'low', got '%v'", settings["effortLevel"])
-	}
-
-	// Test setting to "medium"
-	twel.SetEffortLevel("medium")
-	settings = tool.GetSandboxSettings()
-	if settings["effortLevel"] != "medium" {
-		t.Errorf("Expected effortLevel 'medium', got '%v'", settings["effortLevel"])
+		if settings["effortLevel"] != level {
+			t.Errorf("level %q: expected effortLevel %q, got %v", level, level, settings["effortLevel"])
+		}
+		env, ok := settings["env"].(map[string]string)
+		if !ok {
+			t.Fatalf("level %q: expected env to be map[string]string", level)
+		}
+		if env["CLAUDE_CODE_EFFORT_LEVEL"] != level {
+			t.Errorf("level %q: expected CLAUDE_CODE_EFFORT_LEVEL %q, got %q", level, level, env["CLAUDE_CODE_EFFORT_LEVEL"])
+		}
 	}
 }
 
 func TestClaudeEffortLevelDefault(t *testing.T) {
-	// When effortLevel is not set, GetSandboxSettings should default to "medium"
+	// When effortLevel is not set, effortLevel and CLAUDE_CODE_EFFORT_LEVEL must be absent
+	// so the user can change the effort level interactively inside Claude.
 	tool := NewClaude()
 	settings := tool.GetSandboxSettings()
 
-	if settings["effortLevel"] != "medium" {
-		t.Errorf("Expected default effortLevel 'medium', got '%v'", settings["effortLevel"])
+	if _, ok := settings["effortLevel"]; ok {
+		t.Error("Expected effortLevel to be absent when not configured — user should control it interactively")
+	}
+	if _, ok := settings["env"]; ok {
+		t.Error("Expected env to be absent when effort level not configured")
 	}
 }
 
@@ -380,10 +370,7 @@ func TestClaudeGetSandboxSettings_InteractiveMode(t *testing.T) {
 		t.Error("Expected no 'permissions' key in interactive mode")
 	}
 
-	// Should still have effort level keys
-	if settings["effortLevel"] != "medium" {
-		t.Errorf("Expected effortLevel 'medium', got '%v'", settings["effortLevel"])
-	}
+	// Prompt suppression flags must always be present
 	if settings["effortLevelAccepted"] != true {
 		t.Error("Expected effortLevelAccepted to be true")
 	}
@@ -394,12 +381,12 @@ func TestClaudeGetSandboxSettings_InteractiveMode(t *testing.T) {
 		t.Error("Expected effortCalloutDismissed to be true")
 	}
 
-	env, ok := settings["env"].(map[string]string)
-	if !ok {
-		t.Fatal("Expected env to be map[string]string")
+	// Effort level not configured — must not be locked
+	if _, ok := settings["effortLevel"]; ok {
+		t.Error("Expected effortLevel to be absent when not configured")
 	}
-	if env["CLAUDE_CODE_EFFORT_LEVEL"] != "medium" {
-		t.Errorf("Expected CLAUDE_CODE_EFFORT_LEVEL 'medium', got '%s'", env["CLAUDE_CODE_EFFORT_LEVEL"])
+	if _, ok := settings["env"]; ok {
+		t.Error("Expected env to be absent when effort level not configured")
 	}
 }
 
@@ -427,9 +414,9 @@ func TestClaudeGetSandboxSettings_BypassModeDefault(t *testing.T) {
 		t.Errorf("Expected skipDangerousModePermissionPrompt true, got '%v'", permissions["skipDangerousModePermissionPrompt"])
 	}
 
-	// Should also have effort level keys
-	if settings["effortLevel"] != "medium" {
-		t.Errorf("Expected effortLevel 'medium', got '%v'", settings["effortLevel"])
+	// Effort level not configured — must not be locked
+	if _, ok := settings["effortLevel"]; ok {
+		t.Error("Expected effortLevel to be absent when not configured")
 	}
 }
 

--- a/tests/shell/ephemeral/effort_level_ephemeral.py
+++ b/tests/shell/ephemeral/effort_level_ephemeral.py
@@ -1,0 +1,144 @@
+"""
+Test that effort_level config controls whether CLAUDE_CODE_EFFORT_LEVEL is injected.
+
+Covers issue #376: coi was always injecting effort_level = "medium" (and setting
+CLAUDE_CODE_EFFORT_LEVEL) even when effort_level was not set in config. This
+prevented users from changing the effort level interactively inside Claude because
+Claude treats CLAUDE_CODE_EFFORT_LEVEL as authoritative and refuses overrides.
+
+Tests that:
+1. When effort_level is NOT set in config, settings.json does NOT contain
+   effortLevel or CLAUDE_CODE_EFFORT_LEVEL — user can change it interactively.
+2. When effort_level IS set in config (e.g. "high"), settings.json DOES contain
+   the correct effortLevel and CLAUDE_CODE_EFFORT_LEVEL values.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_text_in_monitor,
+    with_live_screen,
+)
+
+SETTINGS_PATH = "/home/code/.claude/settings.json"
+
+
+def _read_settings(child):
+    """Read settings.json from inside the container and return its text content."""
+    marker = "SETTINGS_DUMP_END"
+    with with_live_screen(child) as monitor:
+        time.sleep(0.5)
+        child.send(f"cat {SETTINGS_PATH} && echo {marker}\r")
+        time.sleep(1)
+        wait_for_text_in_monitor(monitor, marker, timeout=15)
+        return monitor.get_text()
+
+
+def _kill_session(child, coi_binary, container_name):
+    child.send("sudo poweroff\r")
+    try:
+        child.expect(EOF, timeout=60)
+    except TIMEOUT:
+        pass
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+    time.sleep(5)
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_effort_level_not_injected_when_unset(coi_binary, cleanup_containers, workspace_dir):
+    """
+    When effort_level is not set in config, settings.json must NOT contain
+    effortLevel or CLAUDE_CODE_EFFORT_LEVEL so the user can change it interactively.
+    """
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text('[tool]\nname = "claude"\n')
+
+    env = {"COI_USE_DUMMY": "1"}
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    child = spawn_coi(coi_binary, ["shell"], cwd=workspace_dir, env=env, timeout=120)
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    # Exit Claude/dummy to bash
+    child.send("exit\r")
+    time.sleep(2)
+
+    # Use grep to produce a clear marker — grep exits 1 (no output) when absent
+    with with_live_screen(child) as monitor:
+        time.sleep(0.5)
+        child.send(
+            f"grep -q effortLevel {SETTINGS_PATH} "
+            "&& echo HAS_EFFORT_LEVEL || echo NO_EFFORT_LEVEL\r"
+        )
+        time.sleep(1)
+        no_effort = wait_for_text_in_monitor(monitor, "NO_EFFORT_LEVEL", timeout=15)
+
+    _kill_session(child, coi_binary, container_name)
+
+    assert no_effort, (
+        "settings.json must NOT contain effortLevel when effort_level is not "
+        "configured — user should be able to change it interactively inside Claude"
+    )
+
+
+def test_effort_level_injected_when_configured(coi_binary, cleanup_containers, workspace_dir):
+    """
+    When effort_level = "high" is set in config, settings.json MUST contain
+    effortLevel = "high" and CLAUDE_CODE_EFFORT_LEVEL = "high".
+    """
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text(
+        '[tool]\nname = "claude"\n\n[tool.claude]\neffort_level = "high"\n'
+    )
+
+    env = {"COI_USE_DUMMY": "1"}
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    child = spawn_coi(coi_binary, ["shell"], cwd=workspace_dir, env=env, timeout=120)
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    child.send("exit\r")
+    time.sleep(2)
+
+    with with_live_screen(child) as monitor:
+        time.sleep(0.5)
+        child.send(
+            f"grep -q '\"effortLevel\"' {SETTINGS_PATH} "
+            "&& echo HAS_EFFORT_LEVEL || echo NO_EFFORT_LEVEL\r"
+        )
+        time.sleep(1)
+        has_effort = wait_for_text_in_monitor(monitor, "HAS_EFFORT_LEVEL", timeout=15)
+
+    with with_live_screen(child) as monitor:
+        time.sleep(0.5)
+        child.send(f"grep -q '\"high\"' {SETTINGS_PATH} && echo HAS_HIGH || echo NO_HIGH\r")
+        time.sleep(1)
+        has_high = wait_for_text_in_monitor(monitor, "HAS_HIGH", timeout=15)
+
+    _kill_session(child, coi_binary, container_name)
+
+    assert has_effort, (
+        "settings.json must contain effortLevel when effort_level = 'high' is configured"
+    )
+    assert has_high, (
+        "settings.json must contain the value 'high' when effort_level = 'high' is configured"
+    )


### PR DESCRIPTION
## Summary

Fixes #376: `coi shell` was always injecting `effortLevel = "medium"` and `CLAUDE_CODE_EFFORT_LEVEL=medium` into Claude's `settings.json` even when `effort_level` was not set in `[tool.claude]` config. Claude treats `CLAUDE_CODE_EFFORT_LEVEL` as authoritative and refuses interactive overrides, so users had no way to change the effort level during a session.

### Root cause

`GetSandboxSettings()` in `internal/tool/tool.go` defaulted to `"medium"` when `effortLevel` was empty and always injected both the `effortLevel` settings key and the `CLAUDE_CODE_EFFORT_LEVEL` env var entry.

### Changes

**`internal/tool/tool.go`**
- Only inject `effortLevel` and `env.CLAUDE_CODE_EFFORT_LEVEL` when `effort_level` is explicitly configured
- Always write prompt-suppression flags (`effortLevelAccepted`, `hasSeenEffortPrompt`, `effortCalloutDismissed`) so Claude doesn't show a startup prompt regardless
- Update `SetEffortLevel` docs and field comment to list all valid values

**`internal/config/config.go` + `loader.go`**
- Document all valid effort level values: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`, `"auto"`

**`internal/tool/tool_test.go`**
- Update unit tests to assert `effortLevel` and `env` are absent when not configured
- Expand `TestClaudeSetEffortLevel` to cover all valid values

**`tests/shell/ephemeral/effort_level_ephemeral.py`**
- Integration test: effort level absent from `settings.json` when not configured
- Integration test: correct effort level present in `settings.json` when configured

**`CHANGELOG.md`**
- Document fix under 0.8.2 (Unreleased)

## Test plan

- [ ] `Unit Tests` — `TestClaudeEffortLevelDefault`, `TestClaudeSetEffortLevel`, `TestClaudeGetSandboxSettings`
- [ ] `Integration Tests (shell-ephemeral)` — `effort_level_ephemeral.py`

Closes #376