### PR TITLE
feat(cli): coi version --format json + fix validate os.Exit consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Improvements
 
+- [Feature] **`coi version --format json`** — `coi version` now accepts `--format json`, returning `{"version":"v...","url":"..."}` for scripts and tooling that need to parse the version without regex.
+
+- [Fix] **`coi validate profile` exit consistency** — The validate command was calling `os.Exit(1)` directly instead of returning `ExitCodeError`, bypassing cobra's error handling and any deferred cleanup. It now returns `ExitCodeError{Code: 1}` consistently with the rest of the CLI.
+
 - [Fix] **Health checks now appear in correct sections** — Eight health checks (`immutable_capability`, `ufw_conflict`, `container_connectivity`, `network_restriction`, `monitoring_configuration`, `audit_log_directory`, `cgroup_availability`, `process_monitoring`) were missing from the category map and display-name table in `coi health`, causing them to appear in an "OTHER" catch-all section with auto-generated names. They are now correctly placed: `immutable_capability` → CRITICAL; `ufw_conflict`, `container_connectivity`, `network_restriction` → NETWORKING; `monitoring_configuration`, `audit_log_directory`, `cgroup_availability` → MONITORING; `process_monitoring` → OPTIONAL (verbose only). The OTHER catch-all section remains in the code as a safety net for any future checks not yet assigned to a category.
 
 - [Feature] **`use_tmux` config option for `coi shell`** — Users who consistently prefer `--tmux=false` can now set `use_tmux = false` once in their `[shell]` section of `config.toml` instead of passing the flag on every invocation. The `--tmux` CLI flag still overrides the config when explicitly set. Resolves #399.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -143,7 +143,7 @@ var versionCmd = &cobra.Command{
 			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format %q: must be 'text' or 'json'", format)}
 		}
 		if format == "json" {
-			fmt.Printf(`{"version":%q,"url":"https://github.com/mensfeld/code-on-incus"}`+"\n", Version)
+			fmt.Printf(`{"version":%q,"url":"https://github.com/mensfeld/code-on-incus"}`+"\n", "v"+Version)
 			return nil
 		}
 		fmt.Printf("code-on-incus (coi) v%s\n", Version)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -137,8 +137,21 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		if format != "text" && format != "json" {
+			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format %q: must be 'text' or 'json'", format)}
+		}
+		if format == "json" {
+			fmt.Printf(`{"version":%q,"url":"https://github.com/mensfeld/code-on-incus"}`+"\n", Version)
+			return nil
+		}
 		fmt.Printf("code-on-incus (coi) v%s\n", Version)
 		fmt.Println("https://github.com/mensfeld/code-on-incus")
+		return nil
 	},
+}
+
+func init() {
+	versionCmd.Flags().String("format", "text", "Output format: text or json")
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -61,7 +61,7 @@ Examples:
 		if _, err := toml.DecodeFile(path, &rawMap); err != nil {
 			emitValidateOutput(format, false,
 				[]coischema.ValidationIssue{{Path: "", Message: fmt.Sprintf("failed to parse TOML: %s", err)}})
-			os.Exit(1)
+			return &ExitCodeError{Code: 1}
 		}
 
 		schemaErr := coischema.ValidateProfileMap(rawMap)
@@ -71,8 +71,7 @@ Examples:
 		}
 
 		emitValidateOutput(format, false, coischema.ExtractErrors(schemaErr))
-		os.Exit(1)
-		return nil
+		return &ExitCodeError{Code: 1}
 	},
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -50,6 +50,7 @@ Examples:
   result = JSON.parse(` + "`coi validate profile #{Shellwords.escape(path)} --format json`" + `)`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		format, _ := cmd.Flags().GetString("format")
 		if format != "text" && format != "json" {
 			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format %q: must be 'text' or 'json'", format)}


### PR DESCRIPTION
## Summary

Two small improvements for programmatic/scripting use:

### 1. `coi version --format json`

Scripts that need the version string no longer have to regex-parse text output:

```bash
# Before — fragile text parsing
coi version | grep -oP '(?<=v)\S+'

# After
coi version --format json
# {"version":"v0.9.0","url":"https://github.com/mensfeld/code-on-incus"}
```

### 2. `coi validate profile` exit consistency

The validate command was calling `os.Exit(1)` directly on invalid TOML or schema failure, bypassing cobra's error handling and any deferred cleanup. Replaced with `return &ExitCodeError{Code: 1}` — consistent with every other command in the CLI.

Exit codes are unchanged (0 = valid, 1 = invalid, 2 = bad flag).

## Test plan

- [x] `go build ./...` — clean compile
- [x] `coi version --format json` outputs `{"version":"...","url":"..."}`
- [x] `coi version` still outputs original text
- [x] `coi version --format bad` exits 2 with error message
- [x] `coi validate profile` still exits 1 on invalid file (behaviour unchanged)