### PR TITLE
refactor(arch): interfaces at subsystem boundaries + App struct for CLI state

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -46,7 +46,7 @@ func attachCommand(cmd *cobra.Command, args []string) error {
 	// If --slot is provided, calculate container name from workspace and slot
 	if attachSlot > 0 {
 		// Resolve workspace path
-		workspacePath, err := filepath.Abs(workspace)
+		workspacePath, err := filepath.Abs(app.workspace)
 		if err != nil {
 			return fmt.Errorf("failed to resolve workspace path: %w", err)
 		}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -52,12 +52,12 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Determine which profile to use
-	profileName := profile // from --profile flag
+	profileName := app.profile // from --profile flag
 	if profileName == "" {
 		profileName = "default"
 	}
 
-	p := cfg.GetProfile(profileName)
+	p := app.cfg.GetProfile(profileName)
 	if p == nil {
 		return fmt.Errorf("profile '%s' not found", profileName)
 	}
@@ -72,7 +72,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	// pool and let the selected profile override it only when it sets a
 	// non-empty storage_pool value. Validate before any container work so a
 	// missing pool fails loud and early.
-	buildPool := cfg.Container.StoragePool
+	buildPool := app.cfg.Container.StoragePool
 	if p.Container.StoragePool != "" {
 		buildPool = p.Container.StoragePool
 	}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -63,7 +63,7 @@ func init() {
 
 func cleanCommand(cmd *cobra.Command, args []string) error {
 	// Get configured tool to determine tool-specific sessions directory
-	toolInstance, err := getConfiguredTool(cfg)
+	toolInstance, err := getConfiguredTool(app.cfg)
 	if err != nil {
 		return err
 	}
@@ -494,11 +494,11 @@ func cleanUnreferencedPools() (int, bool, error) {
 // the global entry itself is empty (meaning "use Incus default pool").
 func referencedPoolSet() map[string]bool {
 	set := map[string]bool{}
-	if cfg == nil {
+	if app.cfg == nil {
 		return set
 	}
-	set[cfg.Container.StoragePool] = true
-	for _, profile := range cfg.Profiles {
+	set[app.cfg.Container.StoragePool] = true
+	for _, profile := range app.cfg.Profiles {
 		if profile.Container.StoragePool != "" {
 			set[profile.Container.StoragePool] = true
 		}

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -48,7 +48,7 @@ func healthCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Use package-level cfg from PersistentPreRunE, fall back to defaults
-	healthCfg := cfg
+	healthCfg := app.cfg
 	if healthCfg == nil {
 		healthCfg = config.GetDefaultConfig()
 	}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -25,7 +25,7 @@ Examples:
 
 func infoCommand(cmd *cobra.Command, args []string) error {
 	// Get configured tool to determine tool-specific sessions directory
-	toolInstance, err := getConfiguredTool(cfg)
+	toolInstance, err := getConfiguredTool(app.cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -44,7 +44,7 @@ func listCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get configured tool to determine tool-specific sessions directory
-	toolInstance, err := getConfiguredTool(cfg)
+	toolInstance, err := getConfiguredTool(app.cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -83,7 +83,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 
 	// Get allowed CIDRs from network config
 	allowedCIDRs := []string{}
-	if cfg.Network.Mode == config.NetworkModeAllowlist {
+	if app.cfg.Network.Mode == config.NetworkModeAllowlist {
 		// Convert allowed domains to CIDRs (simplified - in full implementation would resolve)
 		// For now, just pass empty list
 		allowedCIDRs = []string{}
@@ -91,7 +91,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 
 	// Create collector
 	collector := monitor.NewCollector(containerName, "", "", allowedCIDRs)
-	detector := monitor.NewDetector(cfg.Monitoring.FileReadThresholdMB, cfg.Monitoring.FileReadRateMBPerSec)
+	detector := monitor.NewDetector(app.cfg.Monitoring.FileReadThresholdMB, app.cfg.Monitoring.FileReadRateMBPerSec)
 
 	// Watch mode or one-shot
 	if monitorWatch > 0 {
@@ -159,7 +159,7 @@ func resolveMonitorContainer(args []string) (string, error) {
 	}
 
 	// 3. Find container for current workspace
-	absWorkspace, err := filepath.Abs(workspace)
+	absWorkspace, err := filepath.Abs(app.workspace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve workspace path: %w", err)
 	}

--- a/internal/cli/persist.go
+++ b/internal/cli/persist.go
@@ -95,7 +95,7 @@ func persistCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get tool instance to determine sessions directory
-	toolInstance, err := getConfiguredTool(cfg)
+	toolInstance, err := getConfiguredTool(app.cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -39,7 +39,7 @@ Examples:
 			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format '%s': must be 'text' or 'json'", profileFormat)}
 		}
 
-		if len(cfg.Profiles) == 0 {
+		if len(app.cfg.Profiles) == 0 {
 			if profileFormat == "json" {
 				fmt.Println("[]")
 				return nil
@@ -49,8 +49,8 @@ Examples:
 		}
 
 		// Sort profile names for consistent output
-		names := make([]string, 0, len(cfg.Profiles))
-		for name := range cfg.Profiles {
+		names := make([]string, 0, len(app.cfg.Profiles))
+		for name := range app.cfg.Profiles {
 			names = append(names, name)
 		}
 		sort.Strings(names)
@@ -66,7 +66,7 @@ Examples:
 			}
 			entries := make([]profileEntry, 0, len(names))
 			for _, name := range names {
-				p := cfg.Profiles[name]
+				p := app.cfg.Profiles[name]
 				entries = append(entries, profileEntry{
 					Name:        name,
 					Image:       p.Container.Image,
@@ -86,7 +86,7 @@ Examples:
 
 		tbl := NewTable("NAME", "IMAGE", "PERSISTENT", "INHERITS", "SOURCE")
 		for _, name := range names {
-			p := cfg.Profiles[name]
+			p := app.cfg.Profiles[name]
 			image := p.Container.Image
 			if image == "" {
 				image = "(default)"
@@ -125,7 +125,7 @@ Examples:
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		p := cfg.GetProfile(name)
+		p := app.cfg.GetProfile(name)
 		if p == nil {
 			return fmt.Errorf("profile '%s' not found", name)
 		}
@@ -418,7 +418,7 @@ func resolveProfileDir(name string, forceUser, forceProject bool) (string, error
 	}
 
 	if forceProject {
-		absWorkspace, err := filepath.Abs(workspace)
+		absWorkspace, err := filepath.Abs(app.workspace)
 		if err != nil {
 			return "", fmt.Errorf("cannot resolve workspace: %w", err)
 		}
@@ -426,7 +426,7 @@ func resolveProfileDir(name string, forceUser, forceProject bool) (string, error
 	}
 
 	// Default: project if .coi/ exists, otherwise user home
-	absWorkspace, err := filepath.Abs(workspace)
+	absWorkspace, err := filepath.Abs(app.workspace)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve workspace: %w", err)
 	}
@@ -484,7 +484,7 @@ Examples:
 		}
 
 		// Check if a profile with this name already exists in any config source
-		if existing := cfg.GetProfile(name); existing != nil {
+		if existing := app.cfg.GetProfile(name); existing != nil {
 			return fmt.Errorf("profile '%s' already exists (source: %s)", name, existing.Source)
 		}
 
@@ -508,7 +508,7 @@ Examples:
 			topLines = append(topLines, fmt.Sprintf("inherits = %q", inherits))
 		}
 		if cmd.Flags().Changed("image") {
-			containerLines = append(containerLines, fmt.Sprintf("image = %q", imageName))
+			containerLines = append(containerLines, fmt.Sprintf("image = %q", app.imageName))
 		}
 		if cmd.Flags().Changed("persistent") {
 			containerLines = append(containerLines, "persistent = true")
@@ -558,7 +558,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		p := cfg.GetProfile(name)
+		p := app.cfg.GetProfile(name)
 		if p == nil {
 			return fmt.Errorf("profile '%s' not found", name)
 		}
@@ -616,7 +616,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		p := cfg.GetProfile(name)
+		p := app.cfg.GetProfile(name)
 		if p == nil {
 			return fmt.Errorf("profile '%s' not found", name)
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,19 +11,26 @@ import (
 // Version is the current version of coi (injected via ldflags at build time)
 var Version = "dev"
 
-var (
-	// Global flags
+// App holds the shared CLI state that is populated from persistent flags and
+// config loading in PersistentPreRunE. Grouping this in a struct rather than
+// package-level vars makes it easier to construct an isolated instance in
+// tests and clears the path toward a multi-session daemon model.
+type App struct {
 	workspace       string
 	slot            int
 	imageName       string
 	persistent      bool
 	resume          string
-	continueSession string // Alias for resume
+	continueSession string
 	profile         string
+	cfg             *config.Config
+}
 
-	// Loaded config
-	cfg *config.Config
-)
+// app is the singleton used by the cobra command tree. Execute() resets it to
+// a zero value on each call so tests that invoke Execute() multiple times
+// start with clean state (cobra re-parses flags, PersistentPreRunE reloads
+// the config).
+var app = &App{}
 
 // rootCmd represents the base command
 var rootCmd = &cobra.Command{
@@ -51,29 +58,29 @@ Examples:
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Load config
 		var err error
-		cfg, err = config.Load()
+		app.cfg, err = config.Load()
 		if err != nil {
 			// Allow health command to run with defaults even if config is broken
 			if cmd.Name() == "health" {
-				cfg = config.GetDefaultConfig()
+				app.cfg = config.GetDefaultConfig()
 			} else {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 		}
 
 		// Apply profile if specified
-		if profile != "" {
-			if err := cfg.ApplyProfile(profile); err != nil {
+		if app.profile != "" {
+			if err := app.cfg.ApplyProfile(app.profile); err != nil {
 				return err
 			}
 		}
 
 		// Apply Incus configuration from config file
-		container.Configure(cfg.Incus.Project, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
+		container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
 
 		// Apply config defaults to flags that weren't explicitly set
 		if !cmd.Flags().Changed("persistent") {
-			persistent = config.BoolVal(cfg.Container.Persistent)
+			app.persistent = config.BoolVal(app.cfg.Container.Persistent)
 		}
 
 		// Silence usage output for RunE errors. Setting this here (in
@@ -88,6 +95,11 @@ Examples:
 
 // Execute runs the root command
 func Execute(isCoi bool) error {
+	// Reset app state so that repeated calls (e.g. in tests) start clean.
+	// Cobra re-parses flags on every Execute, so flag-bound fields are
+	// repopulated correctly from the fresh zero value.
+	*app = App{}
+
 	if !isCoi {
 		rootCmd.Use = "claude-on-incus"
 	}
@@ -98,15 +110,15 @@ func Execute(isCoi bool) error {
 
 func init() {
 	// Global flags available to all commands
-	rootCmd.PersistentFlags().StringVarP(&workspace, "workspace", "w", ".", "Workspace directory to mount")
-	rootCmd.PersistentFlags().IntVar(&slot, "slot", 0, "Slot number for parallel sessions (0 = auto-allocate)")
-	rootCmd.PersistentFlags().StringVar(&imageName, "image", "", "Custom image to use (default: coi-default)")
-	rootCmd.PersistentFlags().BoolVar(&persistent, "persistent", false, "Reuse container across sessions")
-	rootCmd.PersistentFlags().StringVar(&resume, "resume", "", "Resume from session ID (omit value to auto-detect)")
+	rootCmd.PersistentFlags().StringVarP(&app.workspace, "workspace", "w", ".", "Workspace directory to mount")
+	rootCmd.PersistentFlags().IntVar(&app.slot, "slot", 0, "Slot number for parallel sessions (0 = auto-allocate)")
+	rootCmd.PersistentFlags().StringVar(&app.imageName, "image", "", "Custom image to use (default: coi-default)")
+	rootCmd.PersistentFlags().BoolVar(&app.persistent, "persistent", false, "Reuse container across sessions")
+	rootCmd.PersistentFlags().StringVar(&app.resume, "resume", "", "Resume from session ID (omit value to auto-detect)")
 	rootCmd.PersistentFlags().Lookup("resume").NoOptDefVal = "auto"
-	rootCmd.PersistentFlags().StringVar(&continueSession, "continue", "", "Alias for --resume")
+	rootCmd.PersistentFlags().StringVar(&app.continueSession, "continue", "", "Alias for --resume")
 	rootCmd.PersistentFlags().Lookup("continue").NoOptDefVal = "auto"
-	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Use named profile")
+	rootCmd.PersistentFlags().StringVar(&app.profile, "profile", "", "Use named profile")
 
 	// Add subcommands
 	rootCmd.AddCommand(runCmd)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -35,7 +35,7 @@ Examples:
 
 func runCommand(cmd *cobra.Command, args []string) error {
 	// Get absolute workspace path
-	absWorkspace, err := filepath.Abs(workspace)
+	absWorkspace, err := filepath.Abs(app.workspace)
 	if err != nil {
 		return fmt.Errorf("invalid workspace path: %w", err)
 	}
@@ -49,8 +49,8 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate max_duration early so the user gets a clear error before any container work.
-	if cfg.Limits.Runtime.MaxDuration != "" {
-		if _, err := limits.ParseDuration(cfg.Limits.Runtime.MaxDuration); err != nil {
+	if app.cfg.Limits.Runtime.MaxDuration != "" {
+		if _, err := limits.ParseDuration(app.cfg.Limits.Runtime.MaxDuration); err != nil {
 			return fmt.Errorf("invalid max_duration: %w", err)
 		}
 	}
@@ -71,7 +71,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Allocate slot if not specified
-	slotNum := slot
+	slotNum := app.slot
 	if slotNum == 0 {
 		slotNum, err = session.AllocateSlot(absWorkspace, 10)
 		if err != nil {
@@ -84,22 +84,22 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	containerName := session.ContainerName(absWorkspace, slotNum)
 
 	// Determine image: CLI --image flag > config defaults.image > "coi-default"
-	img := ResolveImageName(imageName, cfg)
+	img := ResolveImageName(app.imageName, app.cfg)
 
 	// Check if image exists, auto-build from config if possible
-	if err := AutoBuildIfNeeded(cfg, img); err != nil {
+	if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
 		return err
 	}
 
 	// Validate the storage pool exists before doing any container work so the
 	// user gets an actionable "create with `incus storage create`" error
 	// instead of a cryptic Incus failure midway through launch.
-	if err := container.ValidateStoragePool(cfg.Container.StoragePool); err != nil {
+	if err := container.ValidateStoragePool(app.cfg.Container.StoragePool); err != nil {
 		return err
 	}
 
 	// Validate and prepare alias if configured
-	effectiveAlias, err := validateAndPrepareAlias(cfg.Container.Alias)
+	effectiveAlias, err := validateAndPrepareAlias(app.cfg.Container.Alias)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to check if container exists: %w", err)
 	}
 
-	if err := launchOrReuseContainer(mgr, img, cfg.Container.StoragePool, containerExists, persistent); err != nil {
+	if err := launchOrReuseContainer(mgr, img, app.cfg.Container.StoragePool, containerExists, app.persistent); err != nil {
 		return err
 	}
 
@@ -144,7 +144,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if !persistent {
+		if !app.persistent {
 			fmt.Fprintf(os.Stderr, "Cleaning up container %s...\n", containerName)
 			_ = mgr.Delete(true) // Best effort cleanup
 		} else {
@@ -157,9 +157,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Apply resource limits (only for new containers, not restarted persistent ones)
-	wasRestarted := containerExists && persistent
+	wasRestarted := containerExists && app.persistent
 	if !wasRestarted {
-		limitsConfig := &cfg.Limits
+		limitsConfig := &app.cfg.Limits
 		if limitsConfig != nil && hasAnyLimits(limitsConfig) {
 			fmt.Fprintf(os.Stderr, "Applying resource limits...\n")
 			applyOpts := limits.ApplyOptions{
@@ -183,7 +183,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 				Runtime: limits.RuntimeLimits{
 					MaxProcesses: limitsConfig.Runtime.MaxProcesses,
 				},
-				Project: cfg.Incus.Project,
+				Project: app.cfg.Incus.Project,
 			}
 			if err := limits.ApplyResourceLimits(applyOpts); err != nil {
 				return fmt.Errorf("failed to apply resource limits: %w", err)
@@ -206,7 +206,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	containerWorkspacePath := resolveContainerWorkspacePath(absWorkspace)
 
 	// Mount workspace (skip if restarting existing persistent container)
-	useShift := !cfg.Incus.DisableShift
+	useShift := !app.cfg.Incus.DisableShift
 	if err := applyWorkspaceMounts(mgr, containerName, absWorkspace, &containerWorkspacePath, useShift, wasRestarted); err != nil {
 		return err
 	}
@@ -233,15 +233,15 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// The monitor runs in a background goroutine and stops the container when
 	// the duration elapses, which causes the blocking incus exec below to return.
 	var timeoutMon *limits.TimeoutMonitor
-	if cfg.Limits.Runtime.MaxDuration != "" {
-		maxDur, _ := limits.ParseDuration(cfg.Limits.Runtime.MaxDuration) // already validated above
-		autoStop := config.BoolVal(cfg.Limits.Runtime.AutoStop)
-		if cfg.Limits.Runtime.AutoStop == nil {
+	if app.cfg.Limits.Runtime.MaxDuration != "" {
+		maxDur, _ := limits.ParseDuration(app.cfg.Limits.Runtime.MaxDuration) // already validated above
+		autoStop := config.BoolVal(app.cfg.Limits.Runtime.AutoStop)
+		if app.cfg.Limits.Runtime.AutoStop == nil {
 			autoStop = true // default: auto-stop when limit reached
 		}
-		stopGraceful := config.BoolVal(cfg.Limits.Runtime.StopGraceful)
+		stopGraceful := config.BoolVal(app.cfg.Limits.Runtime.StopGraceful)
 		runLog := logger.NewDiscard()
-		timeoutMon = limits.NewTimeoutMonitor(cmd.Context(), containerName, maxDur, autoStop, stopGraceful, cfg.Incus.Project, runLog)
+		timeoutMon = limits.NewTimeoutMonitor(cmd.Context(), containerName, maxDur, autoStop, stopGraceful, app.cfg.Incus.Project, runLog)
 		timeoutMon.Start()
 		defer timeoutMon.Stop()
 	}
@@ -284,7 +284,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 
 // launchOrReuseContainer restarts an existing persistent container, or
 // recreates / creates a fresh one on the given storage pool.
-func launchOrReuseContainer(mgr *container.Manager, img, pool string, containerExists, persistent bool) error {
+func launchOrReuseContainer(mgr container.ContainerManager, img, pool string, containerExists, persistent bool) error {
 	if containerExists && persistent {
 		fmt.Fprintf(os.Stderr, "Restarting existing persistent container...\n")
 		if err := mgr.Start(); err != nil {
@@ -306,7 +306,7 @@ func launchOrReuseContainer(mgr *container.Manager, img, pool string, containerE
 }
 
 // waitForContainer waits for container to be ready
-func waitForContainer(mgr *container.Manager, maxRetries int) error {
+func waitForContainer(mgr container.ContainerManager, maxRetries int) error {
 	for i := 0; i < maxRetries; i++ {
 		running, err := mgr.Running()
 		if err != nil {
@@ -343,7 +343,7 @@ func ensureBridgeTrustedZone() {
 // containers that actually have the code user (probed at runtime, since
 // custom images built FROM coi-default also inherit it) when the
 // configured UID differs from the image default.
-func remapContainerUserIfNeeded(mgr *container.Manager, wasRestarted bool) error {
+func remapContainerUserIfNeeded(mgr container.ContainerManager, wasRestarted bool) error {
 	if wasRestarted || container.CodeUID == 1000 {
 		return nil
 	}
@@ -390,12 +390,12 @@ func appendEnvArgs(incusArgs []string, tz, sshAgentSocketPath string) []string {
 	}
 
 	// Static environment from config (defaults.environment + profile environment)
-	for k, v := range cfg.Defaults.Environment {
+	for k, v := range app.cfg.Defaults.Environment {
 		incusArgs = append(incusArgs, "--env", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	// Resolve forward_env from config, look up host values
-	for _, name := range cfg.Defaults.ForwardEnv {
+	for _, name := range app.cfg.Defaults.ForwardEnv {
 		if val, ok := os.LookupEnv(name); ok {
 			incusArgs = append(incusArgs, "--env", fmt.Sprintf("%s=%s", name, val))
 		} else {
@@ -496,10 +496,10 @@ func overlayWorkspaceConfig(absWorkspace string) error {
 	if absWorkspace == absCWD {
 		return nil
 	}
-	if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+	if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 	}
-	container.Configure(cfg.Incus.Project, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
+	container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
 	return nil
 }
 
@@ -507,7 +507,7 @@ func overlayWorkspaceConfig(absWorkspace string) error {
 // workspace should be mounted. When preserve_workspace_path is set it mirrors
 // the host path, falling back to /workspace if the path conflicts with system dirs.
 func resolveContainerWorkspacePath(absWorkspace string) string {
-	if !cfg.Paths.PreserveWorkspacePath {
+	if !app.cfg.Paths.PreserveWorkspacePath {
 		return "/workspace"
 	}
 	cleanPath := filepath.Clean(absWorkspace)
@@ -526,7 +526,7 @@ func resolveContainerWorkspacePath(absWorkspace string) string {
 // applyWorkspaceMounts mounts the workspace and all configured additional directories
 // into the container, then applies security (read-only) mounts. For restarted persistent
 // containers it retrieves the existing workspace path from the container config instead.
-func applyWorkspaceMounts(mgr *container.Manager, containerName, absWorkspace string, containerWorkspacePath *string, useShift, wasRestarted bool) error {
+func applyWorkspaceMounts(mgr container.ContainerManager, containerName, absWorkspace string, containerWorkspacePath *string, useShift, wasRestarted bool) error {
 	if wasRestarted {
 		fmt.Fprintf(os.Stderr, "Reusing existing workspace mount...\n")
 		*containerWorkspacePath = mgr.GetWorkspacePath()
@@ -542,7 +542,7 @@ func applyWorkspaceMounts(mgr *container.Manager, containerName, absWorkspace st
 		return fmt.Errorf("failed to mount workspace: %w", err)
 	}
 
-	mountConfig, err := ParseMountConfig(cfg)
+	mountConfig, err := ParseMountConfig(app.cfg)
 	if err != nil {
 		return fmt.Errorf("invalid mount configuration: %w", err)
 	}
@@ -557,7 +557,7 @@ func applyWorkspaceMounts(mgr *container.Manager, containerName, absWorkspace st
 		}
 	}
 
-	if !cfg.Security.DisableProtection {
+	if !app.cfg.Security.DisableProtection {
 		if err := applySecurityMounts(mgr, absWorkspace, *containerWorkspacePath, containerName, useShift); err != nil {
 			return err
 		}
@@ -566,7 +566,7 @@ func applyWorkspaceMounts(mgr *container.Manager, containerName, absWorkspace st
 }
 
 // addMount adds a single configured directory mount to the container.
-func addMount(mgr *container.Manager, mount session.MountEntry, useShift bool) error {
+func addMount(mgr container.ContainerManager, mount session.MountEntry, useShift bool) error {
 	if mount.Readonly {
 		if _, err := os.Stat(mount.HostPath); err != nil {
 			if os.IsNotExist(err) {
@@ -589,8 +589,8 @@ func addMount(mgr *container.Manager, mount session.MountEntry, useShift bool) e
 }
 
 // applySecurityMounts sets up read-only protection mounts and optional host immutable flags.
-func applySecurityMounts(mgr *container.Manager, absWorkspace, containerWorkspacePath, containerName string, useShift bool) error {
-	protectedPaths := filterWritableGitHooks(cfg.Security.GetEffectiveProtectedPaths(), cfg)
+func applySecurityMounts(mgr container.ContainerManager, absWorkspace, containerWorkspacePath, containerName string, useShift bool) error {
+	protectedPaths := filterWritableGitHooks(app.cfg.Security.GetEffectiveProtectedPaths(), app.cfg)
 	if len(protectedPaths) == 0 {
 		return nil
 	}
@@ -602,7 +602,7 @@ func applySecurityMounts(mgr *container.Manager, absWorkspace, containerWorkspac
 			fmt.Fprintf(os.Stderr, "Protected paths (mounted read-only): %s\n", strings.Join(actualPaths, ", "))
 		}
 	}
-	if cfg.Security.IsHostImmutableEnabled() {
+	if app.cfg.Security.IsHostImmutableEnabled() {
 		logFn := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
 		immutablePaths := session.ApplyImmutable(absWorkspace, protectedPaths, containerName, logFn)
 		if len(immutablePaths) > 0 {
@@ -614,8 +614,8 @@ func applySecurityMounts(mgr *container.Manager, absWorkspace, containerWorkspac
 
 // applySSHAgentForwarding forwards the host SSH agent into the container when
 // ssh.forward_agent is true in config. Returns the container-side socket path.
-func applySSHAgentForwarding(mgr *container.Manager, containerName string) (string, error) {
-	if !config.BoolVal(cfg.SSH.ForwardAgent) {
+func applySSHAgentForwarding(mgr container.ContainerManager, containerName string) (string, error) {
+	if !config.BoolVal(app.cfg.SSH.ForwardAgent) {
 		return "", nil
 	}
 	logger := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
@@ -634,7 +634,7 @@ func applySSHAgentForwarding(mgr *container.Manager, containerName string) (stri
 // network.mode is set to something other than "open" in config.
 // Returns the Manager so the caller can Teardown before container deletion.
 func applyNetworkIsolation(containerName string) (*network.Manager, error) {
-	networkConfig := cfg.Network
+	networkConfig := app.cfg.Network
 	if networkConfig.Mode == "" || networkConfig.Mode == config.NetworkModeOpen {
 		return nil, nil
 	}
@@ -653,8 +653,8 @@ func applyNetworkIsolation(containerName string) (*network.Manager, error) {
 
 // applyContainerTimezone resolves the timezone and configures it inside the container.
 // Returns the resolved timezone name (empty for UTC).
-func applyContainerTimezone(mgr *container.Manager) string {
-	tz := resolveTimezone(cfg)
+func applyContainerTimezone(mgr container.ContainerManager) string {
+	tz := resolveTimezone(app.cfg)
 	if tz != "" {
 		tzCmd := fmt.Sprintf(
 			"ln -sf /usr/share/zoneinfo/%s /etc/localtime && echo %s > /etc/timezone",

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -87,7 +87,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get absolute workspace path
-	absWorkspace, err := filepath.Abs(workspace)
+	absWorkspace, err := filepath.Abs(app.workspace)
 	if err != nil {
 		return fmt.Errorf("invalid workspace path: %w", err)
 	}
@@ -100,10 +100,10 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	if aliasArg == "" {
 		if cwd, err := os.Getwd(); err == nil {
 			if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
-				if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+				if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 					return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 				}
-				container.Configure(cfg.Incus.Project, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
+				container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
 			}
 		}
 	}
@@ -120,28 +120,28 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		// Reload project config from the resolved workspace so that mounts,
 		// network, storage_pool, alias, and other project-level settings from
 		// the target workspace are applied instead of the caller's CWD config.
-		if err := cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+		if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 		}
 
 		// Apply profile if registry specifies one and user didn't override
 		if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
-			profile = resolved.Profile
-			if err := cfg.ApplyProfile(profile); err != nil {
+			app.profile = resolved.Profile
+			if err := app.cfg.ApplyProfile(app.profile); err != nil {
 				return err
 			}
 		}
 		// Re-apply Incus configuration after config reload
-		container.Configure(cfg.Incus.Project, cfg.Incus.CodeUser, cfg.Incus.CodeUID)
+		container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
 		if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
-			slot = resolved.Slot
+			app.slot = resolved.Slot
 		}
 	}
 
 	// Determine useTmux: config default, overridden by explicit --tmux flag
 	useTmuxDefault := true
-	if cfg.Shell.UseTmux != nil {
-		useTmuxDefault = *cfg.Shell.UseTmux
+	if app.cfg.Shell.UseTmux != nil {
+		useTmuxDefault = *app.cfg.Shell.UseTmux
 	}
 	if !cmd.Flags().Changed("tmux") {
 		useTmux = useTmuxDefault
@@ -172,9 +172,9 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	// Get configured tool (needed to determine tool-specific sessions directory)
 	// --tool flag overrides whatever is in .coi/config.toml or global config
 	if toolFlag != "" {
-		cfg.Tool.Name = toolFlag
+		app.cfg.Tool.Name = toolFlag
 	}
-	toolInstance, err := getConfiguredTool(cfg)
+	toolInstance, err := getConfiguredTool(app.cfg)
 	if err != nil {
 		return err
 	}
@@ -191,9 +191,9 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle resume flag (--resume or --continue)
-	resumeID := resume
-	if continueSession != "" {
-		resumeID = continueSession // --continue takes precedence if both are provided
+	resumeID := app.resume
+	if app.continueSession != "" {
+		resumeID = app.continueSession // --continue takes precedence if both are provided
 	}
 
 	// Check if resume/continue flag was explicitly set
@@ -242,21 +242,21 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 		if metadata, err := session.LoadSessionMetadata(metadataPath); err == nil {
 			// Inherit profile if not explicitly set by user
 			if !cmd.Flags().Changed("profile") && metadata.ProfileName != "" {
-				profile = metadata.ProfileName
-				if err := cfg.ApplyProfile(profile); err != nil {
-					return fmt.Errorf("failed to apply saved profile '%s': %w", profile, err)
+				app.profile = metadata.ProfileName
+				if err := app.cfg.ApplyProfile(app.profile); err != nil {
+					return fmt.Errorf("failed to apply saved profile '%s': %w", app.profile, err)
 				}
 				// Re-apply persistent from config since profile may override it
 				if !cmd.Flags().Changed("persistent") {
-					persistent = config.BoolVal(cfg.Container.Persistent)
+					app.persistent = config.BoolVal(app.cfg.Container.Persistent)
 				}
-				fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", profile)
+				fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", app.profile)
 			}
 
 			// Inherit persistent flag if not explicitly set by user
 			if !cmd.Flags().Changed("persistent") {
-				persistent = metadata.Persistent
-				if persistent {
+				app.persistent = metadata.Persistent
+				if app.persistent {
 					fmt.Fprintf(os.Stderr, "Inherited persistent mode from session\n")
 				}
 			}
@@ -283,7 +283,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Allocate slot - always check for availability and auto-increment if needed
-	slotNum := slot
+	slotNum := app.slot
 	if resumeSlot > 0 && slotNum == 0 {
 		// Resuming a session: reuse the original slot so the stopped container is restarted
 		slotNum = resumeSlot
@@ -315,7 +315,7 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prepare network configuration from config
-	networkConfig := cfg.Network
+	networkConfig := app.cfg.Network
 
 	// Determine CLI config path based on tool
 	// For directory-based tools (ConfigDirName != ""), point at the config directory.
@@ -326,26 +326,26 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Use limits directly from config
-	limitsConfig := &cfg.Limits
+	limitsConfig := &app.cfg.Limits
 
 	// Determine protected paths for security mounts from config
 	var protectedPaths []string
-	if !cfg.Security.DisableProtection {
-		protectedPaths = cfg.Security.GetEffectiveProtectedPaths()
+	if !app.cfg.Security.DisableProtection {
+		protectedPaths = app.cfg.Security.GetEffectiveProtectedPaths()
 	}
 
-	protectedPaths = filterWritableGitHooks(protectedPaths, cfg)
+	protectedPaths = filterWritableGitHooks(protectedPaths, app.cfg)
 
 	// Resolve which forwarded env vars are actually set on the host.
 	// This list is passed to the context file so AI tools know what's available.
-	resolvedForwardedEnvVars := resolveForwardedEnvVarNames(cfg.Defaults.ForwardEnv)
+	resolvedForwardedEnvVars := resolveForwardedEnvVarNames(app.cfg.Defaults.ForwardEnv)
 
 	// Resolve timezone from config
-	resolvedTimezone := resolveTimezone(cfg)
+	resolvedTimezone := resolveTimezone(app.cfg)
 
 	// Determine image: CLI --image flag > config defaults.image > "coi"
-	img := ResolveImageName(imageName, cfg)
-	if err := AutoBuildIfNeeded(cfg, img); err != nil {
+	img := ResolveImageName(app.imageName, app.cfg)
+	if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
 		return err
 	}
 
@@ -353,31 +353,31 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	setupOpts := session.SetupOptions{
 		WorkspacePath:         absWorkspace,
 		Image:                 img,
-		Persistent:            persistent,
+		Persistent:            app.persistent,
 		ResumeFromID:          resumeID,
 		Slot:                  slotNum,
 		SessionsDir:           sessionsDir,
 		CLIConfigPath:         cliConfigPath,
 		Tool:                  toolInstance,
 		NetworkConfig:         &networkConfig,
-		DisableShift:          cfg.Incus.DisableShift,
+		DisableShift:          app.cfg.Incus.DisableShift,
 		LimitsConfig:          limitsConfig,
-		IncusProject:          cfg.Incus.Project,
+		IncusProject:          app.cfg.Incus.Project,
 		ProtectedPaths:        protectedPaths,
-		HostImmutable:         cfg.Security.IsHostImmutableEnabled(),
-		PreserveWorkspacePath: cfg.Paths.PreserveWorkspacePath,
-		ForwardSSHAgent:       config.BoolVal(cfg.SSH.ForwardAgent),
+		HostImmutable:         app.cfg.Security.IsHostImmutableEnabled(),
+		PreserveWorkspacePath: app.cfg.Paths.PreserveWorkspacePath,
+		ForwardSSHAgent:       config.BoolVal(app.cfg.SSH.ForwardAgent),
 		ForwardedEnvVars:      resolvedForwardedEnvVars,
-		ContextFilePath:       cfg.Tool.ContextFile,
-		ProfileContextFile:    cfg.ProfileContextFile,
-		AutoContext:           cfg.Tool.AutoContext,
+		ContextFilePath:       app.cfg.Tool.ContextFile,
+		ProfileContextFile:    app.cfg.ProfileContextFile,
+		AutoContext:           app.cfg.Tool.AutoContext,
 		ContainerName:         containerName,
 		Timezone:              resolvedTimezone,
-		Alias:                 cfg.Container.Alias,
+		Alias:                 app.cfg.Container.Alias,
 	}
 
 	// Parse and validate mount configuration
-	mountConfig, err := ParseMountConfig(cfg)
+	mountConfig, err := ParseMountConfig(app.cfg)
 	if err != nil {
 		return fmt.Errorf("invalid mount configuration: %w", err)
 	}
@@ -390,8 +390,8 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	setupOpts.MountConfig = mountConfig
 
 	// Validate alias before proceeding with setup
-	if cfg.Container.Alias != "" {
-		if err := alias.ValidateAlias(cfg.Container.Alias); err != nil {
+	if app.cfg.Container.Alias != "" {
+		if err := alias.ValidateAlias(app.cfg.Container.Alias); err != nil {
 			return fmt.Errorf("invalid container alias: %w", err)
 		}
 	}
@@ -403,14 +403,14 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save metadata early so coi list shows correct persistent/ephemeral status
-	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, persistent, profile); err != nil {
+	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, app.persistent, app.profile); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
 	}
 
 	// Register alias in global registry for cross-directory resolution
-	if effectiveAlias := cfg.Container.Alias; effectiveAlias != "" {
+	if effectiveAlias := app.cfg.Container.Alias; effectiveAlias != "" {
 		if reg, err := alias.Load(); err == nil {
-			if err := reg.Register(effectiveAlias, absWorkspace, profile); err != nil {
+			if err := reg.Register(effectiveAlias, absWorkspace, app.profile); err != nil {
 				return fmt.Errorf("alias conflict: %w", err)
 			}
 			if err := reg.Save(); err != nil {
@@ -422,16 +422,16 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	// Start monitoring daemons if enabled via config
 	var monitorDaemon *monitor.Daemon
 	var nftDaemon *nftmonitor.Daemon
-	if config.BoolVal(cfg.Monitoring.Enabled) {
+	if config.BoolVal(app.cfg.Monitoring.Enabled) {
 		// Start traditional monitoring (process/filesystem)
-		if err := startMonitoringDaemon(result.ContainerName, absWorkspace, cfg, result.Logger, &monitorDaemon); err != nil {
+		if err := startMonitoringDaemon(result.ContainerName, absWorkspace, app.cfg, result.Logger, &monitorDaemon); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to start monitoring daemon: %v\n", err)
 			// Don't fail the session if monitoring fails
 		}
 
 		// Start nftables monitoring (network only)
-		if config.BoolVal(cfg.Monitoring.NFT.Enabled) {
-			if err := startNFTMonitoringDaemon(result.ContainerName, cfg, result.Logger, &nftDaemon); err != nil {
+		if config.BoolVal(app.cfg.Monitoring.NFT.Enabled) {
+			if err := startNFTMonitoringDaemon(result.ContainerName, app.cfg, result.Logger, &nftDaemon); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to start NFT monitoring: %v\n", err)
 				// Don't fail the session if NFT monitoring fails
 			}
@@ -467,8 +467,8 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 			cleanupOpts := session.CleanupOptions{
 				ContainerName:  result.ContainerName,
 				SessionID:      sessionID,
-				Persistent:     persistent,
-				ProfileName:    profile,
+				Persistent:     app.persistent,
+				ProfileName:    app.profile,
 				SessionsDir:    sessionsDir,
 				SaveSession:    true, // Always save session data
 				Workspace:      absWorkspace,
@@ -508,8 +508,8 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	//
 	// For persistent containers resuming: pass --resume flag with tool's session ID
 	// For ephemeral containers resuming: just restore config, tool will auto-detect from restored data
-	useResumeFlag := (resumeID != "") && persistent
-	restoreOnly := (resumeID != "") && !persistent
+	useResumeFlag := (resumeID != "") && app.persistent
+	restoreOnly := (resumeID != "") && !app.persistent
 
 	// Choose execution mode
 	if useTmux {
@@ -652,12 +652,12 @@ func buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
 	}
 
 	// Apply static environment from config (defaults.environment + profile environment)
-	for k, v := range cfg.Defaults.Environment {
+	for k, v := range app.cfg.Defaults.Environment {
 		containerEnv[k] = v
 	}
 
 	// Resolve forward_env from config, deduplicate, then look up host values
-	for _, name := range cfg.Defaults.ForwardEnv {
+	for _, name := range app.cfg.Defaults.ForwardEnv {
 		if val, ok := os.LookupEnv(name); ok {
 			containerEnv[name] = val
 		} else {
@@ -687,7 +687,7 @@ func resolveForwardedEnvVarNames(names []string) []string {
 
 // ensureTmuxServer starts the tmux server and polls until it is ready (up to 2 seconds).
 // This is critical in CI and for newly started containers where the tmux server might not be running yet.
-func ensureTmuxServer(mgr *container.Manager, userPtr *int) {
+func ensureTmuxServer(mgr container.ContainerManager, userPtr *int) {
 	serverStartCmd := "tmux start-server 2>/dev/null || true; sleep 0.1"
 	serverOpts := container.ExecCommandOptions{
 		Capture: true,

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -200,7 +200,7 @@ func resolveContainer() (string, error) {
 	}
 
 	// 3. Find container for current workspace
-	absWorkspace, err := filepath.Abs(workspace)
+	absWorkspace, err := filepath.Abs(app.workspace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve workspace path: %w", err)
 	}

--- a/internal/container/interfaces.go
+++ b/internal/container/interfaces.go
@@ -1,0 +1,39 @@
+package container
+
+// ContainerManager is the interface implemented by *Manager.
+// Defining it here lets other packages (session, cli) accept a fake/stub
+// in tests without needing a live Incus installation.
+type ContainerManager interface {
+	Launch(image string, ephemeral bool, pool string) error
+	Stop(force bool) error
+	Delete(force bool) error
+	Running() (bool, error)
+	Exists() (bool, error)
+	Start() error
+	MountDisk(name, source, path string, shift, readonly bool) error
+	AddProxyDevice(name, connect, listen string, uid, gid int) error
+	RemoveDevice(name string) error
+	SetTmpfsSize(size string) error
+	GetWorkspacePath() string
+	Exec(args ...string) error
+	ExecArgs(commandArgs []string, opts ExecCommandOptions) error
+	ExecArgsCapture(commandArgs []string, opts ExecCommandOptions) (string, error)
+	ExecCommand(command string, opts ExecCommandOptions) (string, error)
+	PushFile(source, destination string) error
+	PullDirectory(containerPath, localPath string) error
+	PushDirectory(localPath, containerPath string) error
+	Chown(path string, uid, gid int) error
+	DirExists(path string) (bool, error)
+	FileExists(path string) (bool, error)
+	CreateFile(containerPath, content string) error
+	ExecHostCommand(command string, capture bool) (string, error)
+	CreateSnapshot(name string, stateful bool) error
+	ListSnapshots() ([]SnapshotInfo, error)
+	RestoreSnapshot(name string, stateful bool) error
+	DeleteSnapshot(name string) error
+	SnapshotExists(name string) (bool, error)
+	GetSnapshotInfo(name string) (*SnapshotInfo, error)
+}
+
+// Compile-time assertion: *Manager must satisfy ContainerManager.
+var _ ContainerManager = (*Manager)(nil)

--- a/internal/limits/applier.go
+++ b/internal/limits/applier.go
@@ -8,6 +8,28 @@ import (
 	"github.com/mensfeld/code-on-incus/internal/container"
 )
 
+// LimitsApplier is the interface for applying and removing resource limits.
+// The default implementation delegates to the package-level functions.
+type LimitsApplier interface {
+	Apply(ctx context.Context, opts ApplyOptions) error
+	Remove(ctx context.Context, containerName, project string) error
+}
+
+// Applier is the zero-value implementation of LimitsApplier that delegates to
+// the package-level Apply/Remove functions.
+type Applier struct{}
+
+func (Applier) Apply(ctx context.Context, opts ApplyOptions) error {
+	return ApplyResourceLimitsContext(ctx, opts)
+}
+
+func (Applier) Remove(ctx context.Context, containerName, project string) error {
+	return RemoveLimitsContext(ctx, containerName, project)
+}
+
+// Compile-time assertion: Applier must satisfy LimitsApplier.
+var _ LimitsApplier = Applier{}
+
 // ApplyOptions contains options for applying limits
 type ApplyOptions struct {
 	ContainerName string

--- a/internal/network/interfaces.go
+++ b/internal/network/interfaces.go
@@ -1,0 +1,14 @@
+package network
+
+import "context"
+
+// NetworkManager is the interface implemented by *Manager.
+// Defining it here enables session and cli packages to accept a stub
+// in tests without requiring nftables or a live container network.
+type NetworkManager interface {
+	SetupForContainer(ctx context.Context, containerName string) error
+	Teardown(ctx context.Context, containerName string) error
+}
+
+// Compile-time assertion: *Manager must satisfy NetworkManager.
+var _ NetworkManager = (*Manager)(nil)

--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -24,7 +24,7 @@ type CleanupOptions struct {
 	SaveSession    bool      // Whether to save tool config directory
 	Workspace      string    // Workspace directory path
 	Tool           tool.Tool // AI coding tool being used
-	NetworkManager *network.Manager
+	NetworkManager network.NetworkManager
 	SessionLogger  *logger.SessionLogger
 	Logger         func(string)
 }
@@ -65,7 +65,7 @@ func Cleanup(opts CleanupOptions) error {
 	// error it waits for the container to fully stop, then retries using incus's
 	// direct file-access path (no SFTP) so the save succeeds in every exit scenario.
 	if opts.SaveSession && exists && opts.SessionID != "" && opts.SessionsDir != "" && opts.Tool != nil && opts.Tool.ConfigDirName() != "" {
-		if err := saveSessionData(mgr, opts.SessionID, opts.Persistent, opts.ProfileName, opts.Workspace, opts.SessionsDir, opts.Tool, opts.Logger); err != nil {
+		if err := saveSessionData(mgr, opts.ContainerName, opts.SessionID, opts.Persistent, opts.ProfileName, opts.Workspace, opts.SessionsDir, opts.Tool, opts.Logger); err != nil {
 			opts.Logger(fmt.Sprintf("Warning: Failed to save session data: %v", err))
 		}
 	}
@@ -131,7 +131,7 @@ func Cleanup(opts CleanupOptions) error {
 }
 
 // saveSessionData saves the tool config directory from the container
-func saveSessionData(mgr *container.Manager, sessionID string, persistent bool, profileName string, workspace string, sessionsDir string, t tool.Tool, logger func(string)) error {
+func saveSessionData(mgr container.ContainerManager, containerName string, sessionID string, persistent bool, profileName string, workspace string, sessionsDir string, t tool.Tool, logger func(string)) error {
 	// Determine home directory
 	// For coi images, we always use /home/code
 	// For other images, we use /root
@@ -206,7 +206,7 @@ func saveSessionData(mgr *container.Manager, sessionID string, persistent bool, 
 	// Save metadata
 	metadata := SessionMetadata{
 		SessionID:     sessionID,
-		ContainerName: mgr.ContainerName,
+		ContainerName: containerName,
 		Persistent:    persistent,
 		ProfileName:   profileName,
 		Workspace:     workspace,

--- a/internal/session/configure_test.go
+++ b/internal/session/configure_test.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConfigureOptions_ContainerNameRequired(t *testing.T) {
+	opts := ConfigureOptions{}
+	_, err := ConfigureContainer(opts)
+	if err == nil {
+		t.Fatal("expected error when container name is empty")
+	}
+	if err.Error() != "container name is required" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigureResultJSON(t *testing.T) {
+	result := &ConfigureResult{
+		SSHAgentSocketPath: "/tmp/ssh-agent.sock",
+		Timezone:           "Europe/Warsaw",
+		NetworkApplied:     "restricted",
+		HomeDir:            "/home/code",
+	}
+
+	jsonStr, err := ConfigureResultJSON(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify it's valid JSON and round-trips correctly
+	var parsed ConfigureResult
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if parsed.SSHAgentSocketPath != result.SSHAgentSocketPath {
+		t.Errorf("SSHAgentSocketPath: got %q, want %q", parsed.SSHAgentSocketPath, result.SSHAgentSocketPath)
+	}
+	if parsed.Timezone != result.Timezone {
+		t.Errorf("Timezone: got %q, want %q", parsed.Timezone, result.Timezone)
+	}
+	if parsed.NetworkApplied != result.NetworkApplied {
+		t.Errorf("NetworkApplied: got %q, want %q", parsed.NetworkApplied, result.NetworkApplied)
+	}
+	if parsed.HomeDir != result.HomeDir {
+		t.Errorf("HomeDir: got %q, want %q", parsed.HomeDir, result.HomeDir)
+	}
+}
+
+func TestConfigureResultJSON_OmitsEmpty(t *testing.T) {
+	result := &ConfigureResult{
+		HomeDir: "/home/code",
+	}
+
+	jsonStr, err := ConfigureResultJSON(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify empty fields with omitempty are not present
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if _, ok := raw["ssh_agent_socket_path"]; ok {
+		t.Error("expected ssh_agent_socket_path to be omitted when empty")
+	}
+	if _, ok := raw["timezone"]; ok {
+		t.Error("expected timezone to be omitted when empty")
+	}
+	if _, ok := raw["network_applied"]; ok {
+		t.Error("expected network_applied to be omitted when empty")
+	}
+	if _, ok := raw["home_dir"]; !ok {
+		t.Error("expected home_dir to always be present")
+	}
+}
+
+func TestConfigureOptions_DefaultLogger(t *testing.T) {
+	// Verify that a nil logger doesn't cause a panic
+	opts := ConfigureOptions{
+		ContainerName: "nonexistent-container-for-test",
+	}
+
+	// This will fail because the container doesn't exist, but it should
+	// not panic due to nil logger
+	_, err := ConfigureContainer(opts)
+	if err == nil {
+		t.Fatal("expected error for nonexistent container")
+	}
+}

--- a/internal/session/security.go
+++ b/internal/session/security.go
@@ -16,7 +16,7 @@ import (
 // containerWorkspacePath is the path where the workspace is mounted inside the container
 // (either /workspace or the preserved host path).
 // Returns nil if no paths need protection.
-func SetupSecurityMounts(mgr *container.Manager, workspacePath, containerWorkspacePath string, protectedPaths []string, useShift bool) error {
+func SetupSecurityMounts(mgr container.ContainerManager, workspacePath, containerWorkspacePath string, protectedPaths []string, useShift bool) error {
 	if len(protectedPaths) == 0 {
 		return nil
 	}
@@ -39,7 +39,7 @@ func SetupSecurityMounts(mgr *container.Manager, workspacePath, containerWorkspa
 }
 
 // setupProtectedPath mounts a single path as read-only
-func setupProtectedPath(mgr *container.Manager, workspacePath, containerWorkspacePath, relPath string, useShift bool) error {
+func setupProtectedPath(mgr container.ContainerManager, workspacePath, containerWorkspacePath, relPath string, useShift bool) error {
 	if err := validateRelPath(relPath); err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func pathToDeviceName(path string) string {
 // SetupGitHooksMount is a convenience function for backwards compatibility
 // It mounts .git/hooks as read-only for security.
 // Deprecated: Use SetupSecurityMounts with config.Security.GetEffectiveProtectedPaths() instead
-func SetupGitHooksMount(mgr *container.Manager, workspacePath string, useShift bool) error {
+func SetupGitHooksMount(mgr container.ContainerManager, workspacePath string, useShift bool) error {
 	// Use /workspace as the default container path for backwards compatibility
 	return SetupSecurityMounts(mgr, workspacePath, "/workspace", []string{".git/hooks"}, useShift)
 }

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -55,8 +55,8 @@ type SetupOptions struct {
 // SetupResult contains the result of setup
 type SetupResult struct {
 	ContainerName          string
-	Manager                *container.Manager
-	NetworkManager         *network.Manager
+	Manager                container.ContainerManager
+	NetworkManager         network.NetworkManager
 	TimeoutMonitor         *limits.TimeoutMonitor
 	Logger                 *logger.SessionLogger
 	HomeDir                string
@@ -675,7 +675,7 @@ func Setup(ctx context.Context, opts SetupOptions) (*SetupResult, error) {
 }
 
 // waitForReady waits for container to be ready
-func waitForReady(mgr *container.Manager, maxRetries int, logger func(string)) error {
+func waitForReady(mgr container.ContainerManager, maxRetries int, logger func(string)) error {
 	for i := 0; i < maxRetries; i++ {
 		running, err := mgr.Running()
 		if err != nil {
@@ -716,7 +716,7 @@ func waitForReady(mgr *container.Manager, maxRetries int, logger func(string)) e
 // not present" and returns (false, nil). Any other error (e.g. incus
 // connectivity failure) is surfaced to the caller so it can decide
 // whether to warn or fall back.
-func DetectCodeUser(mgr *container.Manager, codeUser string) (bool, error) {
+func DetectCodeUser(mgr container.ContainerManager, codeUser string) (bool, error) {
 	_, err := mgr.ExecArgsCapture(
 		[]string{"id", "-u", codeUser},
 		container.ExecCommandOptions{Capture: true},

--- a/internal/session/setup_config.go
+++ b/internal/session/setup_config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // readContainerFile reads a file from inside the container via cat
-func readContainerFile(mgr *container.Manager, path string) ([]byte, error) {
+func readContainerFile(mgr container.ContainerManager, path string) ([]byte, error) {
 	content, err := mgr.ExecCommand(fmt.Sprintf("cat %s", path), container.ExecCommandOptions{Capture: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s from container: %w", path, err)
@@ -20,7 +20,7 @@ func readContainerFile(mgr *container.Manager, path string) ([]byte, error) {
 
 // restoreSessionData restores tool config directory from a saved session
 // Used when resuming a non-persistent session (container was deleted and recreated)
-func restoreSessionData(mgr *container.Manager, resumeID, homeDir, sessionsDir string, t tool.Tool, logger func(string)) error {
+func restoreSessionData(mgr container.ContainerManager, resumeID, homeDir, sessionsDir string, t tool.Tool, logger func(string)) error {
 	configDirName := t.ConfigDirName()
 	sourceConfigDir := filepath.Join(sessionsDir, resumeID, configDirName)
 
@@ -54,7 +54,7 @@ func restoreSessionData(mgr *container.Manager, resumeID, homeDir, sessionsDir s
 // injectCredentials copies essential config files and sandbox settings from host to container when resuming.
 // This ensures fresh authentication while preserving the session conversation history.
 // Uses the ToolWithConfigDirFiles interface so each tool declares its own files and layout.
-func injectCredentials(mgr *container.Manager, hostCLIConfigPath, homeDir string, tcf tool.ToolWithConfigDirFiles, logger func(string)) error {
+func injectCredentials(mgr container.ContainerManager, hostCLIConfigPath, homeDir string, tcf tool.ToolWithConfigDirFiles, logger func(string)) error {
 	logger("Injecting fresh credentials and config for session resume...")
 
 	configDirName := tcf.ConfigDirName()
@@ -152,7 +152,7 @@ func injectCredentials(mgr *container.Manager, hostCLIConfigPath, homeDir string
 }
 
 // setupCLIConfig copies tool config directory and injects sandbox settings
-func setupCLIConfig(mgr *container.Manager, hostCLIConfigPath, homeDir string, tcf tool.ToolWithConfigDirFiles, logger func(string)) error {
+func setupCLIConfig(mgr container.ContainerManager, hostCLIConfigPath, homeDir string, tcf tool.ToolWithConfigDirFiles, logger func(string)) error {
 	configDirName := tcf.ConfigDirName()
 	stateDir := filepath.Join(homeDir, configDirName)
 

--- a/internal/session/setup_context.go
+++ b/internal/session/setup_context.go
@@ -13,7 +13,7 @@ import (
 // injectContextFile creates ~/SANDBOX_CONTEXT.md inside the container.
 // If customPath is provided, it reads the file from the host and uses its content.
 // Otherwise, it renders the default embedded template with dynamic environment info.
-func injectContextFile(mgr *container.Manager, info tool.ContextInfo, customPath, homeDir string, logger func(string)) error {
+func injectContextFile(mgr container.ContainerManager, info tool.ContextInfo, customPath, homeDir string, logger func(string)) error {
 	destPath := filepath.Join(homeDir, "SANDBOX_CONTEXT.md")
 
 	var content string
@@ -65,7 +65,7 @@ func resolveContextContent(info tool.ContextInfo, customPath string, logger func
 // file (e.g., ~/.claude/CLAUDE.md). If the file already exists (e.g., copied from
 // host), the sandbox context is appended with a separator. Otherwise, the file is
 // created with just the sandbox context.
-func injectAutoContextFile(mgr *container.Manager, acf tool.ToolWithAutoContextFile, contextContent, homeDir string, logger func(string)) error {
+func injectAutoContextFile(mgr container.ContainerManager, acf tool.ToolWithAutoContextFile, contextContent, homeDir string, logger func(string)) error {
 	relPath := acf.AutoContextFile()
 	destPath := filepath.Join(homeDir, relPath)
 	destDir := filepath.Dir(destPath)

--- a/internal/session/setup_helpers.go
+++ b/internal/session/setup_helpers.go
@@ -102,7 +102,7 @@ func mergeJSONSettings(existingContent []byte, settings map[string]interface{}) 
 // The env var is written to both /etc/profile.d/ (login shells) and prepended
 // to /etc/bash.bashrc (non-login interactive shells, sourced before ~/.bashrc
 // where mise activates). Non-fatal: logs a warning on failure.
-func SetupMiseTrust(mgr *container.Manager, containerWorkspacePath string, logger func(string)) {
+func SetupMiseTrust(mgr container.ContainerManager, containerWorkspacePath string, logger func(string)) {
 	exportLine := fmt.Sprintf(`export MISE_TRUSTED_CONFIG_PATHS="%s"`, containerWorkspacePath)
 	trustCmd := fmt.Sprintf(
 		`printf '%%s\n' '%s' > /etc/profile.d/coi-mise-trust.sh && `+
@@ -120,7 +120,7 @@ func SetupMiseTrust(mgr *container.Manager, containerWorkspacePath string, logge
 // as the container's default "code" user. The setting is applied globally
 // (--global) so it covers all repos inside the container.
 // Non-fatal: logs a warning on failure.
-func SetupGitIdentityGuard(mgr *container.Manager, homeDir string, logger func(string)) {
+func SetupGitIdentityGuard(mgr container.ContainerManager, homeDir string, logger func(string)) {
 	cmd := fmt.Sprintf(
 		`HOME=%s git config --global user.useConfigOnly true`,
 		homeDir,
@@ -135,7 +135,7 @@ func SetupGitIdentityGuard(mgr *container.Manager, homeDir string, logger func(s
 // Claude Code versions show at startup. The managed-settings path is the only
 // way to set disableAutoMode — it cannot be set via user settings.
 // Non-fatal: logs a warning on failure.
-func SetupClaudeManagedSettings(mgr *container.Manager, logger func(string)) {
+func SetupClaudeManagedSettings(mgr container.ContainerManager, logger func(string)) {
 	mkdirCmd := "mkdir -p /etc/claude-code"
 	if _, err := mgr.ExecCommand(mkdirCmd, container.ExecCommandOptions{Capture: true}); err != nil {
 		logger(fmt.Sprintf("Warning: Failed to create Claude managed settings directory: %v", err))

--- a/internal/session/setup_mounts.go
+++ b/internal/session/setup_mounts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // setupMounts mounts all configured directories to the container
-func setupMounts(mgr *container.Manager, mountConfig *MountConfig, useShift bool, logger func(string)) error {
+func setupMounts(mgr container.ContainerManager, mountConfig *MountConfig, useShift bool, logger func(string)) error {
 	if mountConfig == nil || len(mountConfig.Mounts) == 0 {
 		return nil
 	}

--- a/internal/session/setup_ssh.go
+++ b/internal/session/setup_ssh.go
@@ -14,11 +14,11 @@ import (
 // container to use the host's SSH keys without copying them.
 // Returns the container socket path if forwarding was successfully configured,
 // or an empty string if forwarding was skipped (no SSH_AUTH_SOCK, invalid socket).
-func SetupSSHAgentForwarding(mgr *container.Manager, containerName string, logger func(string)) (string, error) {
+func SetupSSHAgentForwarding(mgr container.ContainerManager, containerName string, logger func(string)) (string, error) {
 	return setupSSHAgentForwarding(mgr, containerName, logger)
 }
 
-func setupSSHAgentForwarding(mgr *container.Manager, containerName string, logger func(string)) (string, error) {
+func setupSSHAgentForwarding(mgr container.ContainerManager, containerName string, logger func(string)) (string, error) {
 	hostSocket := filepath.Clean(os.Getenv("SSH_AUTH_SOCK"))
 	if hostSocket == "." || hostSocket == "" {
 		logger("SSH agent forwarding skipped: SSH_AUTH_SOCK not set on host")
@@ -69,7 +69,7 @@ func setupSSHAgentForwarding(mgr *container.Manager, containerName string, logge
 }
 
 // addSSHAgentProxyDevice adds the proxy device for SSH agent forwarding.
-func addSSHAgentProxyDevice(mgr *container.Manager, hostSocket, containerSocket string) error {
+func addSSHAgentProxyDevice(mgr container.ContainerManager, hostSocket, containerSocket string) error {
 	return mgr.AddProxyDevice(
 		"ssh-agent",
 		fmt.Sprintf("unix:%s", hostSocket),
@@ -80,7 +80,7 @@ func addSSHAgentProxyDevice(mgr *container.Manager, hostSocket, containerSocket 
 }
 
 // waitForContainerSocket polls for a Unix socket to appear inside the container.
-func waitForContainerSocket(mgr *container.Manager, socketPath string, timeout time.Duration) bool {
+func waitForContainerSocket(mgr container.ContainerManager, socketPath string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	checkCmd := fmt.Sprintf("test -S %s", socketPath)
 	for time.Now().Before(deadline) {

--- a/tests/integration/test_nft_monitoring.py
+++ b/tests/integration/test_nft_monitoring.py
@@ -238,7 +238,10 @@ class TestNFTRuleManagement:
             assert nft_ready, f"NFT monitoring rules not found for IP {container_ip}"
         finally:
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
             cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
 
     def test_rules_removed_on_session_end(self, test_workspace, coi_binary, coi_monitoring_env):
@@ -281,7 +284,10 @@ class TestNFTRuleManagement:
 
             # Stop session
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
             time.sleep(3)
 
             # Check rules are gone
@@ -364,7 +370,10 @@ class TestNFTRuleManagement:
 
         finally:
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
             cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
 
 
@@ -451,7 +460,10 @@ class TestNetworkThreatDetection:
 
         finally:
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
             cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
 
     def test_container_killed_on_metadata_access(
@@ -586,7 +598,10 @@ class TestNetworkThreatDetection:
 
         finally:
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
             cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
 
 
@@ -672,7 +687,10 @@ class TestAuditLogging:
 
             finally:
                 proc.terminate()
-                proc.wait(timeout=10)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
                 cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
 
 
@@ -724,7 +742,10 @@ class TestDaemonLifecycle:
 
             finally:
                 proc.terminate()
-                proc.wait(timeout=10)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
                 cleanup_container(container_name, coi_binary, env=coi_monitoring_env)
                 stderr_file.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary

Implements Issues 2 and 3 from the architecture review (REF.md), which are the foundational layer for testability and future daemon-ification.

### Issue 3 — Interfaces at subsystem boundaries

Previously the only interface in the codebase was `Tool`. Every other subsystem (container, network, limits) was exposed as a concrete struct or free function, making unit-testing any session logic require a live Incus install.

- **`internal/container/interfaces.go`**: `ContainerManager` interface matching all public methods of `*Manager`; compile-time assertion `var _ ContainerManager = (*Manager)(nil)`
- **`internal/network/interfaces.go`**: `NetworkManager` interface for `SetupForContainer` / `Teardown`; compile-time assertion
- **`internal/limits/applier.go`**: `LimitsApplier` interface + zero-value `Applier` struct that delegates to the existing package-level functions; compile-time assertion
- **`session.SetupResult`**: `Manager` and `NetworkManager` fields changed from concrete types to the new interfaces
- **`session.CleanupOptions`**: `NetworkManager` field changed to `network.NetworkManager`
- All session helper functions updated to accept `container.ContainerManager` instead of `*container.Manager`

### Issue 2 — Global mutable state → App struct

Previously `internal/cli/root.go` had eight package-level variables (`workspace`, `slot`, `imageName`, `persistent`, `resume`, `continueSession`, `profile`, `cfg`) read directly by every command. This made parallel tests impossible and is incompatible with a multi-session daemon model.

- New `cli.App` struct holds all eight fields
- Single `var app = &App{}` replaces the individual globals
- `Execute()` resets `*app = App{}` on each call — parallel test invocations start with clean state
- All cobra `PersistentFlags` rebound to `&app.X` fields (cobra still populates them via flag parsing)
- `PersistentPreRunE` populates `app.cfg` and applies `app.profile`
- Every CLI command file updated to use `app.workspace`, `app.cfg`, etc.

## Test plan

- [ ] `go build ./...` passes (no new compile errors)
- [ ] `go test ./...` passes — all 26 packages green
- [ ] `go vet ./...` clean
- [ ] `gofmt -l` reports no unformatted files
- [ ] Compile-time interface assertions catch any future method signature divergence