### PR TITLE
feat(session): introduce Phase/Pipeline for structured session lifecycle

### DIFF
--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -1,0 +1,482 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mensfeld/code-on-incus/internal/alias"
+	"github.com/mensfeld/code-on-incus/internal/config"
+	"github.com/mensfeld/code-on-incus/internal/container"
+	"github.com/mensfeld/code-on-incus/internal/monitor"
+	"github.com/mensfeld/code-on-incus/internal/nftmonitor"
+	"github.com/mensfeld/code-on-incus/internal/session"
+	"github.com/mensfeld/code-on-incus/internal/tool"
+	"github.com/spf13/cobra"
+)
+
+// shellState is the mutable state accumulated across shell pipeline phases.
+// Each phase reads its inputs from state and writes its outputs back.
+type shellState struct {
+	aliasArg string // positional argument from cobra args[0], if given
+
+	// After resolve-workspace
+	absWorkspace string
+
+	// After validate-env
+	useTmux bool // determined from config + explicit --tmux flag
+
+	// After configure-session
+	sessionID    string
+	resumeID     string
+	slotNum      int
+	toolInstance tool.Tool
+	sessionsDir  string
+	setupOpts    session.SetupOptions // fully built options for session.Setup
+
+	// After setup-container
+	result *session.SetupResult
+
+	// After start-monitoring
+	monitorDaemon *monitor.Daemon
+	nftDaemon     *nftmonitor.Daemon
+}
+
+// resolveWorkspacePhase resolves the absolute workspace path from --workspace
+// or alias, overlays the workspace's project config, and applies any alias
+// profile/slot inherited from the registry.
+func resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "resolve-workspace",
+		RunFn: func(_ context.Context) (session.Teardown, error) {
+			absWorkspace, err := filepath.Abs(app.workspace)
+			if err != nil {
+				return nil, fmt.Errorf("invalid workspace path: %w", err)
+			}
+
+			// When no alias is given, overlay the workspace's project config when it
+			// differs from CWD (config.Load only reads from CWD).
+			if s.aliasArg == "" {
+				if cwd, err := os.Getwd(); err == nil {
+					if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
+						if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+							return nil, fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+						}
+						container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
+					}
+				}
+			}
+
+			// Alias resolution overrides workspace and may apply a saved profile/slot.
+			if s.aliasArg != "" {
+				resolved, err := alias.ResolveAliasForLaunch(s.aliasArg)
+				if err != nil {
+					return nil, err
+				}
+				absWorkspace = resolved.Workspace
+
+				if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+					return nil, fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
+				}
+
+				if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
+					app.profile = resolved.Profile
+					if err := app.cfg.ApplyProfile(app.profile); err != nil {
+						return nil, err
+					}
+				}
+				container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
+				if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
+					app.slot = resolved.Slot
+				}
+			}
+
+			s.absWorkspace = absWorkspace
+			return nil, nil
+		},
+	}
+}
+
+// validateEnvPhase determines the effective tmux mode (config default vs
+// explicit flag) and verifies that Incus is available and at the minimum
+// required version.
+func validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "validate-env",
+		RunFn: func(_ context.Context) (session.Teardown, error) {
+			// Config default, overridden by explicit --tmux flag.
+			useTmuxDefault := true
+			if app.cfg.Shell.UseTmux != nil {
+				useTmuxDefault = *app.cfg.Shell.UseTmux
+			}
+			if cmd.Flags().Changed("tmux") {
+				s.useTmux = useTmux // cobra already set the package-level var
+			} else {
+				s.useTmux = useTmuxDefault
+			}
+
+			if !container.Available() {
+				return nil, container.IncusNotAvailableError()
+			}
+			if err := container.CheckMinimumVersion(); err != nil {
+				return nil, err
+			}
+			if warning := container.CheckKernelVersion(); warning != "" {
+				fmt.Fprintf(os.Stderr, "%s\n", warning)
+			}
+			return nil, nil
+		},
+	}
+}
+
+// configureSessionPhase assembles all session options: chooses the tool,
+// determines the sessions directory, resolves the resume ID, allocates a
+// slot, and constructs the SetupOptions for the container.
+//
+//nolint:gocyclo // Many configuration paths — sequential by design
+func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "configure-session",
+		RunFn: func(_ context.Context) (session.Teardown, error) {
+			// Override tool from --tool flag.
+			if toolFlag != "" {
+				app.cfg.Tool.Name = toolFlag
+			}
+			ti, err := getConfiguredTool(app.cfg)
+			if err != nil {
+				return nil, err
+			}
+			s.toolInstance = ti
+
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get home directory: %w", err)
+			}
+			baseDir := filepath.Join(homeDir, ".coi")
+			sessionsDir := session.GetSessionsDir(baseDir, ti)
+			if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+				return nil, fmt.Errorf("failed to create sessions directory: %w", err)
+			}
+			s.sessionsDir = sessionsDir
+
+			// Resolve the resume/continue ID.
+			resumeID := app.resume
+			if app.continueSession != "" {
+				resumeID = app.continueSession
+			}
+			resumeFlagSet := cmd.Flags().Changed("resume") || cmd.Flags().Changed("continue")
+
+			isWorkspaceSessionTool := false
+			if ti.Name() == "opencode" {
+				workspaceSessionDir := filepath.Join(s.absWorkspace, ".opencode")
+				if info, err := os.Stat(workspaceSessionDir); err == nil && info.IsDir() {
+					isWorkspaceSessionTool = true
+				}
+			}
+
+			if resumeFlagSet && (resumeID == "" || resumeID == "auto") {
+				if isWorkspaceSessionTool {
+					resumeID = "workspace-session"
+					fmt.Fprintf(os.Stderr, "Resuming %s session from workspace\n", ti.Name())
+				} else {
+					resumeID, err = session.GetLatestSessionForWorkspace(sessionsDir, s.absWorkspace)
+					if err != nil {
+						return nil, fmt.Errorf("no previous session to resume for this workspace: %w", err)
+					}
+					fmt.Fprintf(os.Stderr, "Auto-detected session: %s\n", resumeID)
+				}
+			} else if resumeID != "" && !isWorkspaceSessionTool {
+				if !session.SessionExists(sessionsDir, resumeID) {
+					return nil, fmt.Errorf("session '%s' not found - check available sessions with: coi list --all", resumeID)
+				}
+				fmt.Fprintf(os.Stderr, "Resuming session: %s\n", resumeID)
+			}
+			s.resumeID = resumeID
+
+			// Inherit persistent flag, profile, and slot from session metadata.
+			var resumeSlot int
+			if resumeID != "" && !isWorkspaceSessionTool {
+				metadataPath := filepath.Join(sessionsDir, resumeID, "metadata.json")
+				if metadata, err := session.LoadSessionMetadata(metadataPath); err == nil {
+					if !cmd.Flags().Changed("profile") && metadata.ProfileName != "" {
+						app.profile = metadata.ProfileName
+						if err := app.cfg.ApplyProfile(app.profile); err != nil {
+							return nil, fmt.Errorf("failed to apply saved profile '%s': %w", app.profile, err)
+						}
+						if !cmd.Flags().Changed("persistent") {
+							app.persistent = config.BoolVal(app.cfg.Container.Persistent)
+						}
+						fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", app.profile)
+					}
+					if !cmd.Flags().Changed("persistent") {
+						app.persistent = metadata.Persistent
+						if app.persistent {
+							fmt.Fprintf(os.Stderr, "Inherited persistent mode from session\n")
+						}
+					}
+					if !cmd.Flags().Changed("slot") {
+						if _, origSlot, err := session.ParseContainerName(metadata.ContainerName); err == nil {
+							resumeSlot = origSlot
+						}
+					}
+				}
+			}
+
+			// Generate or reuse session ID.
+			if resumeID != "" {
+				s.sessionID = resumeID
+			} else {
+				id, err := session.GenerateSessionID()
+				if err != nil {
+					return nil, err
+				}
+				s.sessionID = id
+			}
+
+			// Allocate slot.
+			slotNum := app.slot
+			if resumeSlot > 0 && slotNum == 0 {
+				slotNum = resumeSlot
+				fmt.Fprintf(os.Stderr, "Reusing original slot %d from session\n", slotNum)
+			} else if slotNum == 0 {
+				slotNum, err = session.AllocateSlot(s.absWorkspace, 10)
+				if err != nil {
+					return nil, fmt.Errorf("failed to allocate slot: %w", err)
+				}
+				fmt.Fprintf(os.Stderr, "Auto-allocated slot %d\n", slotNum)
+			} else {
+				available, err := session.IsSlotAvailable(s.absWorkspace, slotNum)
+				if err != nil {
+					return nil, fmt.Errorf("failed to check slot availability: %w", err)
+				}
+				if !available {
+					orig := slotNum
+					slotNum, err = session.AllocateSlotFrom(s.absWorkspace, slotNum+1, 10)
+					if err != nil {
+						return nil, fmt.Errorf("slot %d is occupied and failed to find next available slot: %w", orig, err)
+					}
+					fmt.Fprintf(os.Stderr, "Slot %d is occupied, using slot %d instead\n", orig, slotNum)
+				}
+			}
+			s.slotNum = slotNum
+
+			// Resolve image and auto-build if needed.
+			img := ResolveImageName(app.imageName, app.cfg)
+			if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
+				return nil, err
+			}
+
+			// Build config-derived options.
+			networkConfig := app.cfg.Network
+			limitsConfig := &app.cfg.Limits
+			var protectedPaths []string
+			if !app.cfg.Security.DisableProtection {
+				protectedPaths = app.cfg.Security.GetEffectiveProtectedPaths()
+			}
+			protectedPaths = filterWritableGitHooks(protectedPaths, app.cfg)
+
+			var cliConfigPath string
+			if configDirName := ti.ConfigDirName(); configDirName != "" {
+				cliConfigPath = filepath.Join(homeDir, configDirName)
+			}
+
+			resolvedForwardedEnvVars := resolveForwardedEnvVarNames(app.cfg.Defaults.ForwardEnv)
+			resolvedTimezone := resolveTimezone(app.cfg)
+
+			mountConfig, err := ParseMountConfig(app.cfg)
+			if err != nil {
+				return nil, fmt.Errorf("invalid mount configuration: %w", err)
+			}
+			if err := session.ValidateMounts(mountConfig); err != nil {
+				return nil, fmt.Errorf("mount validation failed: %w", err)
+			}
+
+			if app.cfg.Container.Alias != "" {
+				if err := alias.ValidateAlias(app.cfg.Container.Alias); err != nil {
+					return nil, fmt.Errorf("invalid container alias: %w", err)
+				}
+			}
+
+			s.setupOpts = session.SetupOptions{
+				WorkspacePath:         s.absWorkspace,
+				Image:                 img,
+				Persistent:            app.persistent,
+				ResumeFromID:          resumeID,
+				Slot:                  slotNum,
+				MountConfig:           mountConfig,
+				SessionsDir:           sessionsDir,
+				CLIConfigPath:         cliConfigPath,
+				Tool:                  ti,
+				NetworkConfig:         &networkConfig,
+				DisableShift:          app.cfg.Incus.DisableShift,
+				LimitsConfig:          limitsConfig,
+				IncusProject:          app.cfg.Incus.Project,
+				ProtectedPaths:        protectedPaths,
+				HostImmutable:         app.cfg.Security.IsHostImmutableEnabled(),
+				PreserveWorkspacePath: app.cfg.Paths.PreserveWorkspacePath,
+				ForwardSSHAgent:       config.BoolVal(app.cfg.SSH.ForwardAgent),
+				ForwardedEnvVars:      resolvedForwardedEnvVars,
+				ContextFilePath:       app.cfg.Tool.ContextFile,
+				ProfileContextFile:    app.cfg.ProfileContextFile,
+				AutoContext:           app.cfg.Tool.AutoContext,
+				ContainerName:         containerName,
+				Timezone:              resolvedTimezone,
+				Alias:                 app.cfg.Container.Alias,
+			}
+			return nil, nil
+		},
+	}
+}
+
+// setupContainerPhase calls session.Setup, saves early metadata for coi list,
+// and registers the alias in the global registry. Its teardown calls
+// session.Cleanup so the container and session data are handled correctly on
+// all exit paths.
+func setupContainerPhase(s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "setup-container",
+		RunFn: func(ctx context.Context) (session.Teardown, error) {
+			fmt.Fprintf(os.Stderr, "Setting up session %s...\n", s.sessionID)
+			result, err := session.Setup(ctx, s.setupOpts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to setup session: %w", err)
+			}
+			s.result = result
+
+			if err := session.SaveMetadataEarly(s.sessionsDir, s.sessionID, result.ContainerName, s.absWorkspace, app.persistent, app.profile); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
+			}
+
+			if effectiveAlias := app.cfg.Container.Alias; effectiveAlias != "" {
+				if reg, err := alias.Load(); err == nil {
+					if err := reg.Register(effectiveAlias, s.absWorkspace, app.profile); err != nil {
+						return nil, fmt.Errorf("alias conflict: %w", err)
+					}
+					if err := reg.Save(); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to save alias registry: %v\n", err)
+					}
+				}
+			}
+
+			teardown := func() {
+				fmt.Fprintf(os.Stderr, "\nCleaning up session...\n")
+				if s.result.TimeoutMonitor != nil {
+					s.result.TimeoutMonitor.Stop()
+				}
+				cleanupOpts := session.CleanupOptions{
+					ContainerName:  s.result.ContainerName,
+					SessionID:      s.sessionID,
+					Persistent:     app.persistent,
+					ProfileName:    app.profile,
+					SessionsDir:    s.sessionsDir,
+					SaveSession:    true,
+					Workspace:      s.absWorkspace,
+					Tool:           s.toolInstance,
+					NetworkManager: s.result.NetworkManager,
+					SessionLogger:  s.result.Logger,
+				}
+				if err := session.Cleanup(cleanupOpts); err != nil {
+					fmt.Fprintf(os.Stderr, "Cleanup error: %v\n", err)
+				}
+			}
+			return teardown, nil
+		},
+	}
+}
+
+// startMonitoringPhase starts the traditional and NFT monitoring daemons when
+// enabled in config. Its teardown stops both daemons.
+func startMonitoringPhase(s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "start-monitoring",
+		RunFn: func(_ context.Context) (session.Teardown, error) {
+			if !config.BoolVal(app.cfg.Monitoring.Enabled) {
+				return nil, nil
+			}
+
+			if err := startMonitoringDaemon(s.result.ContainerName, s.absWorkspace, app.cfg, s.result.Logger, &s.monitorDaemon); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to start monitoring daemon: %v\n", err)
+			}
+
+			if config.BoolVal(app.cfg.Monitoring.NFT.Enabled) {
+				if err := startNFTMonitoringDaemon(s.result.ContainerName, app.cfg, s.result.Logger, &s.nftDaemon); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to start NFT monitoring: %v\n", err)
+				}
+			}
+
+			teardown := func() {
+				if s.monitorDaemon != nil {
+					if err := s.monitorDaemon.Stop(); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to stop monitoring daemon: %v\n", err)
+					}
+				}
+				if s.nftDaemon != nil {
+					if err := s.nftDaemon.Stop(); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to stop NFT monitoring: %v\n", err)
+					}
+				}
+			}
+			return teardown, nil
+		},
+	}
+}
+
+// runToolPhase executes the AI coding tool (via tmux or direct mode) and
+// normalises expected exit conditions (SIGINT, container shutdown) to nil.
+func runToolPhase(s *shellState) session.Phase {
+	return session.PhaseFunc{
+		PhaseName: "run-tool",
+		RunFn: func(_ context.Context) (session.Teardown, error) {
+			fmt.Fprintf(os.Stderr, "\nStarting session...\n")
+			fmt.Fprintf(os.Stderr, "Session ID: %s\n", s.sessionID)
+			fmt.Fprintf(os.Stderr, "Container: %s\n", s.result.ContainerName)
+			fmt.Fprintf(os.Stderr, "Workspace: %s\n", s.absWorkspace)
+
+			useResumeFlag := (s.resumeID != "") && app.persistent
+			restoreOnly := (s.resumeID != "") && !app.persistent
+
+			var runErr error
+			if s.useTmux {
+				if background {
+					fmt.Fprintf(os.Stderr, "Mode: Background (tmux)\n")
+				} else {
+					fmt.Fprintf(os.Stderr, "Mode: Interactive (tmux)\n")
+				}
+				if restoreOnly {
+					fmt.Fprintf(os.Stderr, "Resume mode: Restored conversation (auto-detect)\n")
+				} else if useResumeFlag {
+					fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
+				}
+				fmt.Fprintf(os.Stderr, "\n")
+				runErr = runCLIInTmux(s.result, s.sessionID, background, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
+			} else {
+				fmt.Fprintf(os.Stderr, "Mode: Direct (no tmux)\n")
+				if restoreOnly {
+					fmt.Fprintf(os.Stderr, "Resume mode: Restored conversation (auto-detect)\n")
+				} else if useResumeFlag {
+					fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
+				}
+				fmt.Fprintf(os.Stderr, "\n")
+				runErr = runCLI(s.result, s.sessionID, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
+			}
+
+			// Normalise expected exit conditions so the pipeline doesn't log
+			// a spurious error and the teardown (cleanup) still runs.
+			if runErr != nil {
+				errStr := runErr.Error()
+				if errStr == "exit status 130" {
+					return nil, nil
+				}
+				if strings.Contains(errStr, "Failed to retrieve PID") ||
+					strings.Contains(errStr, "server exited") ||
+					strings.Contains(errStr, "connection reset") ||
+					errStr == "exit status 1" {
+					return nil, nil
+				}
+			}
+			return nil, runErr
+		},
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -126,35 +126,45 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// networkMgr holds the network.Manager when isolation is active; set after
-	// applyNetworkIsolation so the defer below can call Teardown before deletion.
+	// networkMgr is assigned by applyNetworkIsolation below. Declared here so
+	// the teardown closures can capture it by reference.
 	var networkMgr *network.Manager
 
-	// Cleanup container on exit (only if ephemeral)
-	defer func() {
-		// Clear immutable bits before container deletion (must happen first)
-		logger := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
-		session.RemoveImmutable(containerName, logger)
+	// Teardowns run LIFO. Register in reverse of desired execution order so
+	// the actual sequence is: immutable → network → container.
+	pipeline := &session.Pipeline{}
+	defer pipeline.Teardown()
 
-		// Teardown network isolation before deleting the container so that
-		// firewall rules are removed while the container IP is still resolvable.
-		if networkMgr != nil {
-			if err := networkMgr.Teardown(context.Background(), containerName); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to teardown network isolation: %v\n", err)
-			}
-		}
-
+	// 1. Container (registered first → executes last in LIFO)
+	pipeline.AddTeardown(func() {
 		if !app.persistent {
 			fmt.Fprintf(os.Stderr, "Cleaning up container %s...\n", containerName)
-			_ = mgr.Delete(true) // Best effort cleanup
+			_ = mgr.Delete(true)
 		} else {
-			// Only stop if container is running (avoids spurious error messages)
 			if running, _ := mgr.Running(); running {
 				fmt.Fprintf(os.Stderr, "Stopping persistent container %s...\n", containerName)
-				_ = mgr.Stop(false) // Best effort stop
+				_ = mgr.Stop(false)
 			}
 		}
-	}()
+	})
+
+	// 2. Network (registered second → executes second; runs before container
+	// deletion so firewall rules are removed while the IP is still resolvable)
+	pipeline.AddTeardown(func() {
+		if networkMgr == nil {
+			return
+		}
+		if err := networkMgr.Teardown(context.Background(), containerName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to teardown network isolation: %v\n", err)
+		}
+	})
+
+	// 3. Immutable (registered last → executes first; clears host-side bits
+	// before any container or network operation so protected files are writable)
+	pipeline.AddTeardown(func() {
+		logFn := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
+		session.RemoveImmutable(containerName, logFn)
+	})
 
 	// Apply resource limits (only for new containers, not restarted persistent ones)
 	wasRestarted := containerExists && app.persistent

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -8,11 +8,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
-	"github.com/mensfeld/code-on-incus/internal/alias"
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/logger"
@@ -78,483 +76,46 @@ func init() {
 	shellCmd.Flags().StringVar(&toolFlag, "tool", "", "Override AI tool (e.g. claude, opencode, aider)")
 }
 
-//nolint:gocyclo // Sequential initialization with many configuration paths
 func shellCommand(cmd *cobra.Command, args []string) error {
-	// Handle positional alias argument
-	var aliasArg string
-	if len(args) > 0 {
-		aliasArg = args[0]
-	}
-
-	// Get absolute workspace path
-	absWorkspace, err := filepath.Abs(app.workspace)
-	if err != nil {
-		return fmt.Errorf("invalid workspace path: %w", err)
-	}
-
-	// If workspace differs from CWD and no alias argument overrides it, overlay
-	// the workspace's project config. config.Load() only reads from CWD, so a
-	// --workspace pointing elsewhere would otherwise miss that .coi/config.toml.
-	// Skip when aliasArg is set: alias resolution will reassign absWorkspace and
-	// call OverlayProjectConfig itself, avoiding a double-overlay from the wrong dir.
-	if aliasArg == "" {
-		if cwd, err := os.Getwd(); err == nil {
-			if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
-				if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
-					return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
-				}
-				container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
-			}
-		}
-	}
-
-	// If alias argument provided, resolve it from the registry
-	if aliasArg != "" {
-		resolved, err := alias.ResolveAliasForLaunch(aliasArg)
-		if err != nil {
-			return err
-		}
-		// Override workspace from registry
-		absWorkspace = resolved.Workspace
-
-		// Reload project config from the resolved workspace so that mounts,
-		// network, storage_pool, alias, and other project-level settings from
-		// the target workspace are applied instead of the caller's CWD config.
-		if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
-		}
-
-		// Apply profile if registry specifies one and user didn't override
-		if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
-			app.profile = resolved.Profile
-			if err := app.cfg.ApplyProfile(app.profile); err != nil {
-				return err
-			}
-		}
-		// Re-apply Incus configuration after config reload
-		container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
-		if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
-			app.slot = resolved.Slot
-		}
-	}
-
-	// Determine useTmux: config default, overridden by explicit --tmux flag
-	useTmuxDefault := true
-	if app.cfg.Shell.UseTmux != nil {
-		useTmuxDefault = *app.cfg.Shell.UseTmux
-	}
-	if !cmd.Flags().Changed("tmux") {
-		useTmux = useTmuxDefault
-	}
-
-	// Create a context that is cancelled on SIGINT/SIGTERM.
-	// This propagates cancellation to session.Setup so that Ctrl+C during
-	// container launch unblocks the provisioning sequence rather than leaving
-	// orphaned containers.
+	// Create a context that is cancelled on SIGINT/SIGTERM so session.Setup
+	// can abort container provisioning on Ctrl+C instead of leaving orphaned
+	// containers.
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Check if Incus is available
-	if !container.Available() {
-		return container.IncusNotAvailableError()
+	s := &shellState{}
+	if len(args) > 0 {
+		s.aliasArg = args[0]
 	}
 
-	// Check minimum Incus version
-	if err := container.CheckMinimumVersion(); err != nil {
-		return err
-	}
+	pipeline := &session.Pipeline{}
+	defer pipeline.Teardown()
 
-	// Warn if kernel is too old (non-blocking)
-	if warning := container.CheckKernelVersion(); warning != "" {
-		fmt.Fprintf(os.Stderr, "%s\n", warning)
-	}
-
-	// Get configured tool (needed to determine tool-specific sessions directory)
-	// --tool flag overrides whatever is in .coi/config.toml or global config
-	if toolFlag != "" {
-		app.cfg.Tool.Name = toolFlag
-	}
-	toolInstance, err := getConfiguredTool(app.cfg)
-	if err != nil {
-		return err
-	}
-
-	// Get sessions directory (tool-specific: sessions-claude, sessions-aider, etc.)
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-	baseDir := filepath.Join(homeDir, ".coi")
-	sessionsDir := session.GetSessionsDir(baseDir, toolInstance)
-	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create sessions directory: %w", err)
-	}
-
-	// Handle resume flag (--resume or --continue)
-	resumeID := app.resume
-	if app.continueSession != "" {
-		resumeID = app.continueSession // --continue takes precedence if both are provided
-	}
-
-	// Check if resume/continue flag was explicitly set
-	resumeFlagSet := cmd.Flags().Changed("resume") || cmd.Flags().Changed("continue")
-
-	// Check if tool uses workspace-based sessions (like opencode stores in .opencode/)
-	// These tools don't need COI session tracking - their data is in the workspace
-	isWorkspaceSessionTool := false
-	if toolInstance.Name() == "opencode" {
-		// opencode stores sessions in workspace .opencode/ SQLite, not ~/.coi/sessions-*
-		workspaceSessionDir := filepath.Join(absWorkspace, ".opencode")
-		if info, err := os.Stat(workspaceSessionDir); err == nil && info.IsDir() {
-			isWorkspaceSessionTool = true
-		}
-	}
-
-	// Auto-detect if flag was set but value is empty or "auto"
-	if resumeFlagSet && (resumeID == "" || resumeID == "auto") {
-		if isWorkspaceSessionTool {
-			// For workspace-session tools, use a synthetic session ID
-			// The actual session data is in the workspace directory
-			resumeID = "workspace-session"
-			fmt.Fprintf(os.Stderr, "Resuming %s session from workspace\n", toolInstance.Name())
-		} else {
-			// Auto-detect latest for workspace (only looks at sessions from the same workspace)
-			resumeID, err = session.GetLatestSessionForWorkspace(sessionsDir, absWorkspace)
-			if err != nil {
-				return fmt.Errorf("no previous session to resume for this workspace: %w", err)
-			}
-			fmt.Fprintf(os.Stderr, "Auto-detected session: %s\n", resumeID)
-		}
-	} else if resumeID != "" && !isWorkspaceSessionTool {
-		// Validate that the explicitly provided session exists (skip for workspace-session tools)
-		if !session.SessionExists(sessionsDir, resumeID) {
-			return fmt.Errorf("session '%s' not found - check available sessions with: coi list --all", resumeID)
-		}
-		fmt.Fprintf(os.Stderr, "Resuming session: %s\n", resumeID)
-	}
-
-	// When resuming, inherit persistent flag and original slot from the session
-	// unless explicitly overridden by the user.
-	// Skip for workspace-session tools (they don't have COI metadata files)
-	var resumeSlot int // Original slot from session metadata (0 = not set)
-	if resumeID != "" && !isWorkspaceSessionTool {
-		metadataPath := filepath.Join(sessionsDir, resumeID, "metadata.json")
-		if metadata, err := session.LoadSessionMetadata(metadataPath); err == nil {
-			// Inherit profile if not explicitly set by user
-			if !cmd.Flags().Changed("profile") && metadata.ProfileName != "" {
-				app.profile = metadata.ProfileName
-				if err := app.cfg.ApplyProfile(app.profile); err != nil {
-					return fmt.Errorf("failed to apply saved profile '%s': %w", app.profile, err)
-				}
-				// Re-apply persistent from config since profile may override it
-				if !cmd.Flags().Changed("persistent") {
-					app.persistent = config.BoolVal(app.cfg.Container.Persistent)
-				}
-				fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", app.profile)
-			}
-
-			// Inherit persistent flag if not explicitly set by user
-			if !cmd.Flags().Changed("persistent") {
-				app.persistent = metadata.Persistent
-				if app.persistent {
-					fmt.Fprintf(os.Stderr, "Inherited persistent mode from session\n")
-				}
-			}
-
-			// Extract original slot from container name so we reuse the same container
-			// instead of allocating a new slot (which would create a fresh container)
-			if !cmd.Flags().Changed("slot") {
-				if _, origSlot, err := session.ParseContainerName(metadata.ContainerName); err == nil {
-					resumeSlot = origSlot
-				}
-			}
-		}
-	}
-
-	// Generate or use session ID
-	var sessionID string
-	if resumeID != "" {
-		sessionID = resumeID // Reuse the same session ID when resuming
-	} else {
-		sessionID, err = session.GenerateSessionID()
-		if err != nil {
-			return err
-		}
-	}
-
-	// Allocate slot - always check for availability and auto-increment if needed
-	slotNum := app.slot
-	if resumeSlot > 0 && slotNum == 0 {
-		// Resuming a session: reuse the original slot so the stopped container is restarted
-		slotNum = resumeSlot
-		fmt.Fprintf(os.Stderr, "Reusing original slot %d from session\n", slotNum)
-	} else if slotNum == 0 {
-		// No slot specified, find first available
-		slotNum, err = session.AllocateSlot(absWorkspace, 10)
-		if err != nil {
-			return fmt.Errorf("failed to allocate slot: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "Auto-allocated slot %d\n", slotNum)
-	} else {
-		// Slot specified, but check if it's available
-		// If not, find next available slot starting from the specified one
-		available, err := session.IsSlotAvailable(absWorkspace, slotNum)
-		if err != nil {
-			return fmt.Errorf("failed to check slot availability: %w", err)
-		}
-
-		if !available {
-			// Slot is occupied, find next available starting from slot+1
-			originalSlot := slotNum
-			slotNum, err = session.AllocateSlotFrom(absWorkspace, slotNum+1, 10)
-			if err != nil {
-				return fmt.Errorf("slot %d is occupied and failed to find next available slot: %w", originalSlot, err)
-			}
-			fmt.Fprintf(os.Stderr, "Slot %d is occupied, using slot %d instead\n", originalSlot, slotNum)
-		}
-	}
-
-	// Prepare network configuration from config
-	networkConfig := app.cfg.Network
-
-	// Determine CLI config path based on tool
-	// For directory-based tools (ConfigDirName != ""), point at the config directory.
-	// For ENV-based tools (returns ""), leave empty.
-	var cliConfigPath string
-	if configDirName := toolInstance.ConfigDirName(); configDirName != "" {
-		cliConfigPath = filepath.Join(homeDir, configDirName)
-	}
-
-	// Use limits directly from config
-	limitsConfig := &app.cfg.Limits
-
-	// Determine protected paths for security mounts from config
-	var protectedPaths []string
-	if !app.cfg.Security.DisableProtection {
-		protectedPaths = app.cfg.Security.GetEffectiveProtectedPaths()
-	}
-
-	protectedPaths = filterWritableGitHooks(protectedPaths, app.cfg)
-
-	// Resolve which forwarded env vars are actually set on the host.
-	// This list is passed to the context file so AI tools know what's available.
-	resolvedForwardedEnvVars := resolveForwardedEnvVarNames(app.cfg.Defaults.ForwardEnv)
-
-	// Resolve timezone from config
-	resolvedTimezone := resolveTimezone(app.cfg)
-
-	// Determine image: CLI --image flag > config defaults.image > "coi"
-	img := ResolveImageName(app.imageName, app.cfg)
-	if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
-		return err
-	}
-
-	// Setup session
-	setupOpts := session.SetupOptions{
-		WorkspacePath:         absWorkspace,
-		Image:                 img,
-		Persistent:            app.persistent,
-		ResumeFromID:          resumeID,
-		Slot:                  slotNum,
-		SessionsDir:           sessionsDir,
-		CLIConfigPath:         cliConfigPath,
-		Tool:                  toolInstance,
-		NetworkConfig:         &networkConfig,
-		DisableShift:          app.cfg.Incus.DisableShift,
-		LimitsConfig:          limitsConfig,
-		IncusProject:          app.cfg.Incus.Project,
-		ProtectedPaths:        protectedPaths,
-		HostImmutable:         app.cfg.Security.IsHostImmutableEnabled(),
-		PreserveWorkspacePath: app.cfg.Paths.PreserveWorkspacePath,
-		ForwardSSHAgent:       config.BoolVal(app.cfg.SSH.ForwardAgent),
-		ForwardedEnvVars:      resolvedForwardedEnvVars,
-		ContextFilePath:       app.cfg.Tool.ContextFile,
-		ProfileContextFile:    app.cfg.ProfileContextFile,
-		AutoContext:           app.cfg.Tool.AutoContext,
-		ContainerName:         containerName,
-		Timezone:              resolvedTimezone,
-		Alias:                 app.cfg.Container.Alias,
-	}
-
-	// Parse and validate mount configuration
-	mountConfig, err := ParseMountConfig(app.cfg)
-	if err != nil {
-		return fmt.Errorf("invalid mount configuration: %w", err)
-	}
-
-	// Validate no nested mounts
-	if err := session.ValidateMounts(mountConfig); err != nil {
-		return fmt.Errorf("mount validation failed: %w", err)
-	}
-
-	setupOpts.MountConfig = mountConfig
-
-	// Validate alias before proceeding with setup
-	if app.cfg.Container.Alias != "" {
-		if err := alias.ValidateAlias(app.cfg.Container.Alias); err != nil {
-			return fmt.Errorf("invalid container alias: %w", err)
-		}
-	}
-
-	fmt.Fprintf(os.Stderr, "Setting up session %s...\n", sessionID)
-	result, err := session.Setup(ctx, setupOpts)
-	if err != nil {
-		return fmt.Errorf("failed to setup session: %w", err)
-	}
-
-	// Save metadata early so coi list shows correct persistent/ephemeral status
-	if err := session.SaveMetadataEarly(sessionsDir, sessionID, result.ContainerName, absWorkspace, app.persistent, app.profile); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
-	}
-
-	// Register alias in global registry for cross-directory resolution
-	if effectiveAlias := app.cfg.Container.Alias; effectiveAlias != "" {
-		if reg, err := alias.Load(); err == nil {
-			if err := reg.Register(effectiveAlias, absWorkspace, app.profile); err != nil {
-				return fmt.Errorf("alias conflict: %w", err)
-			}
-			if err := reg.Save(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to save alias registry: %v\n", err)
-			}
-		}
-	}
-
-	// Start monitoring daemons if enabled via config
-	var monitorDaemon *monitor.Daemon
-	var nftDaemon *nftmonitor.Daemon
-	if config.BoolVal(app.cfg.Monitoring.Enabled) {
-		// Start traditional monitoring (process/filesystem)
-		if err := startMonitoringDaemon(result.ContainerName, absWorkspace, app.cfg, result.Logger, &monitorDaemon); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to start monitoring daemon: %v\n", err)
-			// Don't fail the session if monitoring fails
-		}
-
-		// Start nftables monitoring (network only)
-		if config.BoolVal(app.cfg.Monitoring.NFT.Enabled) {
-			if err := startNFTMonitoringDaemon(result.ContainerName, app.cfg, result.Logger, &nftDaemon); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to start NFT monitoring: %v\n", err)
-				// Don't fail the session if NFT monitoring fails
-			}
-		}
-	}
-
-	// Define cleanup function so it can be called from both defer and signal handler.
-	// sync.Once ensures cleanup runs exactly once even if both paths trigger concurrently
-	// (e.g., signal arrives while the function is already returning normally).
-	// Note: os.Exit() does NOT run deferred functions, so we must call cleanup explicitly.
-	var cleanupOnce sync.Once
-	doCleanup := func() {
-		cleanupOnce.Do(func() {
-			fmt.Fprintf(os.Stderr, "\nCleaning up session...\n")
-
-			// Stop monitoring daemons if they were started
-			if monitorDaemon != nil {
-				if err := monitorDaemon.Stop(); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: Failed to stop monitoring daemon: %v\n", err)
-				}
-			}
-			if nftDaemon != nil {
-				if err := nftDaemon.Stop(); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: Failed to stop NFT monitoring: %v\n", err)
-				}
-			}
-
-			// Stop timeout monitor if it was started
-			if result.TimeoutMonitor != nil {
-				result.TimeoutMonitor.Stop()
-			}
-
-			cleanupOpts := session.CleanupOptions{
-				ContainerName:  result.ContainerName,
-				SessionID:      sessionID,
-				Persistent:     app.persistent,
-				ProfileName:    app.profile,
-				SessionsDir:    sessionsDir,
-				SaveSession:    true, // Always save session data
-				Workspace:      absWorkspace,
-				Tool:           toolInstance,
-				NetworkManager: result.NetworkManager,
-				SessionLogger:  result.Logger,
-			}
-			if err := session.Cleanup(cleanupOpts); err != nil {
-				fmt.Fprintf(os.Stderr, "Cleanup error: %v\n", err)
-			}
-		})
-	}
-
-	// Setup cleanup on exit (for normal return paths)
-	defer doCleanup()
-
-	// Handle Ctrl+C gracefully - must call cleanup explicitly since os.Exit skips defers
+	// Signal handler: call pipeline.Teardown on SIGINT/SIGTERM so session
+	// cleanup runs even while runCLI is blocking on an interactive incus exec.
+	// pipeline.Teardown is idempotent — the defer above is a safe no-op second
+	// call. We do NOT os.Exit here: stopping the container (inside Teardown)
+	// causes incus exec to return, which unblocks runCLI and lets the normal
+	// return path complete.
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
-		<-sigChan
-		fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
-		doCleanup()
-		os.Exit(0)
+		select {
+		case <-sigChan:
+			fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
+			pipeline.Teardown()
+		case <-ctx.Done():
+		}
 	}()
 
