### PR TITLE
ci: split misc test group into 3 parallel groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,15 @@ jobs:
           - name: core-build
             path: tests/build tests/run
             description: "Build and run command tests"
-          - name: misc
-            path: tests/clean tests/cli tests/completion tests/docker tests/errors tests/help tests/image tests/info tests/mount tests/monitor tests/shutdown tests/snapshot tests/update tests/version tests/meta tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/cli/completion/docker/errors/help/image/info/mount/monitor/shutdown/snapshot/update/version/meta"
+          - name: misc-cli
+            path: tests/cli
+            description: "CLI flag/format/output tests"
+          - name: misc-snapshot
+            path: tests/meta tests/snapshot tests/image
+            description: "Snapshot, image, and meta command tests"
+          - name: misc-commands
+            path: tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: clean/docker/errors/help/info/mount/monitor/shutdown/update/version"
           - name: misc-config
             path: tests/config tests/health tests/limits tests/schema
             description: "Config, health, limits, and schema tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           go tool cover -func=coverage.out | tail -1  # Show total coverage
 
   # Integration tests run in parallel with unit tests (after build passes)
-  # Split into 13 test groups for parallel execution
+  # Split into 15 test groups for parallel execution
   # Network isolation uses nftables (ip coi forward chain)
   integration:
     name: Integration Tests (${{ matrix.test_group.name }})
@@ -139,7 +139,7 @@ jobs:
             description: "Snapshot, image, and meta command tests"
           - name: misc-commands
             path: tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/docker/errors/help/info/mount/monitor/shutdown/update/version"
+            description: "Misc commands: clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
           - name: misc-config
             path: tests/config tests/health tests/limits tests/schema
             description: "Config, health, limits, and schema tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Verify all test paths are assigned to a CI group
+        run: python3 scripts/check-ci-coverage.py
+
   # Go unit tests run in parallel with integration tests (after build passes)
   unit-tests:
     name: Unit Tests

--- a/scripts/check-ci-coverage.py
+++ b/scripts/check-ci-coverage.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Verify that every test directory and standalone test file under tests/ is
+referenced by at least one group in the CI integration matrix.
+
+Run: python3 scripts/check-ci-coverage.py
+Exit 0 = all covered. Exit 1 = uncovered paths found.
+"""
+import sys
+import yaml
+from pathlib import Path
+
+# Files/dirs that intentionally live under tests/ but are not test groups.
+NOT_TEST_ENTRIES = {
+    "conftest.py",  # pytest fixtures shared across groups
+    "support",      # helper modules (helpers.py etc.)
+    "__pycache__",
+}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parent.parent
+    ci_file = repo / ".github" / "workflows" / "ci.yml"
+    tests_dir = repo / "tests"
+
+    with open(ci_file) as f:
+        ci = yaml.safe_load(f)
+
+    # Collect every path token from every group's `path:` field.
+    covered: set[str] = set()
+    for group in ci["jobs"]["integration"]["strategy"]["matrix"]["test_group"]:
+        path_field = group.get("path", "")
+        for token in path_field.split():
+            covered.add(token)
+
+    uncovered: list[str] = []
+
+    for item in sorted(tests_dir.iterdir()):
+        if item.name in NOT_TEST_ENTRIES or item.name.startswith("_"):
+            continue
+
+        if item.is_dir():
+            # Only flag directories that actually contain .py files.
+            if not any(item.rglob("*.py")):
+                continue
+            rel = f"tests/{item.name}"
+        elif item.suffix == ".py":
+            rel = f"tests/{item.name}"
+        else:
+            continue
+
+        # Covered if: exact match, rel is a sub-path of a covered token,
+        # or a covered token is a sub-path of rel (e.g. tests/shell covered
+        # via tests/shell/ephemeral and tests/shell/persistent).
+        is_covered = any(
+            rel == p
+            or rel.startswith(p.rstrip("/") + "/")
+            or p.startswith(rel.rstrip("/") + "/")
+            for p in covered
+        )
+        if not is_covered:
+            uncovered.append(rel)
+
+    if uncovered:
+        print("ERROR: the following test paths are not assigned to any CI group:")
+        for p in uncovered:
+            print(f"  {p}")
+        print()
+        print("Add them to a group in .github/workflows/ci.yml under")
+        print("jobs.integration.strategy.matrix.test_group[*].path")
+        return 1
+
+    print(f"OK: all test paths are covered ({len(covered)} path entries across CI groups)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The `misc` CI group was a single job running for ~28 minutes, making it the longest-running group in the pipeline. This blocked PR merges unnecessarily.

## What

Replaced `misc` with three parallel groups based on actual timing data from run [26821063610](https://github.com/mensfeld/code-on-incus/actions/runs/26821063610):

| Group | Directories | Tests | Est. time |
|-------|-------------|-------|-----------|
| `misc-cli` | `tests/cli` | 110 | ~10m |
| `misc-snapshot` | `tests/meta` + `tests/snapshot` + `tests/image` | 84 | ~12m |
| `misc-commands` | `tests/clean` + `tests/docker` + `tests/errors` + `tests/help` + `tests/info` + `tests/mount` + `tests/monitor` + `tests/shutdown` + `tests/update` + `tests/version` + `tests/completion` + 2 root test files | 56 | ~5m |

All three run in parallel on separate runners (same as every other group).

## Expected improvement

~28 minutes → ~12 minutes wall-clock time (the new longest group, `misc-snapshot`).

## Checklist

- [x] No tests removed or skipped — same test files, just reorganised across groups
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Group names are distinct from the old `misc` name (avoids confusion in CI history)