### PR TITLE
fix(monitor): read network connections from container network namespace

### DIFF
--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -43,10 +43,16 @@ func GetContainerInitPID(ctx context.Context, containerName string) (int, error)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get container info: %w", err)
 	}
+	return parseInitPIDFromIncusInfo(output)
+}
 
+// parseInitPIDFromIncusInfo extracts the container init PID from `incus info`
+// output. Exported for testing; production callers use GetContainerInitPID.
+func parseInitPIDFromIncusInfo(output string) (int, error) {
 	for _, line := range strings.Split(output, "\n") {
-		if strings.Contains(line, "PID:") || strings.Contains(line, "Pid:") {
-			parts := strings.Fields(line)
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "PID:") || strings.HasPrefix(trimmed, "Pid:") {
+			parts := strings.Fields(trimmed)
 			if len(parts) >= 2 {
 				pid, err := strconv.Atoi(parts[1])
 				if err == nil && pid > 0 {
@@ -55,7 +61,6 @@ func GetContainerInitPID(ctx context.Context, containerName string) (int, error)
 			}
 		}
 	}
-
 	return 0, fmt.Errorf("could not find container PID in incus info output")
 }
 

--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -47,7 +47,8 @@ func GetContainerInitPID(ctx context.Context, containerName string) (int, error)
 }
 
 // parseInitPIDFromIncusInfo extracts the container init PID from `incus info`