-	// Run CLI tool
-	fmt.Fprintf(os.Stderr, "\nStarting session...\n")
-	fmt.Fprintf(os.Stderr, "Session ID: %s\n", sessionID)
-	fmt.Fprintf(os.Stderr, "Container: %s\n", result.ContainerName)
-	fmt.Fprintf(os.Stderr, "Workspace: %s\n", absWorkspace)
-
-	// Determine resume mode
-	// The difference is:
-	// - Persistent: container is reused, tool config stays in container, pass --resume flag
-	// - Ephemeral: container is recreated, we restore config dir, tool auto-detects session
-	//
-	// For persistent containers resuming: pass --resume flag with tool's session ID
-	// For ephemeral containers resuming: just restore config, tool will auto-detect from restored data
-	useResumeFlag := (resumeID != "") && app.persistent
-	restoreOnly := (resumeID != "") && !app.persistent
-
-	// Choose execution mode
-	if useTmux {
-		if background {
-			fmt.Fprintf(os.Stderr, "Mode: Background (tmux)\n")
-		} else {
-			fmt.Fprintf(os.Stderr, "Mode: Interactive (tmux)\n")
-		}
-		if restoreOnly {
-			fmt.Fprintf(os.Stderr, "Resume mode: Restored conversation (auto-detect)\n")
-		} else if useResumeFlag {
-			fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
-		}
-		fmt.Fprintf(os.Stderr, "\n")
-		err = runCLIInTmux(result, sessionID, background, useResumeFlag, restoreOnly, sessionsDir, resumeID, toolInstance)
-	} else {
-		fmt.Fprintf(os.Stderr, "Mode: Direct (no tmux)\n")
-		if restoreOnly {
-			fmt.Fprintf(os.Stderr, "Resume mode: Restored conversation (auto-detect)\n")
-		} else if useResumeFlag {
-			fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
-		}
-		fmt.Fprintf(os.Stderr, "\n")
-		err = runCLI(result, sessionID, useResumeFlag, restoreOnly, sessionsDir, resumeID, toolInstance)
-	}
-
-	// Handle expected exit conditions gracefully
-	if err != nil {
-		errStr := err.Error()
-		// Exit status 130 means interrupted by SIGINT (Ctrl+C) - this is normal
-		if errStr == "exit status 130" {
-			return nil
-		}
-		// Container shutdown from within (sudo shutdown 0) causes exec to fail
-		// This can manifest as various errors depending on timing
-		if strings.Contains(errStr, "Failed to retrieve PID") ||
-			strings.Contains(errStr, "server exited") ||
-			strings.Contains(errStr, "connection reset") ||
-			errStr == "exit status 1" {
-			// Don't print anything - cleanup will show appropriate message
-			return nil
-		}
-	}
-
-	return err
+	return pipeline.Run(ctx,
+		resolveWorkspacePhase(cmd, s),
+		validateEnvPhase(cmd, s),
+		configureSessionPhase(cmd, s),
+		setupContainerPhase(s),
+		startMonitoringPhase(s),
+		runToolPhase(s),
+	)
 }
 
 // getConfiguredTool returns the tool to use based on config

