### PR TITLE
refactor: rename remaining legacy firewall identifiers to nft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+- [Refactor] **Renamed remaining legacy firewall identifiers to nft** — Continued nft naming cleanup: health check key `firewall` → `nft`; `CheckFirewall()` → `CheckNft()`; `orphaned_firewall_rules` JSON detail key → `orphaned_nft_rules`; `errFirewallNotAvailable` → `errNftNotAvailable`. Breaking changes: `coi health --format json` consumers checking `checks.firewall` must update to `checks.nft`; `orphaned_firewall_rules` detail key renamed to `orphaned_nft_rules`.
+
 - [Refactor] **Renamed legacy firewalld identifiers to nft** — Cleaned up all remaining `firewalld`-era naming after the firewalld→nftables migration: health check key `bridge_firewalld_zone` → `bridge_forward_rules`; Go function `CheckBridgeFirewalldZone` → `CheckBridgeForwardRules`; `FirewallManager`/`NewFirewallManager` → `NftManager`/`NewNftManager`; `FirewallAvailable`/`FirewallInstalled` → `NftAvailable`/`NftInstalled`; orphan helpers `DetectOrphanedFirewallRules`/`CleanupOrphanedFirewallRules` → `DetectOrphanedNftRules`/`CleanupOrphanedNftRules`; source file `firewall.go` → `nft_filter.go`. Breaking change: `coi health --format json` consumers checking the `bridge_firewalld_zone` key must update to `bridge_forward_rules`.
 
 

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -92,17 +92,17 @@ var containerDeleteCmd = &cobra.Command{
 
 		mgr := container.NewManager(name)
 
-		// Get container IP BEFORE deleting (needed for firewall cleanup)
+		// Get container IP BEFORE deleting (needed for nft cleanup)
 		var containerIP string
 		if network.NftAvailable() {
 			containerIP, _ = network.GetContainerIPFast(name)
 		}
 
-		// Clean up firewall rules BEFORE deleting container
+		// Clean up nft rules BEFORE deleting container
 		if containerIP != "" {
 			fm := network.NewNftManager(containerIP, "")
 			if err := fm.RemoveRules(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup firewall rules: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup nft rules: %v\n", err)
 			}
 		}
 

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -89,7 +89,7 @@ func outputHealthText(result *health.HealthResult) error {
 	categories := map[string][]string{
 		"SYSTEM":        {"os", "kernel_version", "timezone"},
 		"CRITICAL":      {"incus", "permissions", "image", "image_age", "privileged_profile", "security_posture"},
-		"NETWORKING":    {"network_bridge", "ip_forwarding", "firewall", "bridge_forward_rules", "docker_forward_policy"},
+		"NETWORKING":    {"network_bridge", "ip_forwarding", "nft", "bridge_forward_rules", "docker_forward_policy"},
 		"MONITORING":    {"nftables", "systemd_journal", "libsystemd"},
 		"STORAGE":       {"coi_directory", "sessions_directory", "disk_space", "incus_storage_pools"},
 		"CONFIGURATION": {"config", "network_mode", "tool"},
@@ -213,7 +213,7 @@ func formatCheckName(name string) string {
 		"privileged_profile":    "Privileged check",
 		"network_bridge":        "Network bridge",
 		"ip_forwarding":         "IP forwarding",
-		"firewall":              "nft firewall",
+		"nft":                   "nft firewall",
 		"bridge_forward_rules":  "Bridge forward",
 		"docker_forward_policy": "Docker FORWARD",
 		"nftables":              "nftables",

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -395,8 +395,8 @@ func CheckIPForwarding() HealthCheck {
 	}
 }
 
-// CheckFirewall verifies nft availability and masquerade configuration
-func CheckFirewall(mode config.NetworkMode) HealthCheck {
+// CheckNft verifies nft availability and masquerade configuration
+func CheckNft(mode config.NetworkMode) HealthCheck {
 	installed := network.NftInstalled()
 	available := network.NftAvailable()
 	masquerade := network.MasqueradeEnabled()
@@ -411,7 +411,7 @@ func CheckFirewall(mode config.NetworkMode) HealthCheck {
 
 	if mode == config.NetworkModeOpen {
 		return HealthCheck{
-			Name:    "firewall",
+			Name:    "nft",
 			Status:  StatusOK,
 			Message: "nft not required for open mode",
 			Details: details,
@@ -425,7 +425,7 @@ func CheckFirewall(mode config.NetworkMode) HealthCheck {
 			message = "nft not installed — on Colima, set mode = \"open\" in [network] section of your config.toml"
 		}
 		return HealthCheck{
-			Name:    "firewall",
+			Name:    "nft",
 			Status:  StatusFailed,
 			Message: message,
 			Details: details,
@@ -438,7 +438,7 @@ func CheckFirewall(mode config.NetworkMode) HealthCheck {
 			message = "nft sudo not configured — on Colima, set mode = \"open\" in [network] section of your config.toml"
 		}
 		return HealthCheck{
-			Name:    "firewall",
+			Name:    "nft",
 			Status:  StatusFailed,
 			Message: message,
 			Details: details,
@@ -447,7 +447,7 @@ func CheckFirewall(mode config.NetworkMode) HealthCheck {
 
 	if !masquerade {
 		return HealthCheck{
-			Name:    "firewall",
+			Name:    "nft",
 			Status:  StatusWarning,
 			Message: "Incus bridge NAT (masquerade) not enabled — containers may not reach the internet. Check with: incus network get incusbr0 ipv4.nat",
 			Details: details,
@@ -455,7 +455,7 @@ func CheckFirewall(mode config.NetworkMode) HealthCheck {
 	}
 
 	return HealthCheck{
-		Name:    "firewall",
+		Name:    "nft",
 		Status:  StatusOK,
 		Message: fmt.Sprintf("nft available, Incus bridge NAT enabled (%s mode available)", mode),
 		Details: details,
@@ -1009,13 +1009,13 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 	}
 
 	// Track if we applied firewall rules (for cleanup)
-	var firewallManager *network.NftManager
+	var nftManager *network.NftManager
 
 	// Ensure cleanup on any exit path
 	defer func() {
 		// Remove firewall rules first
-		if firewallManager != nil {
-			_ = firewallManager.RemoveRules()
+		if nftManager != nil {
+			_ = nftManager.RemoveRules()
 		}
 		// Then stop/delete container
 		_ = container.StopContainer(containerName)
@@ -1079,7 +1079,7 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 	}
 
 	// Apply restricted mode firewall rules
-	firewallManager = network.NewNftManager(containerIP, gatewayIP)
+	nftManager = network.NewNftManager(containerIP, gatewayIP)
 	boolTrue := true
 	restrictedConfig := &config.NetworkConfig{
 		Mode:                  config.NetworkModeRestricted,
@@ -1087,7 +1087,7 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 		BlockMetadataEndpoint: &boolTrue,
 	}
 
-	if err := firewallManager.ApplyRestricted(restrictedConfig); err != nil {
+	if err := nftManager.ApplyRestricted(restrictedConfig); err != nil {
 		return HealthCheck{
 			Name:    "network_restriction",
 			Status:  StatusFailed,
@@ -1703,7 +1703,7 @@ func CheckOrphanedResources() HealthCheck {
 		Message: message,
 		Details: map[string]interface{}{
 			"orphaned_veths":          orphanedVeths,
-			"orphaned_firewall_rules": orphanedRules,
+			"orphaned_nft_rules": orphanedRules,
 		},
 	}
 }
@@ -2193,13 +2193,13 @@ func CheckMonitoringConfiguration(cfg *config.Config) HealthCheck {
 func CheckDockerForwardPolicy() HealthCheck {
 	dockerRunning := network.IsDockerRunning()
 	forwardDrop := network.ForwardPolicyIsDrop()
-	firewallAvailable := network.NftAvailable()
+	nftAvailable := network.NftAvailable()
 	iptablesAvailable := network.IptablesAvailable()
 
 	details := map[string]interface{}{
 		"docker_running":      dockerRunning,
 		"forward_policy_drop": forwardDrop,
-		"nft_available":       firewallAvailable,
+		"nft_available":       nftAvailable,
 		"iptables_available":  iptablesAvailable,
 	}
 
@@ -2222,7 +2222,7 @@ func CheckDockerForwardPolicy() HealthCheck {
 	}
 
 	// FORWARD is DROP
-	if firewallAvailable {
+	if nftAvailable {
 		return HealthCheck{
 			Name:    "docker_forward_policy",
 			Status:  StatusOK,

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -1702,7 +1702,7 @@ func CheckOrphanedResources() HealthCheck {
 		Status:  StatusWarning,
 		Message: message,
 		Details: map[string]interface{}{
-			"orphaned_veths":          orphanedVeths,
+			"orphaned_veths":     orphanedVeths,
 			"orphaned_nft_rules": orphanedRules,
 		},
 	}

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -583,7 +583,7 @@ func TestCheckNetworkRestriction_NoImage(t *testing.T) {
 }
 
 // CheckNetworkRestriction should complete and return a definitive status (OK/Warning/Failed)
-// when both firewalld and the COI image are available, and leave no leftover restriction-check
+// when both nft and the COI image are available, and leave no leftover restriction-check
 // containers afterwards.
 func TestCheckNetworkRestriction_WithImage(t *testing.T) {
 	// Skip if incus is not available

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -435,9 +435,9 @@ func TestCheckContainerConnectivity_Cleanup(t *testing.T) {
 	}
 }
 
-// CheckFirewall should return a details map containing nft_installed, nft_available, and masquerade
-// booleans, and the status should reflect the actual firewall state.
-func TestCheckFirewall_DetailedStatus(t *testing.T) {
+// CheckNft should return a details map containing nft_installed, nft_available, and masquerade
+// booleans, and the status should reflect the actual nft state.
+func TestCheckNft_DetailedStatus(t *testing.T) {
 	installed := network.NftInstalled()
 	available := network.NftAvailable()
 	masquerade := network.MasqueradeEnabled()
@@ -449,10 +449,10 @@ func TestCheckFirewall_DetailedStatus(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(string(mode), func(t *testing.T) {
-			result := CheckFirewall(mode)
+			result := CheckNft(mode)
 
-			if result.Name != "firewall" {
-				t.Errorf("Expected check name 'firewall', got %q", result.Name)
+			if result.Name != "nft" {
+				t.Errorf("Expected check name 'nft', got %q", result.Name)
 			}
 
 			// Verify details map has the expected keys
@@ -505,7 +505,7 @@ func TestCheckFirewall_DetailedStatus(t *testing.T) {
 				}
 			}
 
-			t.Logf("CheckFirewall(%s): status=%s installed=%v available=%v masquerade=%v message=%s",
+			t.Logf("CheckNft(%s): status=%s installed=%v available=%v masquerade=%v message=%s",
 				mode, result.Status, installed, available, masquerade, result.Message)
 		})
 	}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -69,7 +69,7 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	// Networking checks
 	checks["network_bridge"] = CheckNetworkBridge()
 	checks["ip_forwarding"] = CheckIPForwarding()
-	checks["firewall"] = CheckFirewall(cfg.Network.Mode)
+	checks["nft"] = CheckNft(cfg.Network.Mode)
 	checks["bridge_forward_rules"] = CheckBridgeForwardRules()
 	checks["docker_forward_policy"] = CheckDockerForwardPolicy()
 	checks["ufw_conflict"] = CheckUFWConflict()

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -166,17 +166,17 @@ func (b *Builder) launchBuildContainer() error {
 	// Wait for container to start
 	time.Sleep(3 * time.Second)
 
-	// Setup open mode firewall rules for build container
+	// Setup open mode nft rules for build container
 	// This is needed when FORWARD chain policy is DROP (common with Docker)
 	if network.NftAvailable() {
 		containerIP, err := network.GetContainerIP(b.mgr.ContainerName)
 		if err != nil {
-			b.opts.Logger(fmt.Sprintf("Warning: could not get container IP for firewall rules: %v", err))
+			b.opts.Logger(fmt.Sprintf("Warning: could not get container IP for nft rules: %v", err))
 		} else {
 			if err := network.EnsureOpenModeRules(containerIP); err != nil {
-				b.opts.Logger(fmt.Sprintf("Warning: could not add firewall rules: %v", err))
+				b.opts.Logger(fmt.Sprintf("Warning: could not add nft rules: %v", err))
 			} else {
-				b.opts.Logger(fmt.Sprintf("Firewall rules added for build container (%s)", containerIP))
+				b.opts.Logger(fmt.Sprintf("nft rules added for build container (%s)", containerIP))
 			}
 		}
 	} else if network.NeedsIptablesFallback() {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -14,8 +14,8 @@ import (
 	"github.com/mensfeld/code-on-incus/internal/logger"
 )
 
-// errFirewallNotAvailable is the user-facing error when nft is unavailable
-const errFirewallNotAvailable = `nft is not available or passwordless sudo is not configured
+// errNftNotAvailable is the user-facing error when nft is unavailable
+const errNftNotAvailable = `nft is not available or passwordless sudo is not configured
 
 Network isolation in restricted/allowlist modes requires nftables (nft).
 
@@ -116,7 +116,7 @@ func (m *Manager) setupRestricted(ctx context.Context, containerName string) err
 
 	// Check if nft is available
 	if !NftAvailable() {
-		return fmt.Errorf("%s", errFirewallNotAvailable)
+		return fmt.Errorf("%s", errNftNotAvailable)
 	}
 
 	// Get container IP
@@ -167,7 +167,7 @@ func (m *Manager) setupAllowlist(ctx context.Context, containerName string) erro
 
 	// Check if nft is available
 	if !NftAvailable() {
-		return fmt.Errorf("%s", errFirewallNotAvailable)
+		return fmt.Errorf("%s", errNftNotAvailable)
 	}
 
 	// Validate configuration

--- a/tests/health/health_json_output.py
+++ b/tests/health/health_json_output.py
@@ -70,6 +70,8 @@ def test_health_json_output(coi_binary):
         "privileged_profile",
         "security_posture",
         "network_bridge",
+        "nft",
+        "bridge_forward_rules",
         "disk_space",
         "incus_storage_pools",
     ]

--- a/tests/health/health_nft_check.py
+++ b/tests/health/health_nft_check.py
@@ -1,0 +1,138 @@
+"""
+Test for coi health - nft firewall check (formerly "firewall" / CheckFirewall).
+
+Tests that:
+1. The "nft" check exists in health JSON output (renamed from "firewall")
+2. Check has nft_installed and nft_available detail fields
+3. Text output shows "nft firewall" label
+4. Orphan health check uses "orphaned_nft_rules" key (not "orphaned_firewall_rules")
+"""
+
+import json
+import subprocess
+
+
+def test_health_nft_check_exists(coi_binary):
+    """
+    Verify the "nft" check (formerly "firewall") appears in health JSON.
+
+    Flow:
+    1. Run coi health --format json
+    2. Verify "nft" key exists in checks (not the old "firewall" key)
+    3. Verify required fields are present
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2], (
+        f"Health check failed unexpectedly. stderr: {result.stderr}"
+    )
+
+    data = json.loads(result.stdout)
+    checks = data["checks"]
+
+    assert "nft" in checks, (
+        f"Should have 'nft' check (renamed from 'firewall'). Got keys: {list(checks.keys())}"
+    )
+    assert "firewall" not in checks, (
+        "Old 'firewall' key should no longer exist — it was renamed to 'nft'"
+    )
+
+    check = checks["nft"]
+    assert "name" in check and check["name"] == "nft", (
+        f"Check name should be 'nft', got: {check.get('name')}"
+    )
+    assert "status" in check, "nft check should have 'status'"
+    assert "message" in check, "nft check should have 'message'"
+    assert check["status"] in ("ok", "warning", "failed"), f"Invalid status: {check['status']}"
+
+
+def test_health_nft_check_detail_fields(coi_binary):
+    """
+    Verify the "nft" check includes nft_installed and nft_available detail fields.
+
+    Flow:
+    1. Run coi health --format json
+    2. Check that nft check has details with nft_installed and nft_available
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    data = json.loads(result.stdout)
+    check = data["checks"].get("nft")
+    assert check is not None, "nft check should exist"
+
+    details = check.get("details", {})
+    assert "nft_installed" in details, (
+        f"nft check should have 'nft_installed' detail. Got: {list(details.keys())}"
+    )
+    assert "nft_available" in details, (
+        f"nft check should have 'nft_available' detail. Got: {list(details.keys())}"
+    )
+    assert isinstance(details["nft_installed"], bool), "nft_installed should be bool"
+    assert isinstance(details["nft_available"], bool), "nft_available should be bool"
+
+
+def test_health_nft_text_label(coi_binary):
+    """
+    Verify "nft firewall" appears in text health output under NETWORKING.
+
+    Flow:
+    1. Run coi health (text output)
+    2. Verify "nft firewall" label appears (the renamed display label)
+    """
+    result = subprocess.run(
+        [coi_binary, "health"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    assert "nft firewall" in result.stdout, (
+        f"Expected 'nft firewall' label in text output. Got:\n{result.stdout}"
+    )
+
+
+def test_health_orphan_check_uses_nft_key(coi_binary):
+    """
+    Verify the orphan health check uses "orphaned_nft_rules" detail key
+    (renamed from "orphaned_firewall_rules").
+
+    Flow:
+    1. Run coi health --format json --verbose
+    2. If orphan check is present and has details, verify key name
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json", "--verbose"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    data = json.loads(result.stdout)
+    checks = data["checks"]
+
+    orphan_check = checks.get("orphaned_resources")
+    if orphan_check is None:
+        return  # check may not appear in all configs
+
+    details = orphan_check.get("details", {})
+    if details:
+        assert "orphaned_nft_rules" in details, (
+            f"Orphan check should use 'orphaned_nft_rules' key (not 'orphaned_firewall_rules'). "
+            f"Got: {list(details.keys())}"
+        )
+        assert "orphaned_firewall_rules" not in details, (
+            "Old 'orphaned_firewall_rules' key should no longer exist"
+        )


### PR DESCRIPTION
## Summary

- Renames `CheckFirewall()` → `CheckNft()` and health check key `"firewall"` → `"nft"` throughout
- Renames `orphaned_firewall_rules` JSON detail key → `orphaned_nft_rules`
- Renames `errFirewallNotAvailable` constant → `errNftNotAvailable` in `internal/network/manager.go`
- Updates stale "firewall" comments and warning messages in `internal/cli/container.go` and `internal/image/builder.go`
- Updates integration test `TestCheckFirewall_DetailedStatus` → `TestCheckNft_DetailedStatus`
- Documents breaking changes in CHANGELOG.md

## Breaking Changes

- `coi health --format json` consumers checking `checks.firewall` must update to `checks.nft`
- `orphaned_firewall_rules` detail key renamed to `orphaned_nft_rules`

## Test plan

- [ ] `go build ./...` passes cleanly (verified)
- [ ] `ruff check tests/ && ruff format --check tests/` passes cleanly (verified)
- [ ] Integration tests for `TestCheckNft_DetailedStatus` pass on a system with nft available