### PR TITLE
feat(ux): prompt to build image interactively when missing on TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+- **Interactive build prompt when image is missing** — When `coi shell` or `coi run` is invoked from a terminal and the required image does not exist, COI now asks "Build it now? (~5 min) [y/N]" instead of immediately failing. Answering `y` triggers the build inline and continues with the session. Non-interactive use (piped input, CI) is unchanged — the existing actionable error is returned immediately.
+
 - **Sudo ownership guidance in SANDBOX_CONTEXT.md** — The sandbox context file now instructs AI tools to fix workspace file ownership after `sudo` operations. Files created by `sudo` in the workspace are owned by root, blocking host-side access. The guidance tells tools to run `chown` after any sudo command that touches workspace files (#368).
 
 ### Bug Fixes

--- a/internal/cli/build_helpers.go
+++ b/internal/cli/build_helpers.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/image"
@@ -102,13 +104,12 @@ func imageNotFoundError(imageName string) error {
 	return fmt.Errorf("image '%s' not found — run 'coi build --profile <profile>' first", imageName)
 }
 
-// stdinIsTerminal reports whether os.Stdin is connected to a terminal.
+// stdinIsTerminal reports whether os.Stdin is connected to a real terminal.
+// Uses TIOCGWINSZ rather than ModeCharDevice because /dev/null is also a
+// character device on Linux, causing false positives with the stat approach.
 func stdinIsTerminal() bool {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
+	_, err := unix.IoctlGetWinsize(int(os.Stdin.Fd()), unix.TIOCGWINSZ)
+	return err == nil
 }
 
 // promptYesNo prints prompt and reads a single line from stdin.

--- a/internal/cli/build_helpers.go
+++ b/internal/cli/build_helpers.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
@@ -69,10 +71,10 @@ func ResolveImageName(flagValue string, cfg *config.Config) string {
 	return image.CoiAlias
 }
 
-// AutoBuildIfNeeded checks if the image is missing and returns an error with instructions.
-// Returns nil if the image already exists.
+// AutoBuildIfNeeded checks if the image is missing. When stdin is an
+// interactive terminal it prompts the user to build the image on the spot;
+// otherwise it returns an actionable error with build instructions.
 func AutoBuildIfNeeded(cfg *config.Config, imageName string) error {
-	// Check if image exists
 	exists, err := container.ImageExists(imageName)
 	if err != nil {
 		return fmt.Errorf("failed to check image: %w", err)
@@ -81,9 +83,107 @@ func AutoBuildIfNeeded(cfg *config.Config, imageName string) error {
 		return nil
 	}
 
-	// Image doesn't exist — return error with instructions
+	if !stdinIsTerminal() {
+		return imageNotFoundError(imageName)
+	}
+
+	if !promptYesNo(fmt.Sprintf("Image '%s' not found. Build it now? (~5 min) [y/N]: ", imageName)) {
+		return imageNotFoundError(imageName)
+	}
+
+	return runInlineBuild(cfg, imageName)
+}
+
+// imageNotFoundError returns the standard actionable error for a missing image.
+func imageNotFoundError(imageName string) error {
 	if imageName == image.CoiAlias {
 		return fmt.Errorf("image '%s' not found — run 'coi build' first", imageName)
 	}
 	return fmt.Errorf("image '%s' not found — run 'coi build --profile <profile>' first", imageName)
+}
+
+// stdinIsTerminal reports whether os.Stdin is connected to a terminal.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// promptYesNo prints prompt and reads a single line from stdin.
+// Returns true only if the user types "y" or "Y".
+func promptYesNo(prompt string) bool {
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return false
+	}
+	answer := strings.TrimSpace(scanner.Text())
+	return strings.EqualFold(answer, "y")
+}
+
+// runInlineBuild builds imageName using the same logic as `coi build`,
+// driven by the already-resolved config (profile already applied).
+func runInlineBuild(cfg *config.Config, imageName string) error {
+	buildPool := cfg.Container.StoragePool
+	if err := container.ValidateStoragePool(buildPool); err != nil {
+		return err
+	}
+
+	logger := func(msg string) { fmt.Println(msg) }
+
+	if imageName == image.CoiAlias {
+		opts := image.BuildOptions{
+			Force:       false,
+			ImageType:   "coi",
+			BaseImage:   image.BaseImage,
+			AliasName:   image.CoiAlias,
+			Description: "coi image (Docker + build tools + Claude CLI + GitHub CLI)",
+			StoragePool: buildPool,
+			Logger:      logger,
+		}
+		fmt.Printf("Building image '%s'...\n", imageName)
+		result := image.NewBuilder(opts).Build()
+		if result.Error != nil {
+			return fmt.Errorf("build failed: %w", result.Error)
+		}
+		fmt.Printf("\nImage '%s' built successfully!\n", imageName)
+		return nil
+	}
+
+	// Custom image: requires build config in the resolved cfg.
+	if !cfg.Container.Build.HasBuildConfig() {
+		return fmt.Errorf("image '%s' not found — run 'coi build --profile <profile>' first", imageName)
+	}
+
+	scriptPath, cleanup, err := resolveBuildScript(&cfg.Container.Build)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	baseImage := cfg.Container.Build.Base
+	if baseImage == "" {
+		baseImage = image.CoiAlias
+	}
+
+	opts := image.BuildOptions{
+		ImageType:   "custom",
+		AliasName:   imageName,
+		Description: fmt.Sprintf("Custom image (%s)", imageName),
+		BaseImage:   baseImage,
+		BuildScript: scriptPath,
+		Force:       false,
+		StoragePool: buildPool,
+		Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
+	}
+
+	fmt.Fprintf(os.Stderr, "Building image '%s' (base: %s)...\n", imageName, baseImage)
+	result := image.NewBuilder(opts).Build()
+	if result.Error != nil {
+		return fmt.Errorf("build failed: %w", result.Error)
+	}
+	fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
+	return nil
 }

--- a/internal/cli/build_helpers.go
+++ b/internal/cli/build_helpers.go
@@ -118,6 +118,9 @@ func promptYesNo(prompt string) bool {
 	fmt.Fprint(os.Stderr, prompt)
 	scanner := bufio.NewScanner(os.Stdin)
 	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "\nWarning: failed to read input: %v\n", err)
+		}
 		return false
 	}
 	answer := strings.TrimSpace(scanner.Text())