--- a/internal/session/pipeline.go
+++ b/internal/session/pipeline.go
@@ -1,0 +1,83 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Teardown is a cleanup function registered by a Phase. Teardowns run in LIFO
+// order when Pipeline.Teardown is called.
+type Teardown func()
+
+// Phase is a single step in a session pipeline. Run performs the step's work
+// and returns an optional Teardown that reverses its effects. If Run returns
+// an error, the pipeline stops immediately; already-registered teardowns are
+// called by the pipeline's defer (not by Run itself).
+type Phase interface {
+	Name() string
+	Run(ctx context.Context) (Teardown, error)
+}
+
+// PhaseFunc adapts an inline function to the Phase interface.
+type PhaseFunc struct {
+	PhaseName string
+	RunFn     func(ctx context.Context) (Teardown, error)
+}
+
+func (p PhaseFunc) Name() string                              { return p.PhaseName }
+func (p PhaseFunc) Run(ctx context.Context) (Teardown, error) { return p.RunFn(ctx) }
+
+// Pipeline executes Phases in order and tracks their Teardowns for LIFO
+// cleanup. Teardown is idempotent: subsequent calls after the first are
+// no-ops. It is safe to call Teardown concurrently with Run.
+type Pipeline struct {
+	mu           sync.Mutex
+	teardowns    []Teardown
+	teardownOnce sync.Once
+}
+
+// Run executes each phase in order. If ctx is cancelled before a phase starts,
+// Run stops and returns ctx.Err(). Teardowns registered so far are NOT called
+// by Run — the caller must call Pipeline.Teardown (typically via defer) to
+// ensure cleanup happens on every exit path.
+func (p *Pipeline) Run(ctx context.Context, phases ...Phase) error {
+	for _, phase := range phases {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		td, err := phase.Run(ctx)
+		if td != nil {
+			p.mu.Lock()
+			p.teardowns = append(p.teardowns, td)
+			p.mu.Unlock()
+		}
+		if err != nil {
+			return fmt.Errorf("%s: %w", phase.Name(), err)
+		}
+	}
+	return nil
+}
+
+// AddTeardown registers a teardown function directly, outside of a phase.
+// Useful when the caller accumulates teardowns incrementally (e.g. each step
+// adds its own cleanup before the next step runs).
+func (p *Pipeline) AddTeardown(td Teardown) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.teardowns = append(p.teardowns, td)
+}
+
+// Teardown invokes all registered teardowns in reverse order (LIFO). It is
+// safe to call concurrently and multiple times; only the first call executes.
+func (p *Pipeline) Teardown() {
+	p.teardownOnce.Do(func() {
+		p.mu.Lock()
+		tds := make([]Teardown, len(p.teardowns))
+		copy(tds, p.teardowns)
+		p.mu.Unlock()
+		for i := len(tds) - 1; i >= 0; i-- {
+			tds[i]()
+		}
+	})
+}

