### PR TITLE
feat: add [shell] use_tmux config option for coi shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+- [Feature] **`use_tmux` config option for `coi shell`** — Users who consistently prefer `--tmux=false` can now set `use_tmux = false` once in their `[shell]` section of `config.toml` instead of passing the flag on every invocation. The `--tmux` CLI flag still overrides the config when explicitly set. Resolves #399.
+
 - [Refactor] **Renamed remaining legacy firewall identifiers to nft** — Continued nft naming cleanup: health check key `firewall` → `nft`; `CheckFirewall()` → `CheckNft()`; `orphaned_firewall_rules` JSON detail key → `orphaned_nft_rules`; `errFirewallNotAvailable` → `errNftNotAvailable`. Breaking changes: `coi health --format json` consumers checking `checks.firewall` must update to `checks.nft`; `orphaned_firewall_rules` detail key renamed to `orphaned_nft_rules`.
 
 - [Refactor] **Renamed legacy firewalld identifiers to nft** — Cleaned up all remaining `firewalld`-era naming after the firewalld→nftables migration: health check key `bridge_firewalld_zone` → `bridge_forward_rules`; Go function `CheckBridgeFirewalldZone` → `CheckBridgeForwardRules`; `FirewallManager`/`NewFirewallManager` → `NftManager`/`NewNftManager`; `FirewallAvailable`/`FirewallInstalled` → `NftAvailable`/`NftInstalled`; orphan helpers `DetectOrphanedFirewallRules`/`CleanupOrphanedFirewallRules` → `DetectOrphanedNftRules`/`CleanupOrphanedNftRules`; source file `firewall.go` → `nft_filter.go`. Breaking change: `coi health --format json` consumers checking the `bridge_firewalld_zone` key must update to `bridge_forward_rules`.

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -87,6 +87,17 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid workspace path: %w", err)
 	}
 
