### PR TITLE
fix(tmux): set escape-time 10ms to fix Esc key in nested tmux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,41 @@ jobs:
       fail-fast: false
       matrix:
         test_group:
-          # Fast-feedback: only run tmux/escape-time tests for PR #378
+          - name: shell-ephemeral
+            path: tests/shell/ephemeral
+            description: "Ephemeral shell session tests (17 tests)"
+          - name: shell-persistent
+            path: tests/shell/persistent
+            description: "Persistent shell session tests (9 tests)"
+          - name: network
+            path: tests/network
+            description: "Network isolation tests (10 tests)"
+          - name: container-file
+            path: tests/container tests/file
+            description: "Container and file operations (54 tests)"
           - name: core
-            path: tests/tmux
-            description: "tmux tests including escape-time regression"
+            path: tests/list tests/attach tests/tmux tests/kill tests/run tests/persist tests/build
+            description: "Core commands: list/attach/tmux/kill/run/persist/build (83 tests)"
+          - name: misc
+            path: tests/clean tests/completion tests/config tests/docker tests/errors tests/help tests/image tests/info tests/mount tests/shutdown tests/version tests/meta tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: clean/completion/config/docker/errors/help/image/info/mount/shutdown/version/meta/main help (72 tests)"
+          - name: monitoring-nft
+            path: tests/integration/test_nft_monitoring.py
+            description: "NFT network monitoring tests (17 tests)"
+          - name: monitoring-threats
+            path: tests/integration/test_security_monitoring.py
+            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario or TestMonitoringFeature'"
+            description: "Threat detection tests (20 tests)"
+          - name: monitoring-response
+            path: tests/integration/test_security_monitoring.py
+            pytest_args: "-k 'TestAutomatedResponse or TestHighLevelThreats or TestLargeWriteDetection or TestMonitoringConfiguration or TestMultipleThreats or TestAuditLogValidation or TestFalsePositives or TestThresholdBoundaries or TestConcurrentThreats'"
+            description: "Response and threshold tests (22 tests)"
+          - name: uid-mapping
+            path: tests/container/uid_mapping_shift_true.py tests/container/uid_mapping_raw_idmap.py
+            description: "UID mapping integration tests (2 tests)"
+          - name: git-hooks
+            path: tests/git_hooks
+            description: "Git hooks and security protection tests (32 tests)"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,41 +110,10 @@ jobs:
       fail-fast: false
       matrix:
         test_group:
-          - name: shell-ephemeral
-            path: tests/shell/ephemeral
-            description: "Ephemeral shell session tests (17 tests)"
-          - name: shell-persistent
-            path: tests/shell/persistent
-            description: "Persistent shell session tests (9 tests)"
-          - name: network
-            path: tests/network
-            description: "Network isolation tests (10 tests)"
-          - name: container-file
-            path: tests/container tests/file
-            description: "Container and file operations (54 tests)"
+          # Fast-feedback: only run tmux/escape-time tests for PR #378
           - name: core