--- a/internal/session/pipeline_test.go
+++ b/internal/session/pipeline_test.go
@@ -1,0 +1,145 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPipeline_RunsPhaseInOrder(t *testing.T) {
+	var order []string
+	p := &Pipeline{}
+
+	p.Run(context.Background(),
+		PhaseFunc{"a", func(_ context.Context) (Teardown, error) { order = append(order, "a"); return nil, nil }},
+		PhaseFunc{"b", func(_ context.Context) (Teardown, error) { order = append(order, "b"); return nil, nil }},
+		PhaseFunc{"c", func(_ context.Context) (Teardown, error) { order = append(order, "c"); return nil, nil }},
+	)
+
+	if len(order) != 3 || order[0] != "a" || order[1] != "b" || order[2] != "c" {
+		t.Errorf("unexpected phase order: %v", order)
+	}
+}
+
+func TestPipeline_StopsOnError(t *testing.T) {
+	var ran []string
+	p := &Pipeline{}
+	sentinel := errors.New("boom")
+
+	err := p.Run(context.Background(),
+		PhaseFunc{"ok", func(_ context.Context) (Teardown, error) { ran = append(ran, "ok"); return nil, nil }},
+		PhaseFunc{"fail", func(_ context.Context) (Teardown, error) { return nil, sentinel }},
+		PhaseFunc{"skip", func(_ context.Context) (Teardown, error) { ran = append(ran, "skip"); return nil, nil }},
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(ran) != 1 || ran[0] != "ok" {
+		t.Errorf("expected only 'ok' to run before error, got: %v", ran)
+	}
+}
+
+func TestPipeline_TeardownRunsLIFO(t *testing.T) {
+	var order []string
+	p := &Pipeline{}
+
+	p.Run(context.Background(),
+		PhaseFunc{"a", func(_ context.Context) (Teardown, error) {
+			return func() { order = append(order, "td-a") }, nil
+		}},
+		PhaseFunc{"b", func(_ context.Context) (Teardown, error) {
+			return func() { order = append(order, "td-b") }, nil
+		}},
+		PhaseFunc{"c", func(_ context.Context) (Teardown, error) {
+			return func() { order = append(order, "td-c") }, nil
+		}},
+	)
+
+	p.Teardown()
+
+	if len(order) != 3 || order[0] != "td-c" || order[1] != "td-b" || order[2] != "td-a" {
+		t.Errorf("expected LIFO order [td-c, td-b, td-a], got: %v", order)
+	}
+}
+
+func TestPipeline_TeardownIdempotent(t *testing.T) {
+	var count int
+	p := &Pipeline{}
+
+	p.Run(context.Background(),
+		PhaseFunc{"x", func(_ context.Context) (Teardown, error) {
+			return func() { count++ }, nil
+		}},
+	)
+
+	p.Teardown()
+	p.Teardown()
+	p.Teardown()
+
+	if count != 1 {
+		t.Errorf("teardown ran %d times, expected 1", count)
+	}
+}
+
+func TestPipeline_AddTeardown(t *testing.T) {
+	var order []string
+	p := &Pipeline{}
+
+	p.AddTeardown(func() { order = append(order, "first") })
+	p.AddTeardown(func() { order = append(order, "second") })
+	p.Teardown()
+
+	// LIFO: second registered → first executed
+	if len(order) != 2 || order[0] != "second" || order[1] != "first" {
+		t.Errorf("expected [second, first], got: %v", order)
+	}
+}
+
+func TestPipeline_CancelledContextSkipsPhase(t *testing.T) {
+	var ran []string
+	p := &Pipeline{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Run
+
+	err := p.Run(ctx,
+		PhaseFunc{"should-skip", func(_ context.Context) (Teardown, error) {
+			ran = append(ran, "ran")
+			return nil, nil
+		}},
+	)
+
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if len(ran) != 0 {
+		t.Errorf("phase ran despite cancelled context: %v", ran)
+	}
+}
+
+func TestPipeline_TeardownRunsForCompletedPhasesOnError(t *testing.T) {
+	var torn []string
+	p := &Pipeline{}
+
+	p.Run(context.Background(),
+		PhaseFunc{"a", func(_ context.Context) (Teardown, error) {
+			return func() { torn = append(torn, "a") }, nil
+		}},
+		PhaseFunc{"fail", func(_ context.Context) (Teardown, error) {
+			return nil, errors.New("oops")
+		}},
+		PhaseFunc{"c", func(_ context.Context) (Teardown, error) {
+			return func() { torn = append(torn, "c") }, nil
+		}},
+	)
+	p.Teardown()
+
+	// Only "a" registered a teardown; "c" never ran
+	if len(torn) != 1 || torn[0] != "a" {
+		t.Errorf("expected [a], got: %v", torn)
+	}
+}


### PR DESCRIPTION
## Summary

- **`internal/session/pipeline.go`** (new): `Phase` interface, `PhaseFunc` adapter, and `Pipeline` struct with LIFO-ordered, idempotent, concurrency-safe `Teardown`
- **`internal/cli/phases_shell.go`** (new): `shellState` accumulator and six named phase factory functions extracted from the old `shellCommand()` monolith: `resolve-workspace`, `validate-env`, `configure-session`, `setup-container`, `start-monitoring`, `run-tool`
- **`shell.go`**: `shellCommand()` reduced from 476 to 40 lines; `sync.Once` + `os.Exit` in the signal handler removed — `pipeline.Teardown` stops the container which unblocks the blocking `incus exec`, letting the normal return path run cleanup
- **`run.go`**: inline `defer func()` replaced with `pipeline.AddTeardown` calls registered in reverse-execution order (container → network → immutable) so LIFO gives the required sequence: immutable-first → network-second → container-last
- **7 unit tests** for the pipeline covering phase order, early-stop on error, LIFO teardown, idempotency, and cancelled-context skipping

## Why

Addresses Issue 1 from the architecture review: the 1000-line monolithic `shellCommand` was impossible to unit test, fragile to extend (every new feature bolted on sequentially), and used a brittle `sync.Once` + signal goroutine + `os.Exit` pattern for cleanup. Each phase is now a named, bounded unit with an explicit teardown; the pipeline guarantees cleanup runs in LIFO order on every exit path.

## Test plan

- [ ] Unit tests: `go test ./internal/session/... ./internal/cli/...` — all pass
- [ ] Integration: wait for CI green on all jobs
- [ ] Interactive smoke test: `coi shell` starts, Ctrl+C triggers pipeline teardown without `os.Exit`