### PR TITLE
fix(shell): address Copilot review comments on #409

### DIFF
--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -36,11 +36,15 @@ var (
 var shellCmd = &cobra.Command{
 	Use:   "shell [alias]",
 	Short: "Start an interactive AI coding session",
-	Long: `Start an interactive AI coding session in a container (always runs in tmux).
+	Long: `Start an interactive AI coding session in a container.
 
 By default, runs Claude Code. Other tools can be configured via the tool.name config option.
 
-All sessions run in tmux for monitoring and detach/reattach support:
+Sessions run in tmux by default for monitoring and detach/reattach support.
+Set [shell] use_tmux = false in .coi/config.toml to run without tmux (direct mode).
+The --tmux flag always overrides the config setting.
+
+Tmux mode (default):
   - Interactive: Automatically attaches to tmux session
   - Background: Runs detached, use 'coi tmux capture' to view output
   - Detach anytime: Ctrl+B d (session keeps running)
@@ -54,7 +58,8 @@ Examples:
   coi shell                         # Interactive session in tmux
   coi shell myproject               # Launch session using alias (from any directory)
   coi shell --tool opencode         # Use opencode instead of configured tool
-  coi shell --background            # Run in background (detached)
+  coi shell --background            # Run in background (detached, tmux only)
+  coi shell --tmux=false            # Run in direct mode (no tmux)
   coi shell --resume                # Resume latest session (auto)
   coi shell --resume=<session-id>   # Resume specific session (note: = is required)
   coi shell --continue=<session-id> # Same as --resume (alias)
@@ -87,13 +92,18 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid workspace path: %w", err)
 	}
 
-	// If workspace differs from CWD, overlay its project config. config.Load()
-	// only reads from CWD, so a --workspace pointing elsewhere would otherwise
-	// miss that directory's .coi/config.toml.
-	if cwd, err := os.Getwd(); err == nil {
-		if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
-			if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+	// If workspace differs from CWD and no alias argument overrides it, overlay
+	// the workspace's project config. config.Load() only reads from CWD, so a
+	// --workspace pointing elsewhere would otherwise miss that .coi/config.toml.
+	// Skip when aliasArg is set: alias resolution will reassign absWorkspace and
+	// call OverlayProjectConfig itself, avoiding a double-overlay from the wrong dir.
+	if aliasArg == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
+				if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+				}
+				container.Configure(cfg.Incus.Project, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
 			}
 		}
 	}

--- a/tests/cli/test_shell_use_tmux_config.py
+++ b/tests/cli/test_shell_use_tmux_config.py
@@ -69,11 +69,11 @@ use_tmux = false
     )
 
     combined = result.stdout + result.stderr
-    # With --tmux=true explicit flag, should use tmux even though config says false
-    assert "tmux" in combined.lower() or result.returncode == 0, (
-        f"Expected tmux mode when --tmux=true overrides config. Output:\n{combined}"
+    # --tmux=true explicitly overrides use_tmux=false; must show a tmux Mode line
+    assert "Mode: Background (tmux)" in combined or "Mode: Interactive (tmux)" in combined, (
+        f"Expected tmux Mode line when --tmux=true overrides use_tmux=false config. Output:\n{combined}"
     )
-    assert "Direct" not in combined or "tmux" in combined.lower(), (
+    assert "Mode: Direct" not in combined, (
         f"Expected --tmux=true to override use_tmux=false config. Output:\n{combined}"
     )
 


### PR DESCRIPTION
## Summary

Follow-up to #409 addressing valid Copilot review comments:

- **Stale help text**: removed "always runs in tmux" claim; documented `[shell] use_tmux = false`, `--tmux=false`, and clarified `--background` is tmux-only.
- **Double-overlay bug**: the workspace config overlay is now skipped when an alias arg is present — alias resolution reassigns `absWorkspace` and calls `OverlayProjectConfig` itself, so the early overlay would have merged the wrong directory's config.
- **Missing `container.Configure`**: added call after the non-alias workspace overlay to apply `[incus]` settings from the workspace, matching what the alias path already does.
- **Weak test assertions**: `test_tmux_flag_overrides_config` now checks for the `Mode: Background (tmux)` / `Mode: Interactive (tmux)` line directly instead of substring-matching "tmux" anywhere in the output (which could match the config text or help banners).

## Test plan

- [ ] `go build ./...` passes
- [ ] `ruff check` / `ruff format` clean
- [ ] CI green