### PR TITLE
fix(pipeline): address Copilot review comments on PR #424

### DIFF
--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -91,20 +91,31 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	pipeline := &session.Pipeline{}
 	defer pipeline.Teardown()
 
-	// Signal handler: call pipeline.Teardown on SIGINT/SIGTERM so session
-	// cleanup runs even while runCLI is blocking on an interactive incus exec.
-	// pipeline.Teardown is idempotent — the defer above is a safe no-op second
-	// call. We do NOT os.Exit here: stopping the container (inside Teardown)
-	// causes incus exec to return, which unblocks runCLI and lets the normal
-	// return path complete.
+	// Signal handler: explicitly trigger cleanup when SIGINT/SIGTERM arrives
+	// while runCLI is blocking on an interactive incus exec.
+	//
+	// We cannot use ctx.Done() as the "signal received" branch because
+	// signal.NotifyContext cancels ctx AND delivers to sigChan at the same
+	// time — a select over both is non-deterministic. If ctx.Done() is chosen,
+	// the goroutine exits without calling Teardown, leaving cleanup to the
+	// deferred call, which won't run until the blocking incus exec returns.
+	//
+	// Instead we use a dedicated `done` channel closed when shellCommand
+	// returns. On signal, cleanup is always called. On normal return, the
+	// goroutine exits via the done branch without a second cleanup attempt
+	// (pipeline.Teardown is idempotent). signal.Stop ensures no further
+	// signals are queued after shellCommand returns.
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
 		select {
 		case <-sigChan:
 			fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
 			pipeline.Teardown()
-		case <-ctx.Done():
+		case <-done:
 		}
 	}()
 

--- a/internal/session/pipeline.go
+++ b/internal/session/pipeline.go
@@ -61,15 +61,22 @@ func (p *Pipeline) Run(ctx context.Context, phases ...Phase) error {
 
 // AddTeardown registers a teardown function directly, outside of a phase.
 // Useful when the caller accumulates teardowns incrementally (e.g. each step
-// adds its own cleanup before the next step runs).
+// adds its own cleanup before the next step runs). Nil teardowns are silently
+// ignored, matching the behaviour of Pipeline.Run.
 func (p *Pipeline) AddTeardown(td Teardown) {
+	if td == nil {
+		return
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.teardowns = append(p.teardowns, td)
 }
 
 // Teardown invokes all registered teardowns in reverse order (LIFO). It is
-// safe to call concurrently and multiple times; only the first call executes.
+// safe to call from multiple goroutines simultaneously; only the first call
+// executes — subsequent calls are no-ops. Callers must not call Teardown
+// concurrently with Run: teardowns registered after Teardown's snapshot is
+// taken will not be executed.
 func (p *Pipeline) Teardown() {
 	p.teardownOnce.Do(func() {
 		p.mu.Lock()

--- a/internal/session/pipeline_test.go
+++ b/internal/session/pipeline_test.go
@@ -121,6 +121,12 @@ func TestPipeline_CancelledContextSkipsPhase(t *testing.T) {
 	}
 }
 
+func TestPipeline_AddTeardown_NilIsIgnored(t *testing.T) {
+	p := &Pipeline{}
+	p.AddTeardown(nil) // must not panic at Teardown time
+	p.Teardown()       // would panic if nil was stored and called
+}
+
 func TestPipeline_TeardownRunsForCompletedPhasesOnError(t *testing.T) {
 	var torn []string
 	p := &Pipeline{}


### PR DESCRIPTION
Addresses three valid issues raised by Copilot review on #424.

## Changes

**1. Signal goroutine race (`shell.go`)**

`select{sigChan / ctx.Done()}` is non-deterministic: `signal.NotifyContext` cancels `ctx` at the same instant `sigChan` receives the signal. If `ctx.Done()` wins the race, the goroutine exits without calling `pipeline.Teardown()`, leaving cleanup to the deferred call — which won't run until the blocking `incus exec` returns (potentially never, if the tool ignores the signal).

Fix: replace `ctx.Done()` with a dedicated `done` channel closed by `defer close(done)` when `shellCommand` returns. A signal now *always* takes the `sigChan` branch and triggers teardown. Add `defer signal.Stop(sigChan)` so no signals are queued after return.

**2. `AddTeardown(nil)` panic (`pipeline.go`)**

A nil teardown stored in the slice causes `pipeline.Teardown()` to call `nil()` and panic. Fix: skip nil in `AddTeardown`, matching `Pipeline.Run`'s existing nil guard. New test added.

**3. Misleading concurrency comment (`pipeline.go`)**

"safe to call concurrently with Run" implied no teardowns would be missed, which is false if `Run` is still registering teardowns when `Teardown` snapshots the slice. Fix: clarify that the idempotency guarantee applies to multiple concurrent callers of `Teardown`, not to a concurrent `Run`+`Teardown` scenario.

## Test plan
- [ ] `go test ./internal/session/... ./internal/cli/...` — all pass including new `TestPipeline_AddTeardown_NilIsIgnored`
- [ ] CI green on all jobs