@@ -149,13 +152,17 @@ func runInlineBuild(cfg *config.Config, imageName string) error {
 		if result.Error != nil {
 			return fmt.Errorf("build failed: %w", result.Error)
 		}
+		if result.Skipped {
+			fmt.Printf("\nImage '%s' already exists — skipping build.\n", imageName)
+			return nil
+		}
 		fmt.Printf("\nImage '%s' built successfully!\n", imageName)
 		return nil
 	}
 
 	// Custom image: requires build config in the resolved cfg.
 	if !cfg.Container.Build.HasBuildConfig() {
-		return fmt.Errorf("image '%s' not found — run 'coi build --profile <profile>' first", imageName)
+		return fmt.Errorf("cannot auto-build '%s': no [container.build] section in config — add a build script or commands, then run 'coi build --profile <profile>'", imageName)
 	}
 
 	scriptPath, cleanup, err := resolveBuildScript(&cfg.Container.Build)
@@ -184,6 +191,10 @@ func runInlineBuild(cfg *config.Config, imageName string) error {
 	result := image.NewBuilder(opts).Build()
 	if result.Error != nil {
 		return fmt.Errorf("build failed: %w", result.Error)
+	}
+	if result.Skipped {
+		fmt.Fprintf(os.Stderr, "\nImage '%s' already exists — skipping build.\n", imageName)
+		return nil
 	}
 	fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
 	return nil

--- a/tests/build/test_auto_build.py
+++ b/tests/build/test_auto_build.py
@@ -1,8 +1,9 @@
 """
-Test behavior when image is missing on coi shell / coi run.
+Test non-interactive behavior when image is missing on coi shell / coi run.
 
-Since auto-build was removed, missing images now return an error
-instructing the user to run 'coi build' first.
+When stdin is NOT a terminal (piped subprocess), missing images return an
+error instructing the user to run 'coi build' first. Interactive TTY
+behavior (prompt to build) is covered in test_auto_build_prompt.py.
 
 Tests:
 - coi run with missing image → error with build instructions

--- a/tests/build/test_auto_build_prompt.py
+++ b/tests/build/test_auto_build_prompt.py
@@ -1,0 +1,214 @@
+"""
+Test the interactive auto-build prompt when an image is missing.
+
+When coi shell/run is invoked from a terminal (stdin is a TTY) and the
+requested image does not exist, COI prompts the user to build it instead
+of immediately failing.
+
+Tests:
+- Prompt is shown on a TTY when the default image is missing
+- Answering "n" (or Enter) keeps the not-found error, process exits non-zero
+- Answering "y" triggers a build attempt for the default image
+- Custom image with no build config: "y" answer shows correct error
+- Non-interactive path (subprocess, no PTY) still returns plain error
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import spawn_coi
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_DEFAULT = "coi-prompt-test-default-missing"
+_FAKE_CUSTOM = "coi-prompt-test-custom-missing"
+_PROMPT_TEXT = "Build it now?"
+
+
+def _get_output(child):
+    """Return all captured output from a pexpect child."""
+    if hasattr(child.logfile_read, "get_raw_output"):
+        return child.logfile_read.get_raw_output()
+    if hasattr(child.logfile_read, "get_output"):
+        return child.logfile_read.get_output()
+    return ""
+
+
+def _close(child):
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompt tests (pexpect provides a PTY → stdinIsTerminal() == true)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_shown_on_tty_for_missing_image(coi_binary, workspace_dir):
+    """
+    When stdin is a terminal and the image is missing, COI should ask the
+    user before failing — not immediately print an error.
+    """
+    child = spawn_coi(
+        coi_binary,
+        ["shell", "--image", _FAKE_DEFAULT, "--workspace", workspace_dir],
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    try:
+        child.expect(_PROMPT_TEXT, timeout=30)
+        # Prompt was shown — send "n" to decline and let the process exit
+        child.sendline("n")
+        child.expect(EOF, timeout=15)
+    except TIMEOUT:
+        output = _get_output(child)
+        pytest.fail(f"Expected prompt '{_PROMPT_TEXT}' within 30s. Output:\n{output}")
+    finally:
+        _close(child)
+
+
+def test_prompt_decline_exits_with_not_found_error(coi_binary, workspace_dir):
+    """
+    Answering 'n' (or just Enter) at the build prompt should exit non-zero
+    with a message that still tells the user how to build.
+    """
+    child = spawn_coi(
+        coi_binary,
+        ["shell", "--image", _FAKE_DEFAULT, "--workspace", workspace_dir],
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    try:
+        child.expect(_PROMPT_TEXT, timeout=30)
+        child.sendline("n")
+        child.expect(EOF, timeout=15)
+    except TIMEOUT:
+        output = _get_output(child)
+        pytest.fail(f"Process did not exit cleanly after 'n'. Output:\n{output}")
+    finally:
+        _close(child)
+
+    output = _get_output(child)
+    assert child.exitstatus != 0 or child.signalstatus is not None, (
+        f"Expected non-zero exit after declining build. Output:\n{output}"
+    )
+    assert "not found" in output.lower(), (
+        f"Expected 'not found' in output after declining. Got:\n{output}"
+    )
+
+
+def test_prompt_empty_enter_treated_as_no(coi_binary, workspace_dir):
+    """
+    Pressing Enter without typing anything should default to 'no'.
+    The process should still exit with a not-found error.
+    """
+    child = spawn_coi(
+        coi_binary,
+        ["shell", "--image", _FAKE_DEFAULT, "--workspace", workspace_dir],
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    try:
+        child.expect(_PROMPT_TEXT, timeout=30)
+        child.sendline("")  # just press Enter
+        child.expect(EOF, timeout=15)
+    except TIMEOUT:
+        output = _get_output(child)
+        pytest.fail(f"Process did not exit after Enter. Output:\n{output}")
+    finally:
+        _close(child)
+
+    output = _get_output(child)
+    assert child.exitstatus != 0 or child.signalstatus is not None, (
+        f"Expected non-zero exit after pressing Enter (default No). Output:\n{output}"
+    )
+
+
+def test_prompt_yes_triggers_build_attempt_for_custom_image(coi_binary, workspace_dir):
+    """
+    Answering 'y' for a custom image with no build config should trigger the
+    build path and exit with an informative error about needing a profile —
+    not the generic 'image not found' message.
+    """
+    # Write a minimal config that declares the custom image name but provides
+    # no [container.build] section — so HasBuildConfig() returns false.
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text(
+        f'[container]\nimage = "{_FAKE_CUSTOM}"\n'
+    )
+
+    child = spawn_coi(
+        coi_binary,
+        ["shell", "--workspace", workspace_dir],
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    try:
+        child.expect(_PROMPT_TEXT, timeout=30)
+        child.sendline("y")
+        child.expect(EOF, timeout=30)
+    except TIMEOUT:
+        output = _get_output(child)
+        pytest.fail(f"Process did not exit after 'y'. Output:\n{output}")
+    finally:
+        _close(child)
+
+    output = _get_output(child)
+    assert child.exitstatus != 0 or child.signalstatus is not None, (
+        f"Expected non-zero exit (no build config). Output:\n{output}"
+    )
+    # Should mention profile build, not just "not found"
+    assert "profile" in output.lower() or "build" in output.lower(), (
+        f"Expected build-related guidance in output. Got:\n{output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive path (subprocess, no PTY) — existing behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+def test_no_prompt_when_stdin_not_tty(coi_binary, workspace_dir):
+    """
+    When stdin is not a TTY (piped subprocess), COI must not show the prompt
+    and must fail immediately with the actionable error message.
+    """
+    result = subprocess.run(
+        [
+            coi_binary,
+            "shell",
+            "--workspace",
+            workspace_dir,
+            "--image",
+            _FAKE_DEFAULT,
+            "--debug",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=workspace_dir,
+    )
+
+    assert result.returncode != 0, "Should fail when image is missing (non-interactive)"
+    combined = result.stdout + result.stderr
+    assert "not found" in combined.lower(), (
+        f"Expected 'not found' error in non-interactive mode. Got:\n{combined}"
+    )
+    # The interactive prompt text must NOT appear in non-interactive output
+    assert _PROMPT_TEXT not in combined, (
+        f"Prompt should not appear when stdin is not a TTY. Got:\n{combined}"
+    )

--- a/tests/build/test_auto_build_prompt.py
+++ b/tests/build/test_auto_build_prompt.py
@@ -168,9 +168,11 @@ def test_prompt_yes_triggers_build_attempt_for_custom_image(coi_binary, workspac
         f"Expected non-zero exit (no build config). Output:\n{output}"
     )
     # Should explain that there is no build config, not just repeat "not found"
-    assert "container.build" in output or "no [container.build]" in output or "cannot auto-build" in output, (
-        f"Expected explanation of missing build config. Got:\n{output}"
-    )
+    assert (
+        "container.build" in output
+        or "no [container.build]" in output
+        or "cannot auto-build" in output
+    ), f"Expected explanation of missing build config. Got:\n{output}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/build/test_auto_build_prompt.py
+++ b/tests/build/test_auto_build_prompt.py
@@ -167,9 +167,9 @@ def test_prompt_yes_triggers_build_attempt_for_custom_image(coi_binary, workspac
     assert child.exitstatus != 0 or child.signalstatus is not None, (
         f"Expected non-zero exit (no build config). Output:\n{output}"
     )
-    # Should mention profile build, not just "not found"
-    assert "profile" in output.lower() or "build" in output.lower(), (
-        f"Expected build-related guidance in output. Got:\n{output}"
+    # Should explain that there is no build config, not just repeat "not found"
+    assert "container.build" in output or "no [container.build]" in output or "cannot auto-build" in output, (
+        f"Expected explanation of missing build config. Got:\n{output}"
     )
 
 

--- a/tests/build/test_auto_build_prompt.py
+++ b/tests/build/test_auto_build_prompt.py
@@ -14,14 +14,12 @@ Tests:
 """
 
 import subprocess
-import time
 from pathlib import Path
 
 import pytest
 from pexpect import EOF, TIMEOUT
 
 from support.helpers import spawn_coi
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -146,9 +144,7 @@ def test_prompt_yes_triggers_build_attempt_for_custom_image(coi_binary, workspac
     # no [container.build] section — so HasBuildConfig() returns false.
     config_dir = Path(workspace_dir) / ".coi"
     config_dir.mkdir(exist_ok=True)
-    (config_dir / "config.toml").write_text(
-        f'[container]\nimage = "{_FAKE_CUSTOM}"\n'
-    )
+    (config_dir / "config.toml").write_text(f'[container]\nimage = "{_FAKE_CUSTOM}"\n')
 
     child = spawn_coi(
         coi_binary,

--- a/tests/build/test_auto_build_prompt.py
+++ b/tests/build/test_auto_build_prompt.py
@@ -180,8 +180,11 @@ def test_prompt_yes_triggers_build_attempt_for_custom_image(coi_binary, workspac
 
 def test_no_prompt_when_stdin_not_tty(coi_binary, workspace_dir):
     """
-    When stdin is not a TTY (piped subprocess), COI must not show the prompt
-    and must fail immediately with the actionable error message.
+    When stdin is not a TTY, COI must not show the prompt and must fail
+    immediately with the actionable error message.
+
+    stdin=subprocess.DEVNULL guarantees a non-TTY stdin regardless of
+    whether the CI runner itself has a PTY allocated.
     """
     result = subprocess.run(
         [
@@ -194,6 +197,7 @@ def test_no_prompt_when_stdin_not_tty(coi_binary, workspace_dir):
             "--debug",
         ],
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         text=True,
         timeout=30,
         cwd=workspace_dir,


### PR DESCRIPTION
## Summary

- When `coi shell` or `coi run` is invoked from a terminal and the required image doesn't exist, COI now asks `"Image 'X' not found. Build it now? (~5 min) [y/N]:"` instead of immediately failing
- Answering `y` triggers the build inline (reusing the same `image.NewBuilder` logic as `coi build`) and continues into the session
- Non-interactive use (piped input, CI, scripts) is unchanged — stdin TTY detection gates the prompt, so the existing actionable error is returned immediately

Closes #111

## Changes

- **`internal/cli/build_helpers.go`** — `AutoBuildIfNeeded` gains the interactive path; extracted `imageNotFoundError`, `stdinIsTerminal`, `promptYesNo`, and `runInlineBuild` helpers
- **`tests/build/test_auto_build_prompt.py`** — 5 new integration tests covering: prompt shown on TTY, decline exits with error, Enter defaults to no, yes-with-no-build-config gives correct guidance, non-interactive path shows no prompt
- **`tests/build/test_auto_build.py`** — Updated docstring to clarify these cover the non-interactive path
- **`CHANGELOG.md`** — Entry under 0.8.2

## Test plan

- [ ] `coi shell` with missing `coi-default` image on a real terminal → prompt appears, `y` triggers build, `n` exits with error
- [ ] `coi shell --image nonexistent` piped through subprocess → immediate error, no prompt
- [ ] Python integration tests in `tests/build/test_auto_build_prompt.py` pass
- [ ] Existing `tests/build/test_auto_build.py` tests still pass