### PR TITLE
docs(changelog): clarify escape-time latency is per-layer not absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- **Escape key now works correctly in nested tmux sessions** — The Escape key felt completely broken in applications like opencode and vim when using nested tmux (e.g. SSH → host tmux → COI tmux). The root cause was tmux's default `escape-time` of 500ms stacking across each nesting layer, adding up to multiple seconds of delay before Esc reached the application. COI now ships `/etc/tmux.conf` with `set -g escape-time 10`, delivering Esc within 10ms regardless of nesting depth. (#378)
+- **Escape key now works correctly in nested tmux sessions** — The Escape key felt completely broken in applications like opencode and vim when using nested tmux (e.g. SSH → host tmux → COI tmux). The root cause was tmux's default `escape-time` of 500ms stacking across each nesting layer, adding up to multiple seconds of delay before Esc reached the application. COI now ships `/etc/tmux.conf` with `set -g escape-time 10`, reducing per-layer latency from 500ms to 10ms so that Esc reaches the application promptly even across multiple nesting levels. (#378)
 
 - **Effort level no longer locked when not configured** — `coi shell` was always injecting `effortLevel = "medium"` and `CLAUDE_CODE_EFFORT_LEVEL=medium` into Claude's `settings.json`, even when `effort_level` was not set in config. Claude treats `CLAUDE_CODE_EFFORT_LEVEL` as authoritative and refuses interactive overrides, making it impossible for users to change the effort level during a session. COI now only injects these settings when `effort_level` is explicitly set in `[tool.claude]`. The documented valid values have also been updated to include `xhigh`, `max`, and `auto`. (#376)
 


### PR DESCRIPTION
Addresses Copilot review comment on #380.

The previous wording said "delivering Esc within 10ms regardless of nesting depth" which overstates the guarantee — each tmux layer still applies its own `escape-time`, so latency scales with nesting depth (10ms × layers + scheduling overhead). Rephrased to accurately say "reducing per-layer latency from 500ms to 10ms".