-// output. Exported for testing; production callers use GetContainerInitPID.
+// output. Kept as a separate function so it can be unit-tested without a live
+// Incus daemon; production callers use GetContainerInitPID.
 func parseInitPIDFromIncusInfo(output string) (int, error) {
 	for _, line := range strings.Split(output, "\n") {
 		trimmed := strings.TrimSpace(line)

--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -36,42 +36,45 @@ func GetCgroupPath(ctx context.Context, containerName string) (string, error) {
 	return findCgroupPathViaIncus(ctx, containerName)
 }
 
-// findCgroupPathViaIncus uses incus info to find the cgroup path
-func findCgroupPathViaIncus(ctx context.Context, containerName string) (string, error) {
-	// Get container info
+// GetContainerInitPID returns the host PID of the container's init process by
+// parsing `incus info` output.
+func GetContainerInitPID(ctx context.Context, containerName string) (int, error) {
 	output, err := container.IncusOutputContext(ctx, "info", containerName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container info: %w", err)
+		return 0, fmt.Errorf("failed to get container info: %w", err)
 	}
 
-	// Look for PID in the output (format: "PID: 12345")
-	var pid string
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		// Match both "PID:" and "Pid:" for compatibility
+	for _, line := range strings.Split(output, "\n") {
 		if strings.Contains(line, "PID:") || strings.Contains(line, "Pid:") {
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
-				pid = parts[1]
-				break
+				pid, err := strconv.Atoi(parts[1])
+				if err == nil && pid > 0 {
+					return pid, nil
+				}
 			}
 		}
 	}
 
-	if pid == "" {
-		return "", fmt.Errorf("could not find container PID")
+	return 0, fmt.Errorf("could not find container PID in incus info output")
+}
+
+// findCgroupPathViaIncus uses incus info to find the cgroup path
+func findCgroupPathViaIncus(ctx context.Context, containerName string) (string, error) {
+	pid, err := GetContainerInitPID(ctx, containerName)
+	if err != nil {
+		return "", err
 	}
 
 	// Read cgroup from /proc/<pid>/cgroup
-	cgroupFile := fmt.Sprintf("/proc/%s/cgroup", pid)
+	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", pid)
 	data, err := os.ReadFile(cgroupFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to read cgroup file: %w", err)
 	}
 
 	// Parse cgroup v2 format: 0::/path/to/cgroup
-	lines = strings.Split(string(data), "\n")
-	for _, line := range lines {
+	for _, line := range strings.Split(string(data), "\n") {
 		if strings.HasPrefix(line, "0::") {
 			cgroupPath := strings.TrimPrefix(line, "0::")
 			cgroupPath = strings.TrimSpace(cgroupPath)

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -44,7 +44,7 @@ func (c *Collector) Collect(ctx context.Context) (MonitorSnapshot, error) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		networkStats, err := CollectNetworkStats(ctx, c.containerIP, c.allowedCIDRs)
+		networkStats, err := CollectNetworkStats(ctx, c.containerName, c.containerIP, c.allowedCIDRs)
 		mu.Lock()
 		defer mu.Unlock()
 		if err != nil {

--- a/internal/monitor/network.go
+++ b/internal/monitor/network.go
@@ -41,7 +41,7 @@ func CollectNetworkStats(ctx context.Context, containerName, containerIP string,
 }
 
 // parseConnections reads the container's /proc/net/tcp[6] via the host-side
-// namespaced path /proc/<container-init-pid>/net/tcp[6].  Falls back to the
+// namespaced path /proc/<container-init-pid>/net/tcp[6]. Falls back to the
 // host's /proc/net/tcp + containerIP filter when PID resolution fails or when
 // the namespaced paths cannot be read.
 func parseConnections(ctx context.Context, containerName, containerIP string) ([]Connection, error) {

--- a/internal/monitor/network.go
+++ b/internal/monitor/network.go
@@ -11,9 +11,11 @@ import (
 )
 
 // CollectNetworkStats collects network statistics and flags suspicious connections.
-// It reads /proc/<container-init-pid>/net/tcp[6] from the host so the data is
-// scoped to the container's network namespace and cannot be tampered with from
-// inside the container.
+// It attempts to read /proc/<container-init-pid>/net/tcp[6] from the host so the
+// data is scoped to the container's network namespace. If PID resolution or the
+// namespaced reads fail, it falls back to host /proc/net/tcp[6] filtered by
+// containerIP (best-effort; requires a non-empty containerIP to avoid returning
+// all host connections).
 func CollectNetworkStats(ctx context.Context, containerName, containerIP string, allowedCIDRs []string) (NetworkStats, error) {
 	connections, err := parseConnections(ctx, containerName, containerIP)
 	if err != nil {
@@ -69,6 +71,11 @@ func parseConnections(ctx context.Context, containerName, containerIP string) ([
 	}
 
 	// Fallback: host /proc/net/tcp[6] filtered by containerIP.
+	// Require containerIP to avoid returning all host connections.
+	if containerIP == "" {
+		return nil, nil
+	}
+
 	var connections []Connection
 
 	tcp4Conns, err := parseProcNetTCP("/proc/net/tcp", "tcp")
@@ -81,17 +88,13 @@ func parseConnections(ctx context.Context, containerName, containerIP string) ([
 		connections = append(connections, tcp6Conns...)
 	}
 
-	if containerIP != "" {
-		filtered := make([]Connection, 0, len(connections))
-		for _, conn := range connections {
-			if strings.HasPrefix(conn.LocalAddr, containerIP+":") {
-				filtered = append(filtered, conn)
-			}
+	filtered := make([]Connection, 0, len(connections))
+	for _, conn := range connections {
+		if strings.HasPrefix(conn.LocalAddr, containerIP+":") {
+			filtered = append(filtered, conn)
 		}
-		connections = filtered
 	}
-
-	return connections, nil
+	return filtered, nil
 }
 
 // parseProcNetTCP parses /proc/net/tcp or /proc/net/tcp6

--- a/internal/monitor/network.go
+++ b/internal/monitor/network.go
@@ -39,33 +39,49 @@ func CollectNetworkStats(ctx context.Context, containerName, containerIP string,
 }
 
 // parseConnections reads the container's /proc/net/tcp[6] via the host-side
-// namespaced path /proc/<container-init-pid>/net/tcp[6].  If PID resolution
-// fails it falls back to the host's /proc/net/tcp filtered by containerIP.
+// namespaced path /proc/<container-init-pid>/net/tcp[6].  Falls back to the
+// host's /proc/net/tcp + containerIP filter when PID resolution fails or when
+// the namespaced paths cannot be read.
 func parseConnections(ctx context.Context, containerName, containerIP string) ([]Connection, error) {
-	tcp4Path := "/proc/net/tcp"
-	tcp6Path := "/proc/net/tcp6"
+	pid, _ := GetContainerInitPID(ctx, containerName)
 
-	pid, err := GetContainerInitPID(ctx, containerName)
-	if err == nil && pid > 0 {
-		tcp4Path = fmt.Sprintf("/proc/%d/net/tcp", pid)
-		tcp6Path = fmt.Sprintf("/proc/%d/net/tcp6", pid)
+	if pid > 0 {
+		// Prefer namespaced paths scoped to the container's network namespace.
+		var connections []Connection
+		namespacedOK := false
+
+		tcp4Conns, err := parseProcNetTCP(fmt.Sprintf("/proc/%d/net/tcp", pid), "tcp")
+		if err == nil {
+			connections = append(connections, tcp4Conns...)
+			namespacedOK = true
+		}
+
+		tcp6Conns, err := parseProcNetTCP(fmt.Sprintf("/proc/%d/net/tcp6", pid), "tcp6")
+		if err == nil {
+			connections = append(connections, tcp6Conns...)
+			namespacedOK = true
+		}
+
+		if namespacedOK {
+			return connections, nil
+		}
+		// Namespaced paths unreadable — fall through to host fallback below.
 	}
 
+	// Fallback: host /proc/net/tcp[6] filtered by containerIP.
 	var connections []Connection
 
-	tcp4Conns, err := parseProcNetTCP(tcp4Path, "tcp")
+	tcp4Conns, err := parseProcNetTCP("/proc/net/tcp", "tcp")
 	if err == nil {
 		connections = append(connections, tcp4Conns...)
 	}
 
-	tcp6Conns, err := parseProcNetTCP(tcp6Path, "tcp6")
+	tcp6Conns, err := parseProcNetTCP("/proc/net/tcp6", "tcp6")
 	if err == nil {
 		connections = append(connections, tcp6Conns...)
 	}
 
-	// When falling back to host /proc/net/tcp (no PID), filter by containerIP
-	// so we only return the container's connections.
-	if pid == 0 && containerIP != "" {
+	if containerIP != "" {
 		filtered := make([]Connection, 0, len(connections))
 		for _, conn := range connections {
 			if strings.HasPrefix(conn.LocalAddr, containerIP+":") {

--- a/internal/monitor/network.go
+++ b/internal/monitor/network.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 )
 
-// CollectNetworkStats collects network statistics and flags suspicious connections
-func CollectNetworkStats(ctx context.Context, containerIP string, allowedCIDRs []string) (NetworkStats, error) {
-	connections, err := parseConnections(containerIP)
+// CollectNetworkStats collects network statistics and flags suspicious connections.
+// It reads /proc/<container-init-pid>/net/tcp[6] from the host so the data is
+// scoped to the container's network namespace and cannot be tampered with from
+// inside the container.
+func CollectNetworkStats(ctx context.Context, containerName, containerIP string, allowedCIDRs []string) (NetworkStats, error) {
+	connections, err := parseConnections(ctx, containerName, containerIP)
 	if err != nil {
 		return NetworkStats{}, err
 	}
@@ -35,25 +38,35 @@ func CollectNetworkStats(ctx context.Context, containerIP string, allowedCIDRs [
 	}, nil
 }
 
-// parseConnections reads /proc/net/tcp and /proc/net/tcp6
-func parseConnections(containerIP string) ([]Connection, error) {
+// parseConnections reads the container's /proc/net/tcp[6] via the host-side
+// namespaced path /proc/<container-init-pid>/net/tcp[6].  If PID resolution
+// fails it falls back to the host's /proc/net/tcp filtered by containerIP.
+func parseConnections(ctx context.Context, containerName, containerIP string) ([]Connection, error) {
+	tcp4Path := "/proc/net/tcp"
+	tcp6Path := "/proc/net/tcp6"
+
+	pid, err := GetContainerInitPID(ctx, containerName)
+	if err == nil && pid > 0 {
+		tcp4Path = fmt.Sprintf("/proc/%d/net/tcp", pid)
+		tcp6Path = fmt.Sprintf("/proc/%d/net/tcp6", pid)
+	}
+
 	var connections []Connection
 
-	// Parse IPv4 connections
-	tcp4Conns, err := parseProcNetTCP("/proc/net/tcp", "tcp")
+	tcp4Conns, err := parseProcNetTCP(tcp4Path, "tcp")
 	if err == nil {
 		connections = append(connections, tcp4Conns...)
 	}
 
-	// Parse IPv6 connections
-	tcp6Conns, err := parseProcNetTCP("/proc/net/tcp6", "tcp6")
+	tcp6Conns, err := parseProcNetTCP(tcp6Path, "tcp6")
 	if err == nil {
 		connections = append(connections, tcp6Conns...)
 	}
 
-	// Filter to only connections from this container
-	if containerIP != "" {
-		filtered := make([]Connection, 0)
+	// When falling back to host /proc/net/tcp (no PID), filter by containerIP
+	// so we only return the container's connections.
+	if pid == 0 && containerIP != "" {
+		filtered := make([]Connection, 0, len(connections))
 		for _, conn := range connections {
 			if strings.HasPrefix(conn.LocalAddr, containerIP+":") {
 				filtered = append(filtered, conn)

--- a/internal/monitor/network.go
+++ b/internal/monitor/network.go
@@ -45,7 +45,10 @@ func CollectNetworkStats(ctx context.Context, containerName, containerIP string,
 // host's /proc/net/tcp + containerIP filter when PID resolution fails or when
 // the namespaced paths cannot be read.
 func parseConnections(ctx context.Context, containerName, containerIP string) ([]Connection, error) {
-	pid, _ := GetContainerInitPID(ctx, containerName)
+	pid, pidErr := GetContainerInitPID(ctx, containerName)
+	if pidErr != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	if pid > 0 {
 		// Prefer namespaced paths scoped to the container's network namespace.

--- a/internal/monitor/network_test.go
+++ b/internal/monitor/network_test.go
@@ -1,0 +1,95 @@
+package monitor
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// fakeIncusInfo simulates the output of `incus info <container>` for PID parsing tests.
+const fakeIncusInfoOutput = `Name: coi-test-1
+Status: Running
+Type: container
+Architecture: x86_64
+PID: 12345
+Created: 2024/01/01 00:00 UTC`
+
+const fakeIncusInfoOutputLowercase = `Name: coi-test-2
+Status: Running
+Pid: 99
+Created: 2024/01/01 00:00 UTC`
+
+const fakeIncusInfoNoPID = `Name: coi-test-3
+Status: Stopped
+Created: 2024/01/01 00:00 UTC`
+
+func TestParseContainerInitPID_FromIncusInfoOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantPID int
+		wantErr bool
+	}{
+		{"uppercase PID key", fakeIncusInfoOutput, 12345, false},
+		{"lowercase Pid key", fakeIncusInfoOutputLowercase, 99, false},
+		{"no PID in output", fakeIncusInfoNoPID, 0, true},
+		{"empty output", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pid, err := parseInitPIDFromIncusInfo(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wantErr=%v got err=%v", tt.wantErr, err)
+			}
+			if pid != tt.wantPID {
+				t.Errorf("want PID %d got %d", tt.wantPID, pid)
+			}
+		})
+	}
+}
+
+func TestParseContainerInitPID_StrictPrefix(t *testing.T) {
+	// A line containing "PID:" somewhere in the middle must NOT match.
+	tricky := "  Description: has a PID: 0 in the middle\nPID: 777\n"
+	pid, err := parseInitPIDFromIncusInfo(tricky)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 777 {
+		t.Errorf("want 777 got %d", pid)
+	}
+}
+
+func TestParseConnections_FallbackEmptyContainerIP(t *testing.T) {
+	// When PID resolution fails and containerIP is empty the fallback must
+	// return nil rather than all host connections.
+	ctx := context.Background()
+	// Use a container name that will never resolve via incus info.
+	conns, err := parseConnections(ctx, "nonexistent-container-xyz", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conns) != 0 {
+		t.Errorf("expected empty result when containerIP is empty, got %d connections", len(conns))
+	}
+}
+
+func TestParseProcNetTCP_ValidContent(t *testing.T) {
+	// Verify the parser handles well-formed /proc/net/tcp content.
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0F02000A:C4E0 08080808:0035 01 00000000:00000000 00:00000000 00000000  1000        0 23456 1 0000000000000000 20 4 24 10 -1`
+
+	r := strings.NewReader(content)
+	_ = r // parseProcNetTCP takes a file path, so we test via the exported parse indirectly
+	// Verify hex-to-IP conversion (Linux /proc/net/tcp uses little-endian byte order).
+	// 10.0.0.2 is stored as 0200000A (bytes reversed).
+	ip, err := parseHexIP("0200000A")
+	if err != nil {
+		t.Fatalf("parseHexIP error: %v", err)
+	}
+	if ip != "10.0.0.2" {
+		t.Errorf("want 10.0.0.2 got %s", ip)
+	}
+}

--- a/internal/monitor/network_test.go
+++ b/internal/monitor/network_test.go
@@ -64,8 +64,9 @@ func TestParseConnections_FallbackEmptyContainerIP(t *testing.T) {
 	// When PID resolution fails and containerIP is empty the fallback must
 	// return nil rather than all host connections.
 	ctx := context.Background()
-	// Use a container name that will never resolve via incus info.
-	conns, err := parseConnections(ctx, "nonexistent-container-xyz", "")
+	// Use a syntactically invalid container name so Incus always errors out,
+	// guaranteeing the fallback path is exercised regardless of the environment.
+	conns, err := parseConnections(ctx, "INVALID/CONTAINER/NAME", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/monitor/network_test.go
+++ b/internal/monitor/network_test.go
@@ -2,7 +2,6 @@ package monitor
 
 import (
 	"context"
-	"strings"
 	"testing"
 )
 
@@ -75,16 +74,9 @@ func TestParseConnections_FallbackEmptyContainerIP(t *testing.T) {
 	}
 }
 
-func TestParseProcNetTCP_ValidContent(t *testing.T) {
-	// Verify the parser handles well-formed /proc/net/tcp content.
-	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
-   0: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
-   1: 0F02000A:C4E0 08080808:0035 01 00000000:00000000 00:00000000 00000000  1000        0 23456 1 0000000000000000 20 4 24 10 -1`
-
-	r := strings.NewReader(content)
-	_ = r // parseProcNetTCP takes a file path, so we test via the exported parse indirectly
-	// Verify hex-to-IP conversion (Linux /proc/net/tcp uses little-endian byte order).
-	// 10.0.0.2 is stored as 0200000A (bytes reversed).
+func TestParseHexIP_LittleEndian(t *testing.T) {
+	// Linux /proc/net/tcp stores IPs in little-endian byte order.
+	// 10.0.0.2 is encoded as 0200000A (bytes reversed).
 	ip, err := parseHexIP("0200000A")
 	if err != nil {
 		t.Fatalf("parseHexIP error: %v", err)


### PR DESCRIPTION
## Summary

- The collector was reading `/proc/net/tcp` from the **host** and filtering by container IP. This missed container-internal connections (127.0.0.1, socket pairs between processes inside the container) and scanned all host connections on every poll.
- Adds `GetContainerInitPID` (extracted from existing `findCgroupPathViaIncus` logic in `cgroup.go`) to resolve the container's init PID on the host.
- `parseConnections` now reads `/proc/<init-pid>/net/tcp[6]`, which the kernel scopes to the container's network namespace. An attacker inside the container cannot tamper with these host-side proc files.
- Falls back gracefully to the previous `/proc/net/tcp` + IP-filter path if PID resolution fails.

Part of #371.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/monitor/... -short` passes
- [ ] `coi monitor <container>` still lists active connections
- [ ] Container-internal connections (127.0.0.1) now visible in output