### PR TITLE
refactor: rename legacy firewalld identifiers to nft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Improvements
 
+- [Refactor] **Renamed legacy firewalld identifiers to nft** — Cleaned up all remaining `firewalld`-era naming after the firewalld→nftables migration: health check key `bridge_firewalld_zone` → `bridge_forward_rules`; Go function `CheckBridgeFirewalldZone` → `CheckBridgeForwardRules`; `FirewallManager`/`NewFirewallManager` → `NftManager`/`NewNftManager`; `FirewallAvailable`/`FirewallInstalled` → `NftAvailable`/`NftInstalled`; orphan helpers `DetectOrphanedFirewallRules`/`CleanupOrphanedFirewallRules` → `DetectOrphanedNftRules`/`CleanupOrphanedNftRules`; source file `firewall.go` → `nft_filter.go`. Breaking change: `coi health --format json` consumers checking the `bridge_firewalld_zone` key must update to `bridge_forward_rules`.
+
+
+
 - **Base image downloaded directly from Canonical's CDN** — `coi build` now fetches the Ubuntu base image straight from `cloud-images.ubuntu.com` instead of relying on the LXC community image server (`images.linuxcontainers.org`), whose CDN mirrors are blocked in some corporate networks. COI fetches Canonical's simplestreams index directly in Go, downloads the `lxd.tar.xz` metadata and `squashfs` rootfs, and imports them into Incus as a local alias — bypassing Incus's own simplestreams client, which is incompatible with `cloud-images.ubuntu.com`. The default base image reference is now `ubuntu:24.04`; any `ubuntu:VERSION` reference triggers this download path. Users who prefer the old behaviour can set `[container.build] base = "images:ubuntu/22.04"` in their config. The `[container.build] base` override now also applies to `coi-default` builds (previously it was ignored for the default image). (#388)
 
 - **Interactive build prompt when image is missing** — When `coi shell` or `coi run` is invoked from a terminal and the required image does not exist, COI now asks "Build it now? (~5 min) [y/N]" instead of immediately failing. Answering `y` triggers the build inline and continues with the session. Non-interactive use (piped input, CI) is unchanged — the existing actionable error is returned immediately.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See the [Supported Tools wiki page](https://github.com/mensfeld/code-on-incus/wi
 - Kernel version enforcement - Warns on host kernels below 5.15 that may lack security features for safe isolation
 - Real-time threat detection - Kernel-level nftables monitoring detects reverse shells, C2 connections, data exfiltration, DNS tunneling, and credential scanning
 - Automated response - Auto-pause on HIGH threats, auto-kill on CRITICAL — no manual intervention needed
-- Network isolation - Firewalld-based restricted/allowlist/open modes block private network access and prevent exfiltration
+- Network isolation - nftables-based restricted/allowlist/open modes block private network access and prevent exfiltration
 - Protected paths - `.git/hooks`, `.git/config`, `.husky`, `.vscode` mounted read-only to prevent supply-chain attacks
 - Host-side immutable protection - Protected paths are locked with `chattr +i` during sessions, preventing `unshare -m` + `umount` bypass of read-only mounts (opt out: `[security] host_immutable = false`)
 - Git identity guard - Containers enforce `user.useConfigOnly=true`, preventing AI tools from committing as the default "code" user
@@ -164,7 +164,7 @@ Incus is a modern Linux container and virtual machine manager, forked from LXD. 
 | **Real-time threat detection** | Kernel-level (nftables) | No | No |
 | **Reverse shell detection** | Auto-kill | No | No |
 | **Data exfiltration alerts** | Auto-pause | No | No |
-| **Network isolation** | Firewalld (3 modes) | Basic | No |
+| **Network isolation** | nftables (3 modes) | Basic | No |
 | **Protected paths** | Read-only mounts | No | No |
 | **Auto response (pause/kill)** | Yes | No | No |
 | **Audit logging** | JSONL forensics | No | No |

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ coi shutdown <name>           # Graceful stop (outside)
 
 ## Network Isolation
 
-See the [Network Isolation guide](https://github.com/mensfeld/code-on-incus/wiki/Network-Isolation) for complete documentation on network security and firewalld setup.
+See the [Network Isolation guide](https://github.com/mensfeld/code-on-incus/wiki/Network-Isolation) for complete documentation on network security and nftables-based network filtering.
 
 **Network modes:**
 - **Restricted (default)** - Blocks private networks, allows internet
@@ -612,7 +612,7 @@ See the [Troubleshooting guide](https://github.com/mensfeld/code-on-incus/wiki/T
 See the [FAQ](https://github.com/mensfeld/code-on-incus/wiki/FAQ) for answers to common questions.
 
 **Topics covered:**
-- Orphaned firewalld zone bindings (Docker + firewalld interaction)
+- Orphaned nftables/iptables rules
 - How COI compares to Docker Sandboxes and DevContainers
 - Windows support (WSL2)
 - Security model and prompt injection protection

--- a/internal/cleanup/orphans.go
+++ b/internal/cleanup/orphans.go
@@ -154,7 +154,7 @@ func CleanupOrphanedNftRules(rules []string, logger func(string)) (int, error) {
 
 	cleaned := 0
 	for _, ip := range rules {
-		logger(fmt.Sprintf("Removing orphaned firewall rules for container IP: %s", ip))
+		logger(fmt.Sprintf("Removing orphaned nft rules for container IP: %s", ip))
 		if err := network.DeleteCOIFilterRulesForIP(ip); err != nil {
 			logger(fmt.Sprintf("  Warning: Failed to remove rules for %s: %v", ip, err))
 			continue
@@ -317,7 +317,7 @@ func DetectAll() (*OrphanedResources, error) {
 	rules, err := DetectOrphanedNftRules()
 	if err != nil {
 		// Non-fatal - firewall might not be available
-		log.Printf("Warning: Could not check firewall rules: %v", err)
+		log.Printf("Warning: Could not check nft rules: %v", err)
 	}
 	result.NftRules = rules
 

--- a/internal/cleanup/orphans.go
+++ b/internal/cleanup/orphans.go
@@ -16,7 +16,7 @@ import (
 // OrphanedResources holds information about orphaned system resources
 type OrphanedResources struct {
 	Veths               []string // Orphaned veth interfaces (no master bridge)
-	FirewallRules       []string // Orphaned firewall rules (for non-existent container IPs)
+	NftRules            []string // Orphaned nft rules (for non-existent container IPs)
 	NFTMonitorRules     []string // Orphaned nft monitoring rules (NFT_COI/NFT_DNS/NFT_SUSPICIOUS)
 	IptablesBridgeRules []string // Orphaned iptables coi-bridge-forward rules (no coi containers running)
 }
@@ -51,9 +51,9 @@ func DetectOrphanedVeths() ([]string, error) {
 	return orphaned, nil
 }
 
-// DetectOrphanedFirewallRules finds container IPs in the ip coi forward chain
+// DetectOrphanedNftRules finds container IPs in the ip coi forward chain
 // that don't belong to any running container.
-func DetectOrphanedFirewallRules() ([]string, error) {
+func DetectOrphanedNftRules() ([]string, error) {
 	ipHandles, err := network.ListCOIFilterRuleIPs()
 	if err != nil || len(ipHandles) == 0 {
 		return nil, err
@@ -145,9 +145,9 @@ func CleanupOrphanedVeths(veths []string, logger func(string)) (int, error) {
 	return cleaned, nil
 }
 
-// CleanupOrphanedFirewallRules removes all ip coi forward rules for the given container IPs.
-// The rules slice contains container IP addresses (as returned by DetectOrphanedFirewallRules).
-func CleanupOrphanedFirewallRules(rules []string, logger func(string)) (int, error) {
+// CleanupOrphanedNftRules removes all ip coi forward rules for the given container IPs.
+// The rules slice contains container IP addresses (as returned by DetectOrphanedNftRules).
+func CleanupOrphanedNftRules(rules []string, logger func(string)) (int, error) {
 	if logger == nil {
 		logger = func(msg string) { log.Println(msg) }
 	}
@@ -314,12 +314,12 @@ func DetectAll() (*OrphanedResources, error) {
 	}
 	result.Veths = veths
 
-	rules, err := DetectOrphanedFirewallRules()
+	rules, err := DetectOrphanedNftRules()
 	if err != nil {
 		// Non-fatal - firewall might not be available
 		log.Printf("Warning: Could not check firewall rules: %v", err)
 	}
-	result.FirewallRules = rules
+	result.NftRules = rules
 
 	nftRules, err := DetectOrphanedNFTMonitorRules()
 	if err != nil {
@@ -353,8 +353,8 @@ func CleanupAll(logger func(string)) (vethsCleaned, rulesCleaned, nftRulesCleane
 		vethsCleaned, _ = CleanupOrphanedVeths(orphans.Veths, logger)
 	}
 
-	if len(orphans.FirewallRules) > 0 {
-		rulesCleaned, _ = CleanupOrphanedFirewallRules(orphans.FirewallRules, logger)
+	if len(orphans.NftRules) > 0 {
+		rulesCleaned, _ = CleanupOrphanedNftRules(orphans.NftRules, logger)
 	}
 
 	if len(orphans.NFTMonitorRules) > 0 {
@@ -374,5 +374,5 @@ func HasOrphans() bool {
 	if err != nil {
 		return false
 	}
-	return len(orphans.Veths) > 0 || len(orphans.FirewallRules) > 0 || len(orphans.NFTMonitorRules) > 0 || len(orphans.IptablesBridgeRules) > 0
+	return len(orphans.Veths) > 0 || len(orphans.NftRules) > 0 || len(orphans.NFTMonitorRules) > 0 || len(orphans.IptablesBridgeRules) > 0
 }

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -31,7 +31,7 @@ By default, cleans only stopped containers. Use flags to control what gets clean
 
 Orphaned resources include:
 - Orphaned veth interfaces (network pairs with no master bridge)
-- Orphaned firewall rules (nft coi chain rules for container IPs that no longer exist)
+- Orphaned nft rules (ip coi forward chain rules for container IPs that no longer exist)
 - Orphaned iptables bridge rules (coi-bridge-forward rules with no containers running)
 
 The --pools flag detects COI containers in storage pools that are not
@@ -43,7 +43,7 @@ other projects on this machine.
 Examples:
   coi clean                    # Clean stopped containers
   coi clean --sessions         # Clean saved session data
-  coi clean --orphans          # Clean orphaned veths and firewall rules
+  coi clean --orphans          # Clean orphaned veths and nft rules
   coi clean --pools            # Clean COI containers in unreferenced pools
   coi clean --all              # Clean everything
   coi clean --all --force      # Clean without confirmation
@@ -56,7 +56,7 @@ func init() {
 	cleanCmd.Flags().BoolVarP(&cleanAll, "all", "a", false, "Clean all containers, sessions, and orphaned resources")
 	cleanCmd.Flags().BoolVarP(&cleanForce, "force", "f", false, "Skip confirmation prompts")
 	cleanCmd.Flags().BoolVar(&cleanSessions, "sessions", false, "Clean saved session data")
-	cleanCmd.Flags().BoolVar(&cleanOrphans, "orphans", false, "Clean orphaned veths and firewall rules")
+	cleanCmd.Flags().BoolVar(&cleanOrphans, "orphans", false, "Clean orphaned veths and nft rules")
 	cleanCmd.Flags().BoolVar(&cleanPools, "pools", false, "Clean COI containers in unreferenced storage pools")
 	cleanCmd.Flags().BoolVar(&cleanDryRun, "dry-run", false, "Show what would be cleaned without making changes")
 }
@@ -102,7 +102,7 @@ func cleanCommand(cmd *cobra.Command, args []string) error {
 		cleaned += count
 	}
 
-	// Clean orphaned resources (veths and firewall rules)
+	// Clean orphaned resources (veths and nft rules)
 	if cleanAll || cleanOrphans {
 		count, cancelled := cleanOrphanedResources()
 		if cancelled {
@@ -257,7 +257,7 @@ func cleanSavedSessions(sessionsDir string) (int, bool, error) {
 	return cleaned, false, nil
 }
 
-// cleanOrphanedResources finds and removes orphaned veths and firewall rules.
+// cleanOrphanedResources finds and removes orphaned veths and nft rules.
 // Returns (count cleaned, was cancelled).
 func cleanOrphanedResources() (int, bool) {
 	fmt.Println("\nScanning for orphaned resources...")
@@ -307,7 +307,7 @@ func printOrphanedResources(orphans *cleanup.OrphanedResources) {
 	}
 
 	if len(orphans.NftRules) > 0 {
-		fmt.Printf("  Orphaned firewall rules (%d):\n", len(orphans.NftRules))
+		fmt.Printf("  Orphaned nft rules (%d):\n", len(orphans.NftRules))
 		for _, rule := range orphans.NftRules {
 			fmt.Printf("    - %s\n", rule)
 		}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -268,7 +268,7 @@ func cleanOrphanedResources() (int, bool) {
 		return 0, false
 	}
 
-	totalOrphans := len(orphans.Veths) + len(orphans.FirewallRules) + len(orphans.NFTMonitorRules) + len(orphans.IptablesBridgeRules)
+	totalOrphans := len(orphans.Veths) + len(orphans.NftRules) + len(orphans.NFTMonitorRules) + len(orphans.IptablesBridgeRules)
 
 	if totalOrphans == 0 {
 		fmt.Println("  (no orphaned resources found)")
@@ -296,7 +296,7 @@ func cleanOrphanedResources() (int, bool) {
 
 // printOrphanedResources prints the list of orphaned resources found.
 func printOrphanedResources(orphans *cleanup.OrphanedResources) {
-	totalOrphans := len(orphans.Veths) + len(orphans.FirewallRules) + len(orphans.NFTMonitorRules) + len(orphans.IptablesBridgeRules)
+	totalOrphans := len(orphans.Veths) + len(orphans.NftRules) + len(orphans.NFTMonitorRules) + len(orphans.IptablesBridgeRules)
 	fmt.Printf("Found %d orphaned resource(s):\n", totalOrphans)
 
 	if len(orphans.Veths) > 0 {
@@ -306,9 +306,9 @@ func printOrphanedResources(orphans *cleanup.OrphanedResources) {
 		}
 	}
 
-	if len(orphans.FirewallRules) > 0 {
-		fmt.Printf("  Orphaned firewall rules (%d):\n", len(orphans.FirewallRules))
-		for _, rule := range orphans.FirewallRules {
+	if len(orphans.NftRules) > 0 {
+		fmt.Printf("  Orphaned firewall rules (%d):\n", len(orphans.NftRules))
+		for _, rule := range orphans.NftRules {
 			fmt.Printf("    - %s\n", rule)
 		}
 	}
@@ -347,8 +347,8 @@ func doCleanOrphanedResources(orphans *cleanup.OrphanedResources) int {
 		cleaned += vethsCleaned
 	}
 
-	if len(orphans.FirewallRules) > 0 {
-		rulesCleaned, _ := cleanup.CleanupOrphanedFirewallRules(orphans.FirewallRules, logger)
+	if len(orphans.NftRules) > 0 {
+		rulesCleaned, _ := cleanup.CleanupOrphanedNftRules(orphans.NftRules, logger)
 		cleaned += rulesCleaned
 	}
 

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -94,13 +94,13 @@ var containerDeleteCmd = &cobra.Command{
 
 		// Get container IP BEFORE deleting (needed for firewall cleanup)
 		var containerIP string
-		if network.FirewallAvailable() {
+		if network.NftAvailable() {
 			containerIP, _ = network.GetContainerIPFast(name)
 		}
 
 		// Clean up firewall rules BEFORE deleting container
 		if containerIP != "" {
-			fm := network.NewFirewallManager(containerIP, "")
+			fm := network.NewNftManager(containerIP, "")
 			if err := fm.RemoveRules(); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup firewall rules: %v\n", err)
 			}

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -89,7 +89,7 @@ func outputHealthText(result *health.HealthResult) error {
 	categories := map[string][]string{
 		"SYSTEM":        {"os", "kernel_version", "timezone"},
 		"CRITICAL":      {"incus", "permissions", "image", "image_age", "privileged_profile", "security_posture"},
-		"NETWORKING":    {"network_bridge", "ip_forwarding", "firewall", "bridge_firewalld_zone", "docker_forward_policy"},
+		"NETWORKING":    {"network_bridge", "ip_forwarding", "firewall", "bridge_forward_rules", "docker_forward_policy"},
 		"MONITORING":    {"nftables", "systemd_journal", "libsystemd"},
 		"STORAGE":       {"coi_directory", "sessions_directory", "disk_space", "incus_storage_pools"},
 		"CONFIGURATION": {"config", "network_mode", "tool"},
@@ -214,7 +214,7 @@ func formatCheckName(name string) string {
 		"network_bridge":        "Network bridge",
 		"ip_forwarding":         "IP forwarding",
 		"firewall":              "Firewalld",
-		"bridge_firewalld_zone": "Bridge FW zone",
+		"bridge_forward_rules": "Bridge forward",
 		"docker_forward_policy": "Docker FORWARD",
 		"nftables":              "nftables",
 		"systemd_journal":       "systemd journal",

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -214,7 +214,7 @@ func formatCheckName(name string) string {
 		"network_bridge":        "Network bridge",
 		"ip_forwarding":         "IP forwarding",
 		"firewall":              "Firewalld",
-		"bridge_forward_rules": "Bridge forward",
+		"bridge_forward_rules":  "Bridge forward",
 		"docker_forward_policy": "Docker FORWARD",
 		"nftables":              "nftables",
 		"systemd_journal":       "systemd journal",

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -213,7 +213,7 @@ func formatCheckName(name string) string {
 		"privileged_profile":    "Privileged check",
 		"network_bridge":        "Network bridge",
 		"ip_forwarding":         "IP forwarding",
-		"firewall":              "Firewalld",
+		"firewall":              "nft firewall",
 		"bridge_forward_rules":  "Bridge forward",
 		"docker_forward_policy": "Docker FORWARD",
 		"nftables":              "nftables",

--- a/internal/cli/kill.go
+++ b/internal/cli/kill.go
@@ -143,11 +143,11 @@ func killCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Clean up firewall rules BEFORE deleting container
+		// Clean up nft rules BEFORE deleting container
 		// This ensures we remove any rules that were created for this container
 		if containerIP != "" {
 			if err := cleanupNftRulesForIP(containerIP); err != nil {
-				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup firewall rules: %v\n", err)
+				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup nft rules: %v\n", err)
 			}
 			// Also clean up NFT monitoring rules for this IP
 			if err := cleanupNftMonitoringRulesForIP(containerIP); err != nil {

--- a/internal/cli/kill.go
+++ b/internal/cli/kill.go
@@ -131,7 +131,7 @@ func killCommand(cmd *cobra.Command, args []string) error {
 
 		// Get container IP BEFORE stopping/deleting (needed for firewall cleanup)
 		var containerIP string
-		if network.FirewallAvailable() {
+		if network.NftAvailable() {
 			containerIP, _ = network.GetContainerIPFast(name)
 		}
 
@@ -146,11 +146,11 @@ func killCommand(cmd *cobra.Command, args []string) error {
 		// Clean up firewall rules BEFORE deleting container
 		// This ensures we remove any rules that were created for this container
 		if containerIP != "" {
-			if err := cleanupFirewallRulesForIP(containerIP); err != nil {
+			if err := cleanupNftRulesForIP(containerIP); err != nil {
 				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup firewall rules: %v\n", err)
 			}
 			// Also clean up NFT monitoring rules for this IP
-			if err := cleanupNFTMonitoringRulesForIP(containerIP); err != nil {
+			if err := cleanupNftMonitoringRulesForIP(containerIP); err != nil {
 				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup NFT monitoring rules: %v\n", err)
 			}
 		}
@@ -177,18 +177,18 @@ func killCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// cleanupFirewallRulesForIP removes any firewall rules associated with a container IP
-func cleanupFirewallRulesForIP(containerIP string) error {
+// cleanupNftRulesForIP removes any nft rules associated with a container IP
+func cleanupNftRulesForIP(containerIP string) error {
 	if containerIP == "" {
 		return nil
 	}
 
 	// Create a temporary firewall manager to remove rules for this IP
-	fm := network.NewFirewallManager(containerIP, "")
+	fm := network.NewNftManager(containerIP, "")
 	return fm.RemoveRules()
 }
 
-// cleanupNFTMonitoringRulesForIP removes any NFT monitoring rules for a container IP
-func cleanupNFTMonitoringRulesForIP(containerIP string) error {
+// cleanupNftMonitoringRulesForIP removes any NFT monitoring rules for a container IP
+func cleanupNftMonitoringRulesForIP(containerIP string) error {
 	return network.CleanupNFTMonitoringRules(containerIP)
 }

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -109,10 +109,10 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Clean up firewall rules BEFORE deleting container
+		// Clean up nft rules BEFORE deleting container
 		if containerIP != "" {
 			if err := cleanupNftRulesForIP(containerIP); err != nil {
-				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup firewall rules: %v\n", err)
+				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup nft rules: %v\n", err)
 			}
 			// Also clean up NFT monitoring rules for this IP
 			if err := cleanupNftMonitoringRulesForIP(containerIP); err != nil {

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -69,7 +69,7 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 
 		// Get container IP BEFORE stopping/deleting (needed for firewall cleanup)
 		var containerIP string
-		if network.FirewallAvailable() {
+		if network.NftAvailable() {
 			containerIP, _ = network.GetContainerIPFast(name)
 		}
 
@@ -111,11 +111,11 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 
 		// Clean up firewall rules BEFORE deleting container
 		if containerIP != "" {
-			if err := cleanupFirewallRulesForIP(containerIP); err != nil {
+			if err := cleanupNftRulesForIP(containerIP); err != nil {
 				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup firewall rules: %v\n", err)
 			}
 			// Also clean up NFT monitoring rules for this IP
-			if err := cleanupNFTMonitoringRulesForIP(containerIP); err != nil {
+			if err := cleanupNftMonitoringRulesForIP(containerIP); err != nil {
 				fmt.Fprintf(os.Stderr, "  Warning: Failed to cleanup NFT monitoring rules: %v\n", err)
 			}
 		}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -397,8 +397,8 @@ func CheckIPForwarding() HealthCheck {
 
 // CheckFirewall verifies nft availability and masquerade configuration
 func CheckFirewall(mode config.NetworkMode) HealthCheck {
-	installed := network.FirewallInstalled()
-	available := network.FirewallAvailable()
+	installed := network.NftInstalled()
+	available := network.NftAvailable()
 	masquerade := network.MasqueradeEnabled()
 	isColima := isColimaEnvironment()
 
@@ -502,13 +502,13 @@ func CheckUFWConflict() HealthCheck {
 	}
 }
 
-// CheckBridgeFirewalldZone checks whether the Incus bridge has iptables FORWARD
+// CheckBridgeForwardRules checks whether the Incus bridge has iptables FORWARD
 // ACCEPT rules so containers can get IPs via DHCP even when FORWARD policy is DROP.
-func CheckBridgeFirewalldZone() HealthCheck {
+func CheckBridgeForwardRules() HealthCheck {
 	hasRules, bridgeName, err := network.BridgeInTrustedZone()
 	if err != nil {
 		return HealthCheck{
-			Name:    "bridge_firewalld_zone",
+			Name:    "bridge_forward_rules",
 			Status:  StatusWarning,
 			Message: fmt.Sprintf("Could not check bridge forwarding rules: %v", err),
 		}
@@ -521,7 +521,7 @@ func CheckBridgeFirewalldZone() HealthCheck {
 
 	if !hasRules {
 		return HealthCheck{
-			Name:    "bridge_firewalld_zone",
+			Name:    "bridge_forward_rules",
 			Status:  StatusWarning,
 			Message: fmt.Sprintf("Bridge %s has no iptables FORWARD rules — containers may fail to get IPs if FORWARD policy is DROP (rules are added automatically on first container start)", bridgeName),
 			Details: details,
@@ -529,7 +529,7 @@ func CheckBridgeFirewalldZone() HealthCheck {
 	}
 
 	return HealthCheck{
-		Name:    "bridge_firewalld_zone",
+		Name:    "bridge_forward_rules",
 		Status:  StatusOK,
 		Message: fmt.Sprintf("Bridge %s has iptables FORWARD rules", bridgeName),
 		Details: details,
@@ -859,7 +859,7 @@ func CheckContainerConnectivity(imageName string) HealthCheck {
 	var usedIptablesFallback bool
 	var iptablesBridgeName string
 
-	if network.FirewallAvailable() {
+	if network.NftAvailable() {
 		if err := network.EnsureOpenModeRules(containerIP); err != nil {
 			return HealthCheck{
 				Name:    "container_connectivity",
@@ -891,7 +891,7 @@ func CheckContainerConnectivity(imageName string) HealthCheck {
 	defer func() {
 		if usedIptablesFallback {
 			_ = network.RemoveIptablesBridgeRules(iptablesBridgeName)
-		} else if network.FirewallAvailable() {
+		} else if network.NftAvailable() {
 			_ = network.RemoveOpenModeRules(containerIP)
 		}
 	}()
@@ -973,7 +973,7 @@ func CheckContainerConnectivity(imageName string) HealthCheck {
 // CheckNetworkRestriction tests that restricted network mode properly blocks private networks
 func CheckNetworkRestriction(imageName string) HealthCheck {
 	// Skip if firewall not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		return HealthCheck{
 			Name:    "network_restriction",
 			Status:  StatusWarning,
@@ -1009,7 +1009,7 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 	}
 
 	// Track if we applied firewall rules (for cleanup)
-	var firewallManager *network.FirewallManager
+	var firewallManager *network.NftManager
 
 	// Ensure cleanup on any exit path
 	defer func() {
@@ -1079,7 +1079,7 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 	}
 
 	// Apply restricted mode firewall rules
-	firewallManager = network.NewFirewallManager(containerIP, gatewayIP)
+	firewallManager = network.NewNftManager(containerIP, gatewayIP)
 	boolTrue := true
 	restrictedConfig := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
@@ -1633,7 +1633,7 @@ func CheckOrphanedResources() HealthCheck {
 
 	// Check for orphaned firewall rules
 	orphanedRules := 0
-	if network.FirewallAvailable() {
+	if network.NftAvailable() {
 		// Get running container IPs
 		containerIPs := make(map[string]bool)
 		output, err := container.IncusOutput("list", "--format=json")
@@ -2193,7 +2193,7 @@ func CheckMonitoringConfiguration(cfg *config.Config) HealthCheck {
 func CheckDockerForwardPolicy() HealthCheck {
 	dockerRunning := network.IsDockerRunning()
 	forwardDrop := network.ForwardPolicyIsDrop()
-	firewallAvailable := network.FirewallAvailable()
+	firewallAvailable := network.NftAvailable()
 	iptablesAvailable := network.IptablesAvailable()
 
 	details := map[string]interface{}{

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -438,8 +438,8 @@ func TestCheckContainerConnectivity_Cleanup(t *testing.T) {
 // CheckFirewall should return a details map containing nft_installed, nft_available, and masquerade
 // booleans, and the status should reflect the actual firewall state.
 func TestCheckFirewall_DetailedStatus(t *testing.T) {
-	installed := network.FirewallInstalled()
-	available := network.FirewallAvailable()
+	installed := network.NftInstalled()
+	available := network.NftAvailable()
 	masquerade := network.MasqueradeEnabled()
 
 	modes := []config.NetworkMode{
@@ -525,7 +525,7 @@ func TestCheckNetworkRestriction_NoFirewall(t *testing.T) {
 	}
 
 	// This test only makes sense if firewall is NOT available
-	if network.FirewallAvailable() {
+	if network.NftAvailable() {
 		t.Skip("nft is available, cannot test no-firewall scenario")
 	}
 
@@ -560,7 +560,7 @@ func TestCheckNetworkRestriction_NoImage(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -597,7 +597,7 @@ func TestCheckNetworkRestriction_WithImage(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -657,7 +657,7 @@ func TestCheckNetworkRestriction_Cleanup(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -70,7 +70,7 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	checks["network_bridge"] = CheckNetworkBridge()
 	checks["ip_forwarding"] = CheckIPForwarding()
 	checks["firewall"] = CheckFirewall(cfg.Network.Mode)
-	checks["bridge_firewalld_zone"] = CheckBridgeFirewalldZone()
+	checks["bridge_forward_rules"] = CheckBridgeForwardRules()
 	checks["docker_forward_policy"] = CheckDockerForwardPolicy()
 	checks["ufw_conflict"] = CheckUFWConflict()
 

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -168,7 +168,7 @@ func (b *Builder) launchBuildContainer() error {
 
 	// Setup open mode firewall rules for build container
 	// This is needed when FORWARD chain policy is DROP (common with Docker)
-	if network.FirewallAvailable() {
+	if network.NftAvailable() {
 		containerIP, err := network.GetContainerIP(b.mgr.ContainerName)
 		if err != nil {
 			b.opts.Logger(fmt.Sprintf("Warning: could not get container IP for firewall rules: %v", err))

--- a/internal/monitor/responder.go
+++ b/internal/monitor/responder.go
@@ -217,7 +217,7 @@ func (r *Responder) killContainer(ctx context.Context) error {
 	if containerIP != "" {
 		if err := r.cleanupNftRules(containerIP); err != nil {
 			// Log warning but don't fail the kill operation
-			fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup firewall rules: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup nft rules: %v\n", err)
 		}
 		if err := r.cleanupNFTRules(containerIP); err != nil {
 			// Log warning but don't fail the kill operation

--- a/internal/monitor/responder.go
+++ b/internal/monitor/responder.go
@@ -215,7 +215,7 @@ func (r *Responder) killContainer(ctx context.Context) error {
 
 	// Clean up firewall and NFT monitoring rules BEFORE deleting container
 	if containerIP != "" {
-		if err := r.cleanupFirewallRules(containerIP); err != nil {
+		if err := r.cleanupNftRules(containerIP); err != nil {
 			// Log warning but don't fail the kill operation
 			fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup firewall rules: %v\n", err)
 		}
@@ -237,9 +237,9 @@ func (r *Responder) killContainer(ctx context.Context) error {
 	return nil
 }
 
-// cleanupFirewallRules removes firewall rules for a container IP
-func (r *Responder) cleanupFirewallRules(containerIP string) error {
-	fm := network.NewFirewallManager(containerIP, "")
+// cleanupNftRules removes nft rules for a container IP
+func (r *Responder) cleanupNftRules(containerIP string) error {
+	fm := network.NewNftManager(containerIP, "")
 	return fm.RemoveRules()
 }
 

--- a/internal/network/firewall_cleanup_integration_test.go
+++ b/internal/network/firewall_cleanup_integration_test.go
@@ -51,7 +51,7 @@ func TestOpenModeFirewallCleanup(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -145,7 +145,7 @@ func TestRestrictedModeFirewallCleanup(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -243,7 +243,7 @@ func TestFirewallCleanupBeforeContainerDeletion(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -349,7 +349,7 @@ func TestFirewallCleanupCorrectOrder(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 

--- a/internal/network/firewall_integration_test.go
+++ b/internal/network/firewall_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// FirewallAvailable should return true when nft is installed and passwordless sudo works.
+// NftAvailable should return true when nft is installed and passwordless sudo works.
 func TestNftAvailable_Integration(t *testing.T) {
 	_, lookPathErr := exec.LookPath("nft")
 	installed := lookPathErr == nil
@@ -27,10 +27,10 @@ func TestNftAvailable_Integration(t *testing.T) {
 		t.Errorf("NftAvailable() = %v, but sudo nft list tables returned %v", result, sudoOK)
 	}
 
-	t.Logf("FirewallAvailable: installed=%v sudoOK=%v result=%v", installed, sudoOK, result)
+	t.Logf("NftAvailable: installed=%v sudoOK=%v result=%v", installed, sudoOK, result)
 }
 
-// FirewallInstalled should return true when the nft binary exists on PATH.
+// NftInstalled should return true when the nft binary exists on PATH.
 func TestNftInstalled_Integration(t *testing.T) {
 	_, lookPathErr := exec.LookPath("nft")
 	expected := lookPathErr == nil
@@ -40,7 +40,7 @@ func TestNftInstalled_Integration(t *testing.T) {
 		t.Errorf("NftInstalled() = %v, but exec.LookPath(\"nft\") says %v", result, expected)
 	}
 
-	t.Logf("FirewallInstalled: %v", result)
+	t.Logf("NftInstalled: %v", result)
 }
 
 // MasqueradeEnabled should return true when the Incus bridge has ipv4.nat=true.

--- a/internal/network/firewall_integration_test.go
+++ b/internal/network/firewall_integration_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 // FirewallAvailable should return true when nft is installed and passwordless sudo works.
-func TestFirewallAvailable_Integration(t *testing.T) {
+func TestNftAvailable_Integration(t *testing.T) {
 	_, lookPathErr := exec.LookPath("nft")
 	installed := lookPathErr == nil
 
 	if !installed {
-		t.Log("nft not installed — expecting FirewallAvailable() == false")
-		if FirewallAvailable() {
-			t.Error("FirewallAvailable() returned true but nft is not installed")
+		t.Log("nft not installed — expecting NftAvailable() == false")
+		if NftAvailable() {
+			t.Error("NftAvailable() returned true but nft is not installed")
 		}
 		return
 	}
@@ -22,22 +22,22 @@ func TestFirewallAvailable_Integration(t *testing.T) {
 	cmd := exec.Command("sudo", "-n", "nft", "list", "tables")
 	sudoOK := cmd.Run() == nil
 
-	result := FirewallAvailable()
+	result := NftAvailable()
 	if result != sudoOK {
-		t.Errorf("FirewallAvailable() = %v, but sudo nft list tables returned %v", result, sudoOK)
+		t.Errorf("NftAvailable() = %v, but sudo nft list tables returned %v", result, sudoOK)
 	}
 
 	t.Logf("FirewallAvailable: installed=%v sudoOK=%v result=%v", installed, sudoOK, result)
 }
 
 // FirewallInstalled should return true when the nft binary exists on PATH.
-func TestFirewallInstalled_Integration(t *testing.T) {
+func TestNftInstalled_Integration(t *testing.T) {
 	_, lookPathErr := exec.LookPath("nft")
 	expected := lookPathErr == nil
 
-	result := FirewallInstalled()
+	result := NftInstalled()
 	if result != expected {
-		t.Errorf("FirewallInstalled() = %v, but exec.LookPath(\"nft\") says %v", result, expected)
+		t.Errorf("NftInstalled() = %v, but exec.LookPath(\"nft\") says %v", result, expected)
 	}
 
 	t.Logf("FirewallInstalled: %v", result)

--- a/internal/network/firewall_iptables_integration_test.go
+++ b/internal/network/firewall_iptables_integration_test.go
@@ -118,7 +118,7 @@ func TestEnsureAndRemoveIptablesBridgeRules(t *testing.T) {
 // TestNeedsIptablesFallback verifies the boolean logic.
 func TestNeedsIptablesFallback(t *testing.T) {
 	result := NeedsIptablesFallback()
-	t.Logf("NeedsIptablesFallback: %v (firewall=%v, forwardDrop=%v, iptables=%v)",
+	t.Logf("NeedsIptablesFallback: %v (nft=%v, forwardDrop=%v, iptables=%v)",
 		result, NftAvailable(), ForwardPolicyIsDrop(), IptablesAvailable())
 }
 

--- a/internal/network/firewall_iptables_integration_test.go
+++ b/internal/network/firewall_iptables_integration_test.go
@@ -119,7 +119,7 @@ func TestEnsureAndRemoveIptablesBridgeRules(t *testing.T) {
 func TestNeedsIptablesFallback(t *testing.T) {
 	result := NeedsIptablesFallback()
 	t.Logf("NeedsIptablesFallback: %v (firewall=%v, forwardDrop=%v, iptables=%v)",
-		result, FirewallAvailable(), ForwardPolicyIsDrop(), IptablesAvailable())
+		result, NftAvailable(), ForwardPolicyIsDrop(), IptablesAvailable())
 }
 
 // TestIptablesBridgeRulesExist verifies detection works when no rules are present.

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -35,7 +35,7 @@ config.toml):
 // Manager provides high-level network isolation management for containers
 type Manager struct {
 	config        *config.NetworkConfig
-	firewall      *FirewallManager
+	firewall      *NftManager
 	resolver      *Resolver
 	cacheManager  *CacheManager
 	containerName string
@@ -73,14 +73,14 @@ func (m *Manager) SetupForContainer(ctx context.Context, containerName string) e
 	case config.NetworkModeOpen:
 		m.logger.Println("Network mode: open (no restrictions)")
 		// Add ACCEPT rules via nft so traffic flows even when FORWARD policy is DROP
-		if FirewallAvailable() {
+		if NftAvailable() {
 			containerIP, err := GetContainerIP(containerName)
 			if err != nil {
 				m.logger.Errorf("Warning: could not get container IP for open mode rules: %v", err)
 				return nil
 			}
 			m.containerIP = containerIP
-			m.firewall = NewFirewallManager(containerIP, "")
+			m.firewall = NewNftManager(containerIP, "")
 			if err := EnsureOpenModeRules(containerIP); err != nil {
 				m.logger.Errorf("Warning: could not add open mode rules: %v", err)
 			}
@@ -115,7 +115,7 @@ func (m *Manager) setupRestricted(ctx context.Context, containerName string) err
 	m.logger.Println("Network mode: restricted (blocking local/internal networks)")
 
 	// Check if nft is available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		return fmt.Errorf("%s", errFirewallNotAvailable)
 	}
 
@@ -141,7 +141,7 @@ func (m *Manager) setupRestricted(ctx context.Context, containerName string) err
 	}
 
 	// Create firewall manager
-	m.firewall = NewFirewallManager(containerIP, gatewayIP)
+	m.firewall = NewNftManager(containerIP, gatewayIP)
 
 	// Apply restricted mode rules
 	if err := m.firewall.ApplyRestricted(m.config); err != nil {
@@ -166,7 +166,7 @@ func (m *Manager) setupAllowlist(ctx context.Context, containerName string) erro
 	m.logger.Println("Network mode: allowlist (domain-based filtering)")
 
 	// Check if nft is available
-	if !FirewallAvailable() {
+	if !NftAvailable() {
 		return fmt.Errorf("%s", errFirewallNotAvailable)
 	}
 
@@ -197,7 +197,7 @@ func (m *Manager) setupAllowlist(ctx context.Context, containerName string) erro
 	}
 
 	// Create firewall manager
-	m.firewall = NewFirewallManager(containerIP, gatewayIP)
+	m.firewall = NewNftManager(containerIP, gatewayIP)
 
 	// Load IP cache
 	cache, err := m.cacheManager.Load(containerName)
@@ -433,7 +433,7 @@ func (m *Manager) Teardown(ctx context.Context, containerName string) error {
 
 	// For open mode, also clean up nft ACCEPT rules created by EnsureOpenModeRules()
 	if m.config.Mode == config.NetworkModeOpen {
-		if !FirewallAvailable() && m.iptablesBridgeName == "" {
+		if !NftAvailable() && m.iptablesBridgeName == "" {
 			return nil // No nft and no iptables fallback, no rules to clean up
 		}
 
@@ -449,7 +449,7 @@ func (m *Manager) Teardown(ctx context.Context, containerName string) error {
 
 		// Create firewall manager if not already created
 		if m.firewall == nil {
-			m.firewall = NewFirewallManager(m.containerIP, "")
+			m.firewall = NewNftManager(m.containerIP, "")
 		}
 	}
 

--- a/internal/network/nft_filter.go
+++ b/internal/network/nft_filter.go
@@ -13,24 +13,24 @@ import (
 	"github.com/mensfeld/code-on-incus/internal/container"
 )
 
-// FirewallManager manages nftables rules for container network isolation.
+// NftManager manages nftables rules for container network isolation.
 // Rules live in the dedicated "ip coi" table, forward chain, keeping COI
 // rules isolated from Docker, ufw, and other tools.
-type FirewallManager struct {
+type NftManager struct {
 	containerIP string
 	gatewayIP   string
 }
 
-// NewFirewallManager creates a new firewall manager for a container
-func NewFirewallManager(containerIP, gatewayIP string) *FirewallManager {
-	return &FirewallManager{
+// NewNftManager creates a new nft manager for a container
+func NewNftManager(containerIP, gatewayIP string) *NftManager {
+	return &NftManager{
 		containerIP: containerIP,
 		gatewayIP:   gatewayIP,
 	}
 }
 
 // ApplyRestricted applies restricted mode rules (block RFC1918, allow internet)
-func (f *FirewallManager) ApplyRestricted(cfg *config.NetworkConfig) error {
+func (f *NftManager) ApplyRestricted(cfg *config.NetworkConfig) error {
 	if err := EnsureBaseRules(); err != nil {
 		log.Printf("Warning: failed to ensure base rules: %v", err)
 	}
@@ -70,7 +70,7 @@ func (f *FirewallManager) ApplyRestricted(cfg *config.NetworkConfig) error {
 }
 
 // ApplyAllowlist applies allowlist mode rules (allow specific IPs, block all else)
-func (f *FirewallManager) ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error {
+func (f *NftManager) ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error {
 	if err := EnsureBaseRules(); err != nil {
 		log.Printf("Warning: failed to ensure base rules: %v", err)
 	}
@@ -121,7 +121,7 @@ func (f *FirewallManager) ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs [
 }
 
 // RemoveRules removes all nftables rules for this container's IP
-func (f *FirewallManager) RemoveRules() error {
+func (f *NftManager) RemoveRules() error {
 	if f.containerIP == "" {
 		return nil
 	}
@@ -185,7 +185,7 @@ func DisableIPv6ForContainer(containerName string) error {
 // addRule appends a nftables rule to ip coi forward for this container.
 // Rules are appended in call order, so callers must invoke addRule from most-specific
 // to least-specific (gateway → allowlist → RFC1918 block → default).
-func (f *FirewallManager) addRule(source, destination, action string) error {
+func (f *NftManager) addRule(source, destination, action string) error {
 	args := []string{
 		"add", "rule", "ip", "coi", "forward",
 		"ip", "saddr", source,
@@ -360,14 +360,14 @@ func getContainerIPOnce(containerName string) (string, error) {
 	return "", fmt.Errorf("no IPv4 address found for container %s", containerName)
 }
 
-// FirewallInstalled checks if the nft binary is installed
-func FirewallInstalled() bool {
+// NftInstalled checks if the nft binary is installed
+func NftInstalled() bool {
 	_, err := exec.LookPath("nft")
 	return err == nil
 }
 
-// FirewallAvailable checks if nft is available and passwordless sudo is configured
-func FirewallAvailable() bool {
+// NftAvailable checks if nft is available and passwordless sudo is configured
+func NftAvailable() bool {
 	cmd := exec.Command("sudo", "-n", "nft", "list", "tables")
 	return cmd.Run() == nil
 }
@@ -391,7 +391,7 @@ func UfwActive() bool {
 }
 
 // MasqueradeEnabled checks if the Incus bridge has NAT (masquerade) enabled.
-// Incus manages masquerade natively via its bridge config; no firewalld needed.
+// Incus manages masquerade natively via its bridge config; no extra firewall daemon needed.
 // ipv4.nat defaults to true for Incus-managed bridges; an unset/empty value
 // means the default (enabled), so only an explicit "false" means disabled.
 func MasqueradeEnabled() bool {
@@ -408,7 +408,7 @@ func MasqueradeEnabled() bool {
 }
 
 // BridgeInTrustedZone checks whether the Incus bridge has iptables FORWARD ACCEPT
-// rules in place (the nft-era replacement for firewalld trusted-zone membership).
+// rules in place (the nft-based replacement for iptables bridge forwarding rules).
 // Returns (inZone, bridgeName, error).
 func BridgeInTrustedZone() (bool, string, error) {
 	bridgeName, err := GetIncusBridgeName()
@@ -455,10 +455,10 @@ func ForwardPolicyIsDrop() bool {
 	return strings.Contains(lines[0], "policy DROP")
 }
 
-// NeedsIptablesFallback returns true when firewalld is not available but
+// NeedsIptablesFallback returns true when nft is not available but
 // the FORWARD chain policy is DROP and iptables is available as a fallback
 func NeedsIptablesFallback() bool {
-	return !FirewallAvailable() && ForwardPolicyIsDrop() && IptablesAvailable()
+	return !NftAvailable() && ForwardPolicyIsDrop() && IptablesAvailable()
 }
 
 // GetIncusBridgeName extracts the bridge/network name from the Incus default profile

--- a/internal/session/cleanup_integration_test.go
+++ b/internal/session/cleanup_integration_test.go
@@ -48,7 +48,7 @@ func TestEndToEndCleanupWithOpenMode(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -182,7 +182,7 @@ func TestEndToEndCleanupWithRestrictedMode(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 
@@ -308,7 +308,7 @@ func TestEndToEndCleanupMultipleContainers(t *testing.T) {
 	}
 
 	// Skip if firewall is not available
-	if !network.FirewallAvailable() {
+	if !network.NftAvailable() {
 		t.Skip("nft not available, skipping integration test")
 	}
 

--- a/tests/health/health_bridge_firewalld_zone.py
+++ b/tests/health/health_bridge_firewalld_zone.py
@@ -1,16 +1,16 @@
 """
-Test for coi health - bridge firewalld zone check (now backed by iptables rules).
+Test for coi health - bridge forward rules check (backed by iptables rules).
 
 Tests that:
-1. The bridge_firewalld_zone check exists in health output
+1. The bridge_forward_rules check exists in health output
 2. When iptables bridge FORWARD rules (tagged coi-bridge-forward) are present,
    check is OK
 3. When the rules are absent, check warns
 4. Check appears in text output under NETWORKING section
 
-The Go functions BridgeInTrustedZone / EnsureBridgeInTrustedZone now check
-iptables FORWARD rules tagged with the comment `coi-bridge-forward` rather
-than firewalld zones.  The health check key is still `bridge_firewalld_zone`.
+The Go functions BridgeInTrustedZone / EnsureBridgeInTrustedZone check
+iptables FORWARD rules tagged with the comment `coi-bridge-forward`.
+The health check key is `bridge_forward_rules`.
 Masquerade / NAT is handled by Incus (`ipv4.nat=true` on the bridge), so no
 firewalld presence is required.
 """
@@ -67,13 +67,13 @@ def bridge_has_forward_rules(bridge_name):
         return False
 
 
-def test_health_bridge_firewalld_zone_check_exists(coi_binary):
+def test_health_bridge_forward_rules_check_exists(coi_binary):
     """
-    Verify bridge_firewalld_zone check appears in health JSON output.
+    Verify bridge_forward_rules check appears in health JSON output.
 
     Flow:
     1. Run coi health --format json
-    2. Parse JSON, verify bridge_firewalld_zone key exists
+    2. Parse JSON, verify bridge_forward_rules key exists
     3. Verify it has required fields
     """
     result = subprocess.run(
@@ -90,23 +90,23 @@ def test_health_bridge_firewalld_zone_check_exists(coi_binary):
     data = json.loads(result.stdout)
     checks = data["checks"]
 
-    assert "bridge_firewalld_zone" in checks, "Should have bridge_firewalld_zone check"
+    assert "bridge_forward_rules" in checks, "Should have bridge_forward_rules check"
 
-    check = checks["bridge_firewalld_zone"]
+    check = checks["bridge_forward_rules"]
     assert "name" in check, "Check should have 'name' field"
     assert "status" in check, "Check should have 'status' field"
     assert "message" in check, "Check should have 'message' field"
     assert check["status"] in ["ok", "warning", "failed"], f"Invalid status: {check['status']}"
 
 
-def test_health_bridge_firewalld_zone_ok_when_configured(coi_binary):
+def test_health_bridge_forward_rules_ok_when_configured(coi_binary):
     """
     When iptables coi-bridge-forward rules are present, check reports OK.
 
     Flow:
     1. Skip if iptables not available or bridge rules not present
     2. Run coi health --format json
-    3. Verify bridge_firewalld_zone check is OK with correct details
+    3. Verify bridge_forward_rules check is OK with correct details
     """
     import pytest
 
@@ -125,7 +125,7 @@ def test_health_bridge_firewalld_zone_ok_when_configured(coi_binary):
     )
 
     data = json.loads(result.stdout)
-    check = data["checks"]["bridge_firewalld_zone"]
+    check = data["checks"]["bridge_forward_rules"]
 
     assert check["status"] == "ok", (
         f"Expected OK when bridge FORWARD rules are present, got: {check['status']} - {check['message']}"
@@ -139,14 +139,14 @@ def test_health_bridge_firewalld_zone_ok_when_configured(coi_binary):
     )
 
 
-def test_health_bridge_firewalld_zone_ok_without_firewalld(coi_binary):
+def test_health_bridge_forward_rules_ok_without_firewalld(coi_binary):
     """
-    When firewalld is not running (the normal nftables case), bridge zone check
+    When firewalld is not running (the normal nftables case), bridge forward rules check
     is OK as long as iptables coi-bridge-forward rules are present.
 
     Flow:
     1. Run coi health --format json
-    2. Verify bridge_firewalld_zone check returns ok or warning (not failed/error)
+    2. Verify bridge_forward_rules check returns ok or warning (not failed/error)
     3. Verify message is meaningful
     """
     result = subprocess.run(
@@ -157,7 +157,7 @@ def test_health_bridge_firewalld_zone_ok_without_firewalld(coi_binary):
     )
 
     data = json.loads(result.stdout)
-    check = data["checks"]["bridge_firewalld_zone"]
+    check = data["checks"]["bridge_forward_rules"]
 
     # Without firewalld, the check relies on iptables rules.
     # Status is ok if rules exist, warning if not — both are valid non-error states.
@@ -167,13 +167,13 @@ def test_health_bridge_firewalld_zone_ok_without_firewalld(coi_binary):
     assert check["message"], "Check should have a non-empty message"
 
 
-def test_health_bridge_firewalld_zone_text_output(coi_binary):
+def test_health_bridge_forward_rules_text_output(coi_binary):
     """
-    Verify bridge zone check appears in text health output under NETWORKING.
+    Verify bridge forward rules check appears in text health output under NETWORKING.
 
     Flow:
     1. Run coi health (text format)
-    2. Verify 'Bridge FW zone' appears in output
+    2. Verify 'Bridge forward' appears in output
     """
     result = subprocess.run(
         [coi_binary, "health"],
@@ -187,6 +187,6 @@ def test_health_bridge_firewalld_zone_text_output(coi_binary):
     )
 
     output = result.stdout
-    assert "Bridge FW zone" in output, (
-        f"Should show 'Bridge FW zone' in text output. Got:\n{output}"
+    assert "Bridge forward" in output, (
+        f"Should show 'Bridge forward' in text output. Got:\n{output}"
     )

--- a/tests/network/test_bridge_trusted_zone.py
+++ b/tests/network/test_bridge_trusted_zone.py
@@ -10,7 +10,7 @@ Tests that:
 
 The Go functions BridgeInTrustedZone / EnsureBridgeInTrustedZone now check
 iptables FORWARD rules tagged with the comment `coi-bridge-forward` rather
-than firewalld zones.  The health check key is still `bridge_firewalld_zone`.
+than firewalld zones.  The health check key is `bridge_forward_rules`.
 
 Masquerade / NAT is handled by Incus itself (`ipv4.nat=true` on the bridge),
 so no firewalld setup is required.
@@ -112,7 +112,7 @@ def remove_bridge_forward_rules(bridge_name):
 
 
 def get_health_bridge_check(coi_binary):
-    """Run coi health and return the bridge_firewalld_zone check."""
+    """Run coi health and return the bridge_forward_rules check."""
     result = subprocess.run(
         [coi_binary, "health", "--format", "json"],
         capture_output=True,
@@ -120,7 +120,7 @@ def get_health_bridge_check(coi_binary):
         timeout=120,
     )
     data = json.loads(result.stdout)
-    return data["checks"].get("bridge_firewalld_zone")
+    return data["checks"].get("bridge_forward_rules")
 
 
 def test_bridge_trusted_zone_detection_matches_reality(coi_binary):
@@ -130,7 +130,7 @@ def test_bridge_trusted_zone_detection_matches_reality(coi_binary):
     Flow:
     1. Skip if iptables not available
     2. Check actual bridge FORWARD rule state via iptables -S FORWARD
-    3. Run coi health and get bridge_firewalld_zone check
+    3. Run coi health and get bridge_forward_rules check
     4. Verify the check details match the actual state
     """
     import pytest
@@ -142,7 +142,7 @@ def test_bridge_trusted_zone_detection_matches_reality(coi_binary):
     actual_has_rules = bridge_has_forward_rules(bridge_name)
 
     check = get_health_bridge_check(coi_binary)
-    assert check is not None, "bridge_firewalld_zone check should exist"
+    assert check is not None, "bridge_forward_rules check should exist"
     assert "details" in check, "Check should have details"
     assert check["details"]["has_forward_rules"] == actual_has_rules, (
         f"Health check reports has_forward_rules={check['details']['has_forward_rules']} "
@@ -193,7 +193,7 @@ def test_bridge_zone_removal_and_restore_detected(coi_binary):
 
         # Verify health check detects removal
         check = get_health_bridge_check(coi_binary)
-        assert check is not None, "bridge_firewalld_zone check should exist"
+        assert check is not None, "bridge_forward_rules check should exist"
         assert check["status"] == "warning", (
             f"Expected warning after removing bridge FORWARD rules, got: {check['status']}"
         )
@@ -206,7 +206,7 @@ def test_bridge_zone_removal_and_restore_detected(coi_binary):
         # We trigger it by running a container command or waiting for autofix.
         # For simplicity, verify the check status reflects the current state.
         check_after = get_health_bridge_check(coi_binary)
-        assert check_after is not None, "bridge_firewalld_zone check should exist"
+        assert check_after is not None, "bridge_forward_rules check should exist"
         assert check_after["status"] in ("ok", "warning"), (
             f"Expected ok or warning after checking bridge rules, got: {check_after['status']}"
         )


### PR DESCRIPTION
## Summary

- Renames all remaining `firewalld`-era identifiers after the firewalld→nftables migration
- Health check JSON key `bridge_firewalld_zone` renamed to `bridge_forward_rules`
- Go types/functions cleaned up: `FirewallManager`/`NewFirewallManager` → `NftManager`/`NewNftManager`; `FirewallAvailable`/`FirewallInstalled` → `NftAvailable`/`NftInstalled`
- Orphan helpers: `DetectOrphanedFirewallRules`/`CleanupOrphanedFirewallRules` → `DetectOrphanedNftRules`/`CleanupOrphanedNftRules`; struct field `OrphanedResources.FirewallRules` → `NftRules`
- Source file `internal/network/firewall.go` → `internal/network/nft_filter.go`
- Stale firewalld references in README.md updated to nftables terminology

## Breaking Change

**`coi health --format json` consumers** that check `checks["bridge_firewalld_zone"]` must update to `checks["bridge_forward_rules"]`. All other changes are internal Go renames with no external API surface.

## Test plan

- [ ] `go build ./...` compiles clean (verified in PR)
- [ ] `ruff check tests/ && ruff format --check tests/` passes (verified in PR)
- [ ] Run `coi health --format json` and confirm the key is `bridge_forward_rules`
- [ ] Run `coi health` (text) and confirm `Bridge forward` label appears in NETWORKING section
- [ ] Run `coi clean --orphans` to exercise the renamed orphan helpers