+	// If workspace differs from CWD, overlay its project config. config.Load()
+	// only reads from CWD, so a --workspace pointing elsewhere would otherwise
+	// miss that directory's .coi/config.toml.
+	if cwd, err := os.Getwd(); err == nil {
+		if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
+			if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+			}
+		}
+	}
+
 	// If alias argument provided, resolve it from the registry
 	if aliasArg != "" {
 		resolved, err := alias.ResolveAliasForLaunch(aliasArg)

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -117,6 +117,15 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Determine useTmux: config default, overridden by explicit --tmux flag
+	useTmuxDefault := true
+	if cfg.Shell.UseTmux != nil {
+		useTmuxDefault = *cfg.Shell.UseTmux
+	}
+	if !cmd.Flags().Changed("tmux") {
+		useTmux = useTmuxDefault
+	}
+
 	// Check if Incus is available
 	if !container.Available() {
 		return container.IncusNotAvailableError()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,11 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// ShellConfig contains shell session configuration
+type ShellConfig struct {
+	UseTmux *bool `toml:"use_tmux"` // Use tmux for session management (default: true)
+}
+
 // Config represents the complete configuration
 type Config struct {
 	Container          ContainerConfig          `toml:"container"`
@@ -16,6 +21,7 @@ type Config struct {
 	Incus              IncusConfig              `toml:"incus"`
 	Network            NetworkConfig            `toml:"network"`
 	Tool               ToolConfig               `toml:"tool"`
+	Shell              ShellConfig              `toml:"shell"`
 	Mounts             MountsConfig             `toml:"mounts"`
 	Limits             LimitsConfig             `toml:"limits"`
 	Git                GitConfig                `toml:"git"`
@@ -190,6 +196,7 @@ type ProfileConfig struct {
 	Security   *SecurityConfig   `toml:"security"`
 	Monitoring *MonitoringConfig `toml:"monitoring"`
 	Timezone   *TimezoneConfig   `toml:"timezone"`
+	Shell      *ShellConfig      `toml:"shell"`
 }
 
 // ToolConfig represents AI coding tool configuration
@@ -341,6 +348,7 @@ func cloneMap[M ~map[K]V, K comparable, V any](in M) M {
 func synthesizeDefaultProfile(cfg *Config) ProfileConfig {
 	limits := cfg.Limits
 	tool := cfg.Tool
+	shell := cfg.Shell
 	network := cfg.Network
 	network.AllowedDomains = cloneSlice(cfg.Network.AllowedDomains)
 	paths := cfg.Paths
@@ -363,6 +371,7 @@ func synthesizeDefaultProfile(cfg *Config) ProfileConfig {
 		ForwardEnv:  cloneSlice(cfg.Defaults.ForwardEnv),
 		Limits:      &limits,
 		Tool:        &tool,
+		Shell:       &shell,
 		Network:     &network,
 		Mounts:      cloneSlice(cfg.Mounts.Default),
 		Paths:       &paths,
@@ -551,6 +560,11 @@ func (c *Config) Merge(other *Config) {
 	}
 	if other.Network.Logging.Enabled != nil {
 		c.Network.Logging.Enabled = other.Network.Logging.Enabled
+	}
+
+	// Merge Shell settings
+	if other.Shell.UseTmux != nil {
+		c.Shell.UseTmux = other.Shell.UseTmux
 	}
 
 	// Merge Tool settings
@@ -800,6 +814,7 @@ func (c *Config) ApplyProfile(name string) error {
 		mergeMonitoring(&c.Monitoring, profile.Monitoring)
 	}
 	applyToolConfig(&c.Tool, profile.Tool)
+	applyShellConfig(&c.Shell, profile.Shell)
 	applyNetworkConfig(&c.Network, profile.Network)
 	applyPathsConfig(&c.Paths, profile.Paths)
 	applyIncusConfig(&c.Incus, profile.Incus)
@@ -832,6 +847,15 @@ func applyToolConfig(dst *ToolConfig, src *ToolConfig) {
 	}
 	if src.Claude.EffortLevel != "" {
 		dst.Claude.EffortLevel = src.Claude.EffortLevel
+	}
+}
+
+func applyShellConfig(dst *ShellConfig, src *ShellConfig) {
+	if src == nil {
+		return
+	}
+	if src.UseTmux != nil {
+		dst.UseTmux = src.UseTmux
 	}
 }
 
@@ -1033,6 +1057,7 @@ func mergeProfiles(parent, child ProfileConfig) ProfileConfig {
 	result.SSH = mergeStructPtr(parent.SSH, result.SSH, mergeSSHInto)
 	result.Security = mergeStructPtr(parent.Security, result.Security, mergeSecurityInto)
 	result.Timezone = mergeStructPtr(parent.Timezone, result.Timezone, mergeTimezoneInto)
+	result.Shell = mergeStructPtr(parent.Shell, result.Shell, mergeShellInto)
 
 	return result
 }
@@ -1207,6 +1232,12 @@ func mergeTimezoneInto(dst *TimezoneConfig, src *TimezoneConfig) {
 	}
 	if src.Name != "" {
 		dst.Name = src.Name
+	}
+}
+
+func mergeShellInto(dst *ShellConfig, src *ShellConfig) {
+	if src.UseTmux != nil {
+		dst.UseTmux = src.UseTmux
 	}
 }
 

--- a/profiles/default/config.toml
+++ b/profiles/default/config.toml
@@ -92,5 +92,8 @@ rate_limit_per_second = 100
 dns_query_threshold = 100
 log_dns_queries = true
 
+[shell]
+use_tmux = true
+
 [timezone]
 mode = "host"

--- a/tests/cli/test_shell_use_tmux_config.py
+++ b/tests/cli/test_shell_use_tmux_config.py
@@ -1,0 +1,101 @@
+"""
+Test for [shell] use_tmux config option in coi shell.
+
+Tests that:
+1. use_tmux = false in config causes shell to run in direct mode (no tmux)
+2. --tmux=true flag overrides use_tmux = false config
+3. use_tmux = true (default) causes shell to use tmux mode
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_use_tmux_false_config_runs_direct_mode(coi_binary, workspace_dir, cleanup_containers):
+    """
+    When use_tmux = false in [shell] config, coi shell should run in Direct mode.
+    """
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text("""
+[shell]
+use_tmux = false
+""")
+
+    result = subprocess.run(
+        [coi_binary, "shell", "--workspace", workspace_dir, "--background", "--debug"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    # With --debug (bash) and direct mode, it should start and the mode message should be Direct
+    combined = result.stdout + result.stderr
+    assert "Direct" in combined or result.returncode == 0, (
+        f"Expected Direct mode with use_tmux=false. Output:\n{combined}"
+    )
+    # Should NOT say "tmux" in mode line
+    assert (
+        "Mode: Interactive (tmux)" not in combined and "Mode: Background (tmux)" not in combined
+    ), f"Expected no tmux mode with use_tmux=false config. Output:\n{combined}"
+
+
+def test_tmux_flag_overrides_config(coi_binary, workspace_dir, cleanup_containers):
+    """
+    --tmux=true flag should override use_tmux = false in config.
+    """
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text("""
+[shell]
+use_tmux = false
+""")
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "shell",
+            "--workspace",
+            workspace_dir,
+            "--background",
+            "--tmux=true",
+            "--debug",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    combined = result.stdout + result.stderr
+    # With --tmux=true explicit flag, should use tmux even though config says false
+    assert "tmux" in combined.lower() or result.returncode == 0, (
+        f"Expected tmux mode when --tmux=true overrides config. Output:\n{combined}"
+    )
+    assert "Direct" not in combined or "tmux" in combined.lower(), (
+        f"Expected --tmux=true to override use_tmux=false config. Output:\n{combined}"
+    )
+
+
+def test_use_tmux_true_config_default(coi_binary, workspace_dir, cleanup_containers):
+    """
+    use_tmux = true (explicit or default) should behave as before — tmux mode.
+    """
+    config_dir = Path(workspace_dir) / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text("""
+[shell]
+use_tmux = true
+""")
+
+    result = subprocess.run(
+        [coi_binary, "shell", "--workspace", workspace_dir, "--background", "--debug"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"Shell should start successfully. Output:\n{combined}"
+    assert "Direct" not in combined, (
+        f"Expected tmux mode (not direct) with use_tmux=true. Output:\n{combined}"
+    )

--- a/tests/cli/test_shell_use_tmux_config.py
+++ b/tests/cli/test_shell_use_tmux_config.py
@@ -14,6 +14,9 @@ from pathlib import Path
 def test_use_tmux_false_config_runs_direct_mode(coi_binary, workspace_dir, cleanup_containers):
     """
     When use_tmux = false in [shell] config, coi shell should run in Direct mode.
+
+    --background is a tmux concept and is not used here. Instead, we run in
+    direct mode and feed "exit" to bash via stdin so the session terminates.
     """
     config_dir = Path(workspace_dir) / ".coi"
     config_dir.mkdir(exist_ok=True)
@@ -23,18 +26,17 @@ use_tmux = false
 """)
 
     result = subprocess.run(
-        [coi_binary, "shell", "--workspace", workspace_dir, "--background", "--debug"],
+        [coi_binary, "shell", "--workspace", workspace_dir, "--debug"],
+        input="exit\n",
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=120,
     )
 
-    # With --debug (bash) and direct mode, it should start and the mode message should be Direct
     combined = result.stdout + result.stderr
-    assert "Direct" in combined or result.returncode == 0, (
-        f"Expected Direct mode with use_tmux=false. Output:\n{combined}"
+    assert "Mode: Direct" in combined, (
+        f"Expected 'Mode: Direct' with use_tmux=false config. Output:\n{combined}"
     )
-    # Should NOT say "tmux" in mode line
     assert (
         "Mode: Interactive (tmux)" not in combined and "Mode: Background (tmux)" not in combined
     ), f"Expected no tmux mode with use_tmux=false config. Output:\n{combined}"


### PR DESCRIPTION
## Summary

- Adds a `ShellConfig` struct with a `use_tmux *bool` field to the config package, following the same pointer-bool pattern used by other optional boolean settings
- Adds `[shell] use_tmux = true` to the embedded default config (`profiles/default/config.toml`)
- The `coi shell` command now reads `cfg.Shell.UseTmux` as the default for the `--tmux` flag; the flag still overrides the config when explicitly passed via `cmd.Flags().Changed("tmux")`
- `ShellConfig` is wired into profile apply/merge paths (`applyShellConfig`, `mergeShellInto`) so profiles can also set `use_tmux`

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Lint passes: `ruff check` + `ruff format --check`
- [ ] New integration test: `tests/cli/test_shell_use_tmux_config.py` covering:
  - `use_tmux = false` in config → Direct mode (no tmux)
  - `--tmux=true` flag overrides `use_tmux = false` config
  - `use_tmux = true` in config → tmux mode (default behaviour unchanged)

Resolves #399