### PR TITLE
fix(cli): detect stale incus-admin group session and give actionable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- **Clearer error when incus-admin group not active in session** — After installing COI and running `sudo usermod -aG incus-admin $USER`, users who ran `coi` without logging out first got a confusing generic error ("incus is not available"). COI now detects the case where the user is already in the group in `/etc/group` but the current session predates the change, and tells them exactly what to do: log out and back in, or run `newgrp incus-admin`. The `coi health` command also surfaces this distinction. (#383)
+
 - **Escape key now works correctly in nested tmux sessions** — The Escape key felt completely broken in applications like opencode and vim when using nested tmux (e.g. SSH → host tmux → COI tmux). The root cause was tmux's default `escape-time` of 500ms stacking across each nesting layer, adding up to multiple seconds of delay before Esc reached the application. COI now ships `/etc/tmux.conf` with `set -g escape-time 10`, reducing per-layer latency from 500ms to 10ms so that Esc reaches the application promptly even across multiple nesting levels. (#378)
 
 - **Effort level no longer locked when not configured** — `coi shell` was always injecting `effortLevel = "medium"` and `CLAUDE_CODE_EFFORT_LEVEL=medium` into Claude's `settings.json`, even when `effort_level` was not set in config. Claude treats `CLAUDE_CODE_EFFORT_LEVEL` as authoritative and refuses interactive overrides, making it impossible for users to change the effort level during a session. COI now only injects these settings when `effort_level` is explicitly set in `[tool.claude]`. The documented valid values have also been updated to include `xhigh`, `max`, and `auto`. (#376)

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -38,7 +38,7 @@ func init() {
 func buildCommand(cmd *cobra.Command, args []string) error {
 	// Check if Incus is available
 	if !container.Available() {
-		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
+		return container.IncusNotAvailableError()
 	}
 
 	// Check minimum Incus version

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -211,7 +211,7 @@ func init() {
 func imageListCommand(cmd *cobra.Command, args []string) error {
 	// Check if Incus is available
 	if !container.Available() {
-		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
+		return container.IncusNotAvailableError()
 	}
 
 	format, _ := cmd.Flags().GetString("format")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,7 +49,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 
 	// Check if Incus is available
 	if !container.Available() {
-		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
+		return container.IncusNotAvailableError()
 	}
 
 	// Check minimum Incus version

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -118,7 +118,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 
 	// Check if Incus is available
 	if !container.Available() {
-		return fmt.Errorf("incus is not available - please install Incus and ensure you're in the incus-admin group")
+		return container.IncusNotAvailableError()
 	}
 
 	// Check minimum Incus version

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -527,6 +528,81 @@ func Available() bool {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() == nil
+}
+
+// IncusNotAvailableError returns a descriptive error explaining why Incus is not
+// accessible. It distinguishes three common cases so the user knows exactly what
+// to do:
+//  1. Incus binary is not installed.
+//  2. User is in the incus-admin group in /etc/group but the current session
+//     was started before the group was added — a re-login is needed.
+//  3. User is not in the incus-admin group at all.
+func IncusNotAvailableError() error {
+	if _, err := exec.LookPath("incus"); err != nil {
+		return fmt.Errorf("incus is not installed — please install Incus first")
+	}
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("incus is not available — please ensure you are in the incus-admin group")
+	}
+
+	incusGroup, err := user.LookupGroup("incus-admin")
+	if err != nil {
+		// Group doesn't exist — Incus not installed properly or daemon not running.
+		return fmt.Errorf("incus is not available — the incus-admin group does not exist; please install Incus")
+	}
+
+	// Check whether the group is active in the current session.
+	activeGIDs, err := currentUser.GroupIds()
+	if err == nil {
+		for _, gid := range activeGIDs {
+			if gid == incusGroup.Gid {
+				// Group is active but incus still doesn't work — daemon issue.
+				return fmt.Errorf("incus is not available — please check that the Incus daemon is running (sudo systemctl start incus)")
+			}
+		}
+	}
+
+	// Group exists but is not active — check whether it's in /etc/group.
+	if UserInGroupFile(currentUser.Username, "incus-admin") {
+		return fmt.Errorf(
+			"you have been added to the incus-admin group but your current session does not have it active yet\n" +
+				"Log out and back in, or run: newgrp incus-admin",
+		)
+	}
+
+	return fmt.Errorf(
+		"incus is not available — please add your user to the incus-admin group and re-login:\n" +
+			"  sudo usermod -aG incus-admin $USER\n" +
+			"Then log out and back in, or run: newgrp incus-admin",
+	)
+}
+
+// UserInGroupFile reports whether username appears in the member list of
+// groupName in /etc/group, regardless of whether the group is active in the
+// current session.
+func UserInGroupFile(username, groupName string) bool {
+	data, err := os.ReadFile("/etc/group")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, groupName+":") {
+			continue
+		}
+		// Format: name:password:gid:member1,member2,...
+		parts := strings.SplitN(line, ":", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		for _, member := range strings.Split(parts[3], ",") {
+			if strings.TrimSpace(member) == username {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ImageExistsGlobal checks if an image exists (class method equivalent)

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -531,12 +532,14 @@ func Available() bool {
 }
 
 // IncusNotAvailableError returns a descriptive error explaining why Incus is not
-// accessible. It distinguishes three common cases so the user knows exactly what
-// to do:
+// accessible. It distinguishes the following cases so the user knows exactly
+// what to do:
 //  1. Incus binary is not installed.
-//  2. User is in the incus-admin group in /etc/group but the current session
+//  2. incus-admin group does not exist (Incus not properly installed).
+//  3. User is in the incus-admin group in /etc/group but the current session
 //     was started before the group was added — a re-login is needed.
-//  3. User is not in the incus-admin group at all.
+//  4. User is not in the incus-admin group at all.
+//  5. Group is active in the session but the Incus daemon is not running.
 func IncusNotAvailableError() error {
 	if _, err := exec.LookPath("incus"); err != nil {
 		return fmt.Errorf("incus is not installed — please install Incus first")
@@ -553,11 +556,14 @@ func IncusNotAvailableError() error {
 		return fmt.Errorf("incus is not available — the incus-admin group does not exist; please install Incus")
 	}
 
-	// Check whether the group is active in the current session.
-	activeGIDs, err := currentUser.GroupIds()
+	// Use os.Getgroups() (getgroups(2)) to get the actual supplementary GIDs
+	// of the current process — not the group database. This is what determines
+	// whether the running session can actually use incus.
+	incusGID, _ := strconv.Atoi(incusGroup.Gid)
+	activeGIDs, err := os.Getgroups()
 	if err == nil {
 		for _, gid := range activeGIDs {
-			if gid == incusGroup.Gid {
+			if gid == incusGID {
 				// Group is active but incus still doesn't work — daemon issue.
 				return fmt.Errorf("incus is not available — please check that the Incus daemon is running (sudo systemctl start incus)")
 			}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -198,13 +199,15 @@ func CheckPermissions() HealthCheck {
 		}
 	}
 
-	// Get user's groups
-	groups, err := currentUser.GroupIds()
+	// Use os.Getgroups() (getgroups(2)) to get the actual supplementary GIDs
+	// of the current process — not the group database. This correctly reflects
+	// whether the running session has picked up a recent usermod change.
+	activeGIDs, err := os.Getgroups()
 	if err != nil {
 		return HealthCheck{
 			Name:    "permissions",
 			Status:  StatusWarning,
-			Message: fmt.Sprintf("Could not determine user groups: %v", err),
+			Message: fmt.Sprintf("Could not determine active session groups: %v", err),
 		}
 	}
 
@@ -218,9 +221,10 @@ func CheckPermissions() HealthCheck {
 		}
 	}
 
-	// Check if user is in the group
-	for _, gid := range groups {
-		if gid == incusGroup.Gid {
+	// Check if the group is active in the current session.
+	incusGID, _ := strconv.Atoi(incusGroup.Gid)
+	for _, gid := range activeGIDs {
+		if gid == incusGID {
 			return HealthCheck{
 				Name:    "permissions",
 				Status:  StatusOK,

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -233,10 +233,19 @@ func CheckPermissions() HealthCheck {
 		}
 	}
 
+	// Not active in session — check if they were added but haven't re-logged in.
+	if container.UserInGroupFile(currentUser.Username, "incus-admin") {
+		return HealthCheck{
+			Name:    "permissions",
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("User '%s' is in incus-admin group but session not reloaded — log out and back in, or run: newgrp incus-admin", currentUser.Username),
+		}
+	}
+
 	return HealthCheck{
 		Name:    "permissions",
 		Status:  StatusFailed,
-		Message: fmt.Sprintf("User '%s' not in incus-admin group", currentUser.Username),
+		Message: fmt.Sprintf("User '%s' not in incus-admin group — run: sudo usermod -aG incus-admin $USER", currentUser.Username),
 	}
 }
 


### PR DESCRIPTION
Fixes #383.

## Problem

After running `sudo usermod -aG incus-admin $USER`, users who ran `coi` immediately (without logging out) got:

```
incus is not available - please install Incus and ensure you're in the incus-admin group
```

This is confusing because Incus IS installed and the user IS in the group — they just need to reload their session. There was no way to tell from the error message what was wrong.

## Fix

`IncusNotAvailableError()` now distinguishes four cases by checking both the active session GIDs (`getgroups`) and `/etc/group`:

| Situation | Error message |
|-----------|---------------|
| User in `/etc/group` but session predates the `usermod` | "added to incus-admin group but session not reloaded — log out and back in, or run: `newgrp incus-admin`" |
| User not in `incus-admin` at all | "run: `sudo usermod -aG incus-admin $USER`, then log out and back in" |
| Group active but daemon not responding | "check that the Incus daemon is running (`sudo systemctl start incus`)" |
| Incus binary not found | "incus is not installed" |

`coi health` (`CheckPermissions`) surfaces the same stale-session distinction.

## Changes

- `internal/container/manager.go`: `IncusNotAvailableError()` + exported `UserInGroupFile()` helper
- `internal/health/checks.go`: `CheckPermissions` uses `UserInGroupFile` for better message
- `internal/cli/{build,run,shell,images}.go`: replace hardcoded error string with `container.IncusNotAvailableError()`
- `CHANGELOG.md`: entry for #383