### PR TITLE
chore(renovate): remove unused ruby package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,15 +28,6 @@
       ],
       "groupName": "test dependencies",
       "commitMessageTopic": "test dependencies"
-    },
-    {
-      "description": "Group ruby/setup-ruby action with ruby version updates",
-      "matchPackageNames": [
-        "ruby/setup-ruby",
-        "ruby"
-      ],
-      "groupName": "ruby setup",
-      "internalChecksFilter": "strict"
     }
   ],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
Removes the `ruby/setup-ruby` and `ruby` package grouping rule from `renovate.json` — this project doesn't use Ruby, so the rule is dead config. Closes #381.