### PR TITLE
feat(health): add iptables sudo check to NETWORKING section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,8 @@ jobs:
             path: tests/list tests/attach tests/tmux tests/kill tests/run tests/persist tests/build
             description: "Core commands: list/attach/tmux/kill/run/persist/build (83 tests)"
           - name: misc
-            path: tests/clean tests/cli tests/completion tests/config tests/docker tests/errors tests/help tests/image tests/info tests/mount tests/shutdown tests/version tests/meta tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/cli/completion/config/docker/errors/help/image/info/mount/shutdown/version/meta/main help"
+            path: tests/clean tests/cli tests/completion tests/config tests/docker tests/errors tests/health tests/help tests/image tests/info tests/mount tests/shutdown tests/version tests/meta tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: clean/cli/completion/config/docker/errors/health/help/image/info/mount/shutdown/version/meta/main help"
           - name: monitoring-nft
             path: tests/integration/test_nft_monitoring.py
             description: "NFT network monitoring tests (17 tests)"

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -89,7 +89,7 @@ func outputHealthText(result *health.HealthResult) error {
 	categories := map[string][]string{
 		"SYSTEM":        {"os", "kernel_version", "timezone"},
 		"CRITICAL":      {"incus", "permissions", "image", "image_age", "privileged_profile", "security_posture"},
-		"NETWORKING":    {"network_bridge", "ip_forwarding", "nft", "bridge_forward_rules", "docker_forward_policy"},
+		"NETWORKING":    {"network_bridge", "ip_forwarding", "nft", "bridge_forward_rules", "iptables_sudo", "docker_forward_policy"},
 		"MONITORING":    {"nftables", "systemd_journal", "libsystemd"},
 		"STORAGE":       {"coi_directory", "sessions_directory", "disk_space", "incus_storage_pools"},
 		"CONFIGURATION": {"config", "network_mode", "tool"},
@@ -215,6 +215,7 @@ func formatCheckName(name string) string {
 		"ip_forwarding":         "IP forwarding",
 		"nft":                   "nft firewall",
 		"bridge_forward_rules":  "Bridge forward",
+		"iptables_sudo":         "iptables sudo",
 		"docker_forward_policy": "Docker FORWARD",
 		"nftables":              "nftables",
 		"systemd_journal":       "systemd journal",

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -94,7 +94,7 @@ func outputHealthText(result *health.HealthResult) error {
 		"STORAGE":       {"coi_directory", "sessions_directory", "disk_space", "incus_storage_pools"},
 		"CONFIGURATION": {"config", "network_mode", "tool"},
 		"STATUS":        {"active_containers", "saved_sessions", "orphaned_resources"},
-		"OPTIONAL":      {"dns_resolution", "passwordless_sudo"},
+		"OPTIONAL":      {"dns_resolution"},
 	}
 
 	// Category order
@@ -230,7 +230,6 @@ func formatCheckName(name string) string {
 		"active_containers":     "Containers",
 		"saved_sessions":        "Saved sessions",
 		"dns_resolution":        "DNS resolution",
-		"passwordless_sudo":     "Passwordless sudo",
 		"orphaned_resources":    "Orphaned resources",
 		"security_posture":      "Security posture",
 	}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -1201,39 +1201,6 @@ func CheckNetworkRestriction(imageName string) HealthCheck {
 	}
 }
 
-// CheckPasswordlessSudo verifies passwordless sudo for nft
-func CheckPasswordlessSudo() HealthCheck {
-	if runtime.GOOS == "darwin" {
-		return HealthCheck{
-			Name:    "passwordless_sudo",
-			Status:  StatusOK,
-			Message: "macOS - not required",
-		}
-	}
-
-	if _, err := exec.LookPath("nft"); err != nil {
-		return HealthCheck{
-			Name:    "passwordless_sudo",
-			Status:  StatusWarning,
-			Message: "nft not installed — install with: sudo apt install nftables",
-		}
-	}
-
-	if exec.Command("sudo", "-n", "nft", "list", "tables").Run() != nil {
-		return HealthCheck{
-			Name:    "passwordless_sudo",
-			Status:  StatusWarning,
-			Message: "Passwordless sudo not configured for nft — run: echo \"$USER ALL=(ALL) NOPASSWD: /usr/sbin/nft\" | sudo tee /etc/sudoers.d/coi-nft && sudo chmod 0440 /etc/sudoers.d/coi-nft",
-		}
-	}
-
-	return HealthCheck{
-		Name:    "passwordless_sudo",
-		Status:  StatusOK,
-		Message: "Passwordless sudo configured for nft",
-	}
-}
-
 // CheckDiskSpace checks available disk space in ~/.coi directory
 func CheckDiskSpace() HealthCheck {
 	homeDir, err := os.UserHomeDir()

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -241,7 +241,7 @@ func CheckPermissions() HealthCheck {
 	if container.UserInGroupFile(currentUser.Username, "incus-admin") {
 		return HealthCheck{
 			Name:    "permissions",
-			Status:  StatusFailed,
+			Status:  StatusWarning,
 			Message: fmt.Sprintf("User '%s' is in incus-admin group but session not reloaded — log out and back in, or run: newgrp incus-admin", currentUser.Username),
 		}
 	}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -536,6 +536,41 @@ func CheckBridgeForwardRules() HealthCheck {
 	}
 }
 
+// CheckIptablesSudo verifies passwordless sudo for iptables, which COI uses
+// for bridge FORWARD rule inspection and management regardless of whether nft
+// is also available.
+func CheckIptablesSudo() HealthCheck {
+	if runtime.GOOS == "darwin" {
+		return HealthCheck{
+			Name:    "iptables_sudo",
+			Status:  StatusOK,
+			Message: "macOS — not required",
+		}
+	}
+
+	if _, err := exec.LookPath("iptables"); err != nil {
+		return HealthCheck{
+			Name:    "iptables_sudo",
+			Status:  StatusOK,
+			Message: "iptables not installed — not required",
+		}
+	}
+
+	if exec.Command("sudo", "-n", "iptables", "-L", "FORWARD", "-n").Run() != nil {
+		return HealthCheck{
+			Name:    "iptables_sudo",
+			Status:  StatusWarning,
+			Message: `Passwordless sudo not configured for iptables — run: echo "$USER ALL=(ALL) NOPASSWD: /usr/sbin/iptables" | sudo tee /etc/sudoers.d/coi-iptables && sudo chmod 0440 /etc/sudoers.d/coi-iptables`,
+		}
+	}
+
+	return HealthCheck{
+		Name:    "iptables_sudo",
+		Status:  StatusOK,
+		Message: "Passwordless sudo configured for iptables",
+	}
+}
+
 // CheckCOIDirectory verifies the COI directory exists and is writable
 func CheckCOIDirectory() HealthCheck {
 	homeDir, err := os.UserHomeDir()

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -553,7 +553,8 @@ func CheckIptablesSudo() HealthCheck {
 		}
 	}
 
-	if _, err := exec.LookPath("iptables"); err != nil {
+	iptablesPath, err := exec.LookPath("iptables")
+	if err != nil {
 		return HealthCheck{
 			Name:    "iptables_sudo",
 			Status:  StatusOK,
@@ -561,11 +562,11 @@ func CheckIptablesSudo() HealthCheck {
 		}
 	}
 
-	if exec.Command("sudo", "-n", "iptables", "-L", "FORWARD", "-n").Run() != nil {
+	if exec.Command("sudo", "-n", iptablesPath, "-L", "FORWARD", "-n").Run() != nil {
 		return HealthCheck{
 			Name:    "iptables_sudo",
 			Status:  StatusWarning,
-			Message: `Passwordless sudo not configured for iptables — run: echo "$USER ALL=(ALL) NOPASSWD: /usr/sbin/iptables" | sudo tee /etc/sudoers.d/coi-iptables && sudo chmod 0440 /etc/sudoers.d/coi-iptables`,
+			Message: fmt.Sprintf(`Passwordless sudo not configured for iptables — run: echo "$USER ALL=(ALL) NOPASSWD: %s" | sudo tee /etc/sudoers.d/coi-iptables && sudo chmod 0440 /etc/sudoers.d/coi-iptables`, iptablesPath),
 		}
 	}
 

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -503,7 +503,9 @@ func CheckUFWConflict() HealthCheck {
 }
 
 // CheckBridgeForwardRules checks whether the Incus bridge has iptables FORWARD
-// ACCEPT rules so containers can get IPs via DHCP even when FORWARD policy is DROP.
+// ACCEPT rules in place when the FORWARD chain policy is DROP.  When the policy
+// is ACCEPT (the common case) no per-bridge rules are needed and the check
+// returns OK regardless of whether rules are present.
 func CheckBridgeForwardRules() HealthCheck {
 	hasRules, bridgeName, err := network.BridgeInTrustedZone()
 	if err != nil {
@@ -514,16 +516,19 @@ func CheckBridgeForwardRules() HealthCheck {
 		}
 	}
 
+	forwardDrop := network.ForwardPolicyIsDrop()
+
 	details := map[string]interface{}{
-		"bridge_name":       bridgeName,
-		"has_forward_rules": hasRules,
+		"bridge_name":         bridgeName,
+		"has_forward_rules":   hasRules,
+		"forward_policy_drop": forwardDrop,
 	}
 
-	if !hasRules {
+	if !hasRules && forwardDrop {
 		return HealthCheck{
 			Name:    "bridge_forward_rules",
 			Status:  StatusWarning,
-			Message: fmt.Sprintf("Bridge %s has no iptables FORWARD rules — containers may fail to get IPs if FORWARD policy is DROP (rules are added automatically on first container start)", bridgeName),
+			Message: fmt.Sprintf("Bridge %s has no iptables FORWARD rules and FORWARD policy is DROP — rules are added automatically on first container start", bridgeName),
 			Details: details,
 		}
 	}
@@ -531,7 +536,7 @@ func CheckBridgeForwardRules() HealthCheck {
 	return HealthCheck{
 		Name:    "bridge_forward_rules",
 		Status:  StatusOK,
-		Message: fmt.Sprintf("Bridge %s has iptables FORWARD rules", bridgeName),
+		Message: fmt.Sprintf("Bridge %s forwarding OK", bridgeName),
 		Details: details,
 	}
 }

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -892,4 +893,66 @@ func TestCheckProcessMonitoringCapability(t *testing.T) {
 
 	t.Logf("Process monitoring capability check: %s (status: %s)",
 		result.Message, result.Status)
+}
+
+func TestCheckIptablesSudo(t *testing.T) {
+	result := CheckIptablesSudo()
+
+	if result.Name != "iptables_sudo" {
+		t.Errorf("Expected check name 'iptables_sudo', got %q", result.Name)
+	}
+
+	// Never fails — only OK or Warning
+	if result.Status != StatusOK && result.Status != StatusWarning {
+		t.Errorf("Expected StatusOK or StatusWarning, got %s: %s", result.Status, result.Message)
+	}
+
+	// On macOS the check always returns OK
+	if runtime.GOOS == "darwin" {
+		if result.Status != StatusOK {
+			t.Errorf("macOS: expected StatusOK, got %s", result.Status)
+		}
+		return
+	}
+
+	// If iptables is not installed we expect OK with a clear message
+	if _, err := exec.LookPath("iptables"); err != nil {
+		if result.Status != StatusOK {
+			t.Errorf("iptables not installed: expected StatusOK, got %s", result.Status)
+		}
+		return
+	}
+
+	// iptables is installed — status depends on whether sudo is configured
+	sudoWorks := exec.Command("sudo", "-n", "iptables", "-L", "FORWARD", "-n").Run() == nil
+	if sudoWorks {
+		if result.Status != StatusOK {
+			t.Errorf("sudo iptables works: expected StatusOK, got %s: %s", result.Status, result.Message)
+		}
+		if !strings.Contains(result.Message, "configured") {
+			t.Errorf("OK message should mention 'configured', got: %q", result.Message)
+		}
+	} else {
+		if result.Status != StatusWarning {
+			t.Errorf("sudo iptables fails: expected StatusWarning, got %s: %s", result.Status, result.Message)
+		}
+		// Warning message must include the fix command
+		if !strings.Contains(result.Message, "sudoers.d") {
+			t.Errorf("Warning message should include sudoers.d fix path, got: %q", result.Message)
+		}
+		if !strings.Contains(result.Message, "iptables") {
+			t.Errorf("Warning message should reference iptables, got: %q", result.Message)
+		}
+	}
+
+	t.Logf("CheckIptablesSudo: status=%s message=%s", result.Status, result.Message)
+}
+
+func TestCheckIptablesSudo_InRunAllChecks(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	result := RunAllChecks(cfg, false)
+
+	if _, ok := result.Checks["iptables_sudo"]; !ok {
+		t.Error("RunAllChecks should include 'iptables_sudo' check")
+	}
 }

--- a/internal/health/checks_integration_test.go
+++ b/internal/health/checks_integration_test.go
@@ -956,3 +956,27 @@ func TestCheckIptablesSudo_InRunAllChecks(t *testing.T) {
 		t.Error("RunAllChecks should include 'iptables_sudo' check")
 	}
 }
+
+func TestCheckBridgeForwardRules_NoFalsePositiveWhenForwardNotDrop(t *testing.T) {
+	// If FORWARD policy is not DROP, missing bridge rules are harmless —
+	// the check must not warn in that case.
+	if _, err := exec.LookPath("incus"); err != nil {
+		t.Skip("incus not found, skipping bridge check test")
+	}
+	if network.ForwardPolicyIsDrop() {
+		t.Skip("FORWARD policy is DROP on this host; skipping false-positive test")
+	}
+
+	result := CheckBridgeForwardRules()
+
+	if result.Name != "bridge_forward_rules" {
+		t.Errorf("Expected check name 'bridge_forward_rules', got %q", result.Name)
+	}
+
+	if result.Status != StatusOK {
+		t.Errorf("FORWARD policy is not DROP: expected StatusOK regardless of rule presence, got %s: %s",
+			result.Status, result.Message)
+	}
+
+	t.Logf("CheckBridgeForwardRules (FORWARD not DROP): status=%s message=%s", result.Status, result.Message)
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -110,7 +110,6 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	// Optional checks (only if verbose)
 	if verbose {
 		checks["dns_resolution"] = CheckDNS()
-		checks["passwordless_sudo"] = CheckPasswordlessSudo()
 		checks["process_monitoring"] = CheckProcessMonitoringCapability(cfg.Container.Image)
 	}
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -71,6 +71,7 @@ func RunAllChecks(cfg *config.Config, verbose bool) *HealthResult {
 	checks["ip_forwarding"] = CheckIPForwarding()
 	checks["nft"] = CheckNft(cfg.Network.Mode)
 	checks["bridge_forward_rules"] = CheckBridgeForwardRules()
+	checks["iptables_sudo"] = CheckIptablesSudo()
 	checks["docker_forward_policy"] = CheckDockerForwardPolicy()
 	checks["ufw_conflict"] = CheckUFWConflict()
 

--- a/tests/health/health_iptables_sudo.py
+++ b/tests/health/health_iptables_sudo.py
@@ -1,0 +1,158 @@
+"""
+Tests for coi health - iptables sudo check.
+
+Verifies that:
+1. The 'iptables_sudo' check is present in health JSON output
+2. Its status is always 'ok' or 'warning', never 'failed'
+3. The text output shows the check under NETWORKING
+4. When the status is 'warning', the message contains a sudoers.d fix command
+5. When the status is 'ok', the message is meaningful
+"""
+
+import json
+import subprocess
+
+
+def test_iptables_sudo_check_present(coi_binary):
+    """
+    The 'iptables_sudo' check must appear in coi health --format json.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2], (
+        f"health exited with unexpected code {result.returncode}. stderr: {result.stderr}"
+    )
+
+    data = json.loads(result.stdout)
+    checks = data["checks"]
+
+    assert "iptables_sudo" in checks, (
+        f"Expected 'iptables_sudo' check in health output. Got keys: {sorted(checks.keys())}"
+    )
+
+
+def test_iptables_sudo_check_valid_status(coi_binary):
+    """
+    The 'iptables_sudo' check must be 'ok' or 'warning' — never 'failed'.
+    The check probes a read-only iptables command; if sudo isn't configured
+    it degrades to a warning with a fix, it never hard-fails.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    check = json.loads(result.stdout)["checks"]["iptables_sudo"]
+
+    assert check["status"] in ("ok", "warning"), (
+        f"iptables_sudo status must be 'ok' or 'warning', got: {check['status']!r} "
+        f"(message: {check['message']!r})"
+    )
+
+
+def test_iptables_sudo_check_required_fields(coi_binary):
+    """
+    The 'iptables_sudo' check must have name, status, and message fields.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    check = json.loads(result.stdout)["checks"]["iptables_sudo"]
+
+    assert check.get("name") == "iptables_sudo", (
+        f"Check name field should be 'iptables_sudo', got: {check.get('name')!r}"
+    )
+    assert "status" in check, "Check must have 'status' field"
+    assert "message" in check, "Check must have 'message' field"
+    assert check["message"], "Message must not be empty"
+
+
+def test_iptables_sudo_warning_includes_fix_command(coi_binary):
+    """
+    When iptables sudo is not configured the warning message must include
+    the sudoers.d fix command so the user knows how to resolve it.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    check = json.loads(result.stdout)["checks"]["iptables_sudo"]
+
+    if check["status"] == "warning":
+        assert "sudoers.d" in check["message"], (
+            f"Warning message should include a sudoers.d fix path. Got: {check['message']!r}"
+        )
+        assert "iptables" in check["message"].lower(), (
+            f"Warning message should reference iptables. Got: {check['message']!r}"
+        )
+
+
+def test_iptables_sudo_check_in_networking_section(coi_binary):
+    """
+    The 'iptables sudo' label must appear in the NETWORKING section of the
+    text health output, positioned between 'Bridge forward' and 'Docker FORWARD'.
+    """
+    result = subprocess.run(
+        [coi_binary, "health"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    output = result.stdout
+
+    assert "iptables sudo" in output, (
+        f"Expected 'iptables sudo' label in health text output. Got:\n{output}"
+    )
+
+    # Verify it sits inside the NETWORKING section (before STORAGE:)
+    networking_start = output.find("NETWORKING:")
+    storage_start = output.find("STORAGE:")
+    iptables_pos = output.find("iptables sudo")
+
+    assert networking_start != -1, "NETWORKING section must exist"
+    assert iptables_pos != -1, "iptables sudo label must exist"
+    if storage_start != -1:
+        assert networking_start < iptables_pos < storage_start, (
+            "iptables sudo must appear inside NETWORKING section (between NETWORKING: and STORAGE:)"
+        )
+
+
+def test_iptables_sudo_ok_message_meaningful(coi_binary):
+    """
+    When iptables sudo is configured, the OK message should confirm it clearly.
+    """
+    result = subprocess.run(
+        [coi_binary, "health", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode in [0, 1, 2]
+    check = json.loads(result.stdout)["checks"]["iptables_sudo"]
+
+    if check["status"] == "ok":
+        msg = check["message"].lower()
+        # The message should say something meaningful — not be empty or generic
+        assert any(word in msg for word in ("configured", "not required", "macos")), (
+            f"OK message should be descriptive, got: {check['message']!r}"
+        )

--- a/tests/health/health_verbose_output.py
+++ b/tests/health/health_verbose_output.py
@@ -39,7 +39,6 @@ def test_health_verbose_output(coi_binary):
     # Verify DNS check appears
     assert "DNS resolution" in output, "Verbose should check DNS resolution"
 
-    # Verify passwordless sudo check appears
-    assert "Passwordless sudo" in output or "sudo" in output.lower(), (
-        "Verbose should check passwordless sudo"
-    )
+    # Verify iptables sudo check appears (passwordless_sudo was removed as
+    # it duplicated what CheckNft already verifies)
+    assert "iptables sudo" in output.lower(), "Verbose should show iptables sudo check"

--- a/tests/network/test_bridge_trusted_zone.py
+++ b/tests/network/test_bridge_trusted_zone.py
@@ -85,6 +85,25 @@ def bridge_has_forward_rules(bridge_name):
         return False
 
 
+def forward_policy_is_drop():
+    """Check if the iptables FORWARD chain policy is DROP."""
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", "iptables", "-S", "FORWARD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.splitlines():
+            if line.startswith("-P FORWARD "):
+                return "DROP" in line
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
 def remove_bridge_forward_rules(bridge_name):
     """Remove coi-bridge-forward iptables rules for the bridge (simulates broken state)."""
     # Get all FORWARD rules and delete the ones matching coi-bridge-forward for this bridge
@@ -153,9 +172,13 @@ def test_bridge_trusted_zone_detection_matches_reality(coi_binary):
         assert check["status"] == "ok", (
             f"Expected OK when bridge FORWARD rules exist, got: {check['status']}"
         )
-    else:
+    elif forward_policy_is_drop():
         assert check["status"] == "warning", (
-            f"Expected warning when bridge FORWARD rules missing, got: {check['status']}"
+            f"Expected warning when bridge FORWARD rules missing and FORWARD policy is DROP, got: {check['status']}"
+        )
+    else:
+        assert check["status"] == "ok", (
+            f"Expected OK when bridge FORWARD rules missing but FORWARD policy is not DROP, got: {check['status']}"
         )
 
 
@@ -194,12 +217,17 @@ def test_bridge_zone_removal_and_restore_detected(coi_binary):
         # Verify health check detects removal
         check = get_health_bridge_check(coi_binary)
         assert check is not None, "bridge_forward_rules check should exist"
-        assert check["status"] == "warning", (
-            f"Expected warning after removing bridge FORWARD rules, got: {check['status']}"
-        )
         assert check["details"]["has_forward_rules"] is False, (
             "Should report has_forward_rules=false after removal"
         )
+        if forward_policy_is_drop():
+            assert check["status"] == "warning", (
+                f"Expected warning after removing bridge FORWARD rules (FORWARD policy is DROP), got: {check['status']}"
+            )
+        else:
+            assert check["status"] == "ok", (
+                f"Expected OK after removing bridge FORWARD rules (FORWARD policy is not DROP), got: {check['status']}"
+            )
 
         # Step 2: Re-add by running coi health (or any coi command that triggers autofix)
         # The autofix path in EnsureBridgeInTrustedZone will re-add the rules.


### PR DESCRIPTION
## Summary

- Adds a `CheckIptablesSudo()` health check that probes `sudo -n iptables -L FORWARD -n`
- COI calls `sudo iptables` in several places (`EnsureIptablesBridgeRules`, `ForwardPolicyIsDrop`, `iptablesRuleExists`) regardless of whether nft is also available — without passwordless sudo these operations fail silently
- Fixes a false-positive in `CheckBridgeForwardRules`: previously it warned unconditionally when no bridge FORWARD rules were present, even when FORWARD policy is ACCEPT (meaning no rules are needed at all)
- Downgrades `CheckPermissions` "session not reloaded" result from `StatusFailed` to `StatusWarning`: the user IS correctly configured (in incus-admin group), they just need a re-login; `StatusFailed` is reserved for users not in the group at all
- Also fixes a gap where `tests/health/` was not wired into CI at all

## Health output changes

**iptables sudo** — new check in NETWORKING section:
```
[OK]   iptables sudo     : Passwordless sudo configured for iptables
# or:
[WARN] iptables sudo     : Passwordless sudo not configured for iptables — run: echo "$USER ALL=(ALL) NOPASSWD: /usr/sbin/iptables" | sudo tee /etc/sudoers.d/coi-iptables && sudo chmod 0440 /etc/sudoers.d/coi-iptables
```

**Bridge forward** — no longer a false positive when FORWARD policy is not DROP:
```
# Before (noisy — warned even when FORWARD is ACCEPT):
[WARN] Bridge forward    : Bridge incusbr0 has no iptables FORWARD rules — containers may fail to get IPs if FORWARD policy is DROP

# After (silent when not needed):
[OK]   Bridge forward    : Bridge incusbr0 forwarding OK
```

**Permissions** — "session not reloaded" is now a warning, not a failure:
```
# Before:
[FAIL] Permissions       : User 'alice' is in incus-admin group but session not reloaded

# After:
[WARN] Permissions       : User 'alice' is in incus-admin group but session not reloaded
```

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./internal/health/...` — all pass
- [x] `coi health` — `iptables sudo` in NETWORKING, no spurious Bridge forward warning
- [x] 6 Python integration tests in `tests/health/health_iptables_sudo.py`
- [x] Go regression test: `TestCheckBridgeForwardRules_NoFalsePositiveWhenForwardNotDrop`
- [x] `tests/health` added to CI misc group