-            path: tests/list tests/attach tests/tmux tests/kill tests/run tests/persist tests/build
-            description: "Core commands: list/attach/tmux/kill/run/persist/build (83 tests)"
-          - name: misc
-            path: tests/clean tests/completion tests/config tests/docker tests/errors tests/help tests/image tests/info tests/mount tests/shutdown tests/version tests/meta tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/completion/config/docker/errors/help/image/info/mount/shutdown/version/meta/main help (72 tests)"
-          - name: monitoring-nft
-            path: tests/integration/test_nft_monitoring.py
-            description: "NFT network monitoring tests (17 tests)"
-          - name: monitoring-threats
-            path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario or TestMonitoringFeature'"
-            description: "Threat detection tests (20 tests)"
-          - name: monitoring-response
-            path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestAutomatedResponse or TestHighLevelThreats or TestLargeWriteDetection or TestMonitoringConfiguration or TestMultipleThreats or TestAuditLogValidation or TestFalsePositives or TestThresholdBoundaries or TestConcurrentThreats'"
-            description: "Response and threshold tests (22 tests)"
-          - name: uid-mapping
-            path: tests/container/uid_mapping_shift_true.py tests/container/uid_mapping_raw_idmap.py
-            description: "UID mapping integration tests (2 tests)"
-          - name: git-hooks
-            path: tests/git_hooks
-            description: "Git hooks and security protection tests (32 tests)"
+            path: tests/tmux
+            description: "tmux tests including escape-time regression"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- **Escape key now works correctly in nested tmux sessions** — The Escape key felt completely broken in applications like opencode and vim when using nested tmux (e.g. SSH → host tmux → COI tmux). The root cause was tmux's default `escape-time` of 500ms stacking across each nesting layer, adding up to multiple seconds of delay before Esc reached the application. COI now ships `/etc/tmux.conf` with `set -g escape-time 10`, delivering Esc within 10ms regardless of nesting depth. (#378)
+
 - **Effort level no longer locked when not configured** — `coi shell` was always injecting `effortLevel = "medium"` and `CLAUDE_CODE_EFFORT_LEVEL=medium` into Claude's `settings.json`, even when `effort_level` was not set in config. Claude treats `CLAUDE_CODE_EFFORT_LEVEL` as authoritative and refuses interactive overrides, making it impossible for users to change the effort level during a session. COI now only injects these settings when `effort_level` is explicitly set in `[tool.claude]`. The documented valid values have also been updated to include `xhigh`, `max`, and `auto`. (#376)
 
 - **`coi run` now applies network isolation and SSH agent forwarding from config** — `coi run` was silently ignoring the `[network]` and `[ssh]` sections of `.coi/config.toml`. Network isolation (`mode = "restricted"`) is now applied before the command runs, and `ssh.forward_agent = true` now forwards the host SSH agent socket into the container via `SSH_AUTH_SOCK`, matching the behaviour of `coi shell`. (#373)

--- a/profiles/default/build.sh
+++ b/profiles/default/build.sh
@@ -511,17 +511,25 @@ EOF
 # per-user settings always win.
 #######################################
 configure_tmux() {
-    log "Configuring tmux scrollback history..."
+    log "Configuring tmux..."
 
     cat > /etc/tmux.conf << 'EOF'
 # COI default: large scrollback so long build outputs (bin/setup, npm ci,
 # cargo build, etc.) are fully retrievable. Override in ~/.tmux.conf —
 # tmux loads the per-user file after this one, so your value wins.
 set -g history-limit 50000
+
+# Reduce escape-time from the default 500ms to 10ms so that the Escape key
+# is delivered promptly to applications (e.g. vim, opencode) even when the
+# container tmux is nested inside one or more outer tmux sessions on the
+# host. With the default, each nesting layer adds up to 500ms of latency,
+# making Esc feel completely broken. 10ms is enough to distinguish Esc from
+# the start of an escape sequence without noticeable delay.
+set -g escape-time 10
 EOF
     chmod 644 /etc/tmux.conf
 
-    log "tmux history-limit set to 50000 in /etc/tmux.conf"
+    log "tmux configured: history-limit=50000, escape-time=10ms in /etc/tmux.conf"
 }
 
 #######################################

--- a/profiles/default/build.sh
+++ b/profiles/default/build.sh
@@ -511,25 +511,17 @@ EOF
 # per-user settings always win.
 #######################################
 configure_tmux() {
-    log "Configuring tmux..."
+    log "Configuring tmux scrollback history..."
 
     cat > /etc/tmux.conf << 'EOF'
 # COI default: large scrollback so long build outputs (bin/setup, npm ci,
 # cargo build, etc.) are fully retrievable. Override in ~/.tmux.conf —
 # tmux loads the per-user file after this one, so your value wins.
 set -g history-limit 50000
-
-# Reduce escape-time from the default 500ms to 10ms so that the Escape key
-# is delivered promptly to applications (e.g. vim, opencode) even when the
-# container tmux is nested inside one or more outer tmux sessions on the
-# host. With the default, each nesting layer adds up to 500ms of latency,
-# making Esc feel completely broken. 10ms is enough to distinguish Esc from
-# the start of an escape sequence without noticeable delay.
-set -g escape-time 10
 EOF
     chmod 644 /etc/tmux.conf
 
-    log "tmux configured: history-limit=50000, escape-time=10ms in /etc/tmux.conf"
+    log "tmux history-limit set to 50000 in /etc/tmux.conf"
 }
 
 #######################################

--- a/tests/tmux/tmux_escape_time.py
+++ b/tests/tmux/tmux_escape_time.py
@@ -1,0 +1,141 @@
+"""
+Behavioral test for tmux escape-time in the coi-default image.
+
+Regression for https://github.com/mensfeld/code-on-incus/issues/378:
+When using nested tmux (e.g. SSH → host tmux → COI tmux), the default
+escape-time of 500ms stacks at each nesting level, causing the Escape key to
+feel completely broken in applications like opencode/vim.
+
+The fix ships `/etc/tmux.conf` with `set -g escape-time 10` so the Escape key
+is delivered to applications promptly even in nested setups.
+
+Tests that:
+1. /etc/tmux.conf declares escape-time 10.
+2. The Escape key actually passes through nested tmux within 200ms — a
+   behavioral end-to-end check that would fail at the 500ms default because
+   the inner tmux would not have flushed the byte to the application yet.
+"""
+
+import subprocess
+import time
+
+from support.helpers import calculate_container_name
+
+
+def test_tmux_escape_time_config(coi_binary, cleanup_containers, workspace_dir):
+    """
+    /etc/tmux.conf must declare escape-time 10.
+    """
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    result = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"Container launch failed. stderr: {result.stderr}"
+
+    time.sleep(3)
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "container",
+            "exec",
+            container_name,
+            "--",
+            "cat",
+            "/etc/tmux.conf",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"/etc/tmux.conf must exist. stderr: {result.stderr}"
+    combined = result.stdout + result.stderr
+    assert "set -g escape-time 10" in combined, (
+        f"/etc/tmux.conf must set escape-time to 10. Got:\n{combined}"
+    )
+
+    subprocess.run(
+        [coi_binary, "container", "delete", container_name, "--force"],
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_esc_passes_through_nested_tmux_quickly(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Escape key sent to an outer tmux must arrive in the inner tmux application
+    within 200ms — a timing window that fails at the 500ms default.
+
+    Setup inside the container:
+      outer-tmux → attaches to → inner-tmux → cat (writes stdin to file)
+
+    We send Escape to the outer pane, sleep 200ms, then check whether
+    /tmp/esc_recv contains byte 0x1b. With escape-time=10 the byte arrives in
+    ~10ms; with the default 500ms it would not have arrived yet.
+    """
+    # This test script runs entirely inside the container via `coi run`.
+    # It creates a nested tmux scenario and measures Esc delivery latency.
+    test_script = r"""
+set -e
+
+cleanup() {
+    tmux kill-server 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Start inner tmux with a cat listener writing to a file.
+tmux new-session -d -s inner -x 200 -y 50
+tmux send-keys -t inner 'stdbuf -o0 cat > /tmp/esc_recv' Enter
+sleep 0.3
+
+# Start outer tmux and attach it to the inner session.
+# This replicates the nested-tmux scenario: outer pane → inner tmux terminal.
+tmux new-session -d -s outer -x 200 -y 50
+tmux send-keys -t outer 'tmux attach-session -t inner' Enter
+sleep 0.3
+
+# Send Escape to the outer pane. It travels:
+#   outer pane stdin → outer tmux → inner tmux terminal input
+#   → inner tmux escape-time processing → inner pane (cat)
+tmux send-keys -t outer Escape ''
+
+# 200ms window: with escape-time=10 the byte is flushed in ~10ms.
+# With the default 500ms it would not have arrived within this window.
+sleep 0.2
+
+# Interrupt cat so the file is flushed.
+tmux send-keys -t inner C-c
+sleep 0.1
+
+if od -An -tx1 /tmp/esc_recv 2>/dev/null | tr -d ' \n' | grep -q '1b'; then
+    echo "ESC_DELIVERED_WITHIN_200MS"
+else
+    echo "ESC_NOT_DELIVERED"
+fi
+"""
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "run",
+            "--workspace",
+            workspace_dir,
+            "--",
+            "bash",
+            "-c",
+            test_script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+    combined = result.stdout + result.stderr
+    assert "ESC_DELIVERED_WITHIN_200MS" in combined, (
+        f"Escape key must be delivered through nested tmux within 200ms.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes #378: Escape key feels completely broken in opencode/vim when using nested tmux (SSH → host tmux → COI tmux).

**Root cause:** tmux's default `escape-time` is 500ms — the time it waits after receiving `ESC` to decide if it's a standalone keypress or the start of a meta/escape sequence. In nested tmux sessions, each layer independently applies its own 500ms delay, so the total latency compounds to multiple seconds before `ESC` reaches the application.

**Fix:** Add `set -g escape-time 10` to `/etc/tmux.conf` in the default COI image. 10ms is enough to distinguish `ESC` from escape sequences without any perceptible delay.

## Changes

- `profiles/default/build.sh`: Add `set -g escape-time 10` to the `configure_tmux()` heredoc alongside the existing `history-limit` setting
- `tests/tmux/tmux_escape_time.py`: Two tests:
  1. Config check — asserts `/etc/tmux.conf` declares `escape-time 10`
  2. **Behavioral test** — creates nested tmux inside the container (outer tmux → inner tmux → cat listener), sends `Escape` through the outer session, and asserts the byte `0x1b` arrives in the inner pane within 200ms. This test would reliably fail with the 500ms default.
- `.github/workflows/ci.yml`: Matrix narrowed to `tests/tmux` only for fast feedback on this PR (to be restored before merge)

## Test plan

- [ ] CI passes with the behavioral nested-tmux Esc test green
- [ ] Restore full CI matrix before merge