### PR TITLE
fix(monitor): guard statfs against zero Bsize and free>total underflow

### DIFF
--- a/internal/monitor/filesystem.go
+++ b/internal/monitor/filesystem.go
@@ -179,9 +179,17 @@ func collectDiskSpaceViaStatfs(ctx context.Context, containerName string) (tmpUs
 		return 0, 0, 0, err
 	}
 
-	bsize := uint64(stat.Bsize) //nolint:gosec // Bsize is always positive
+	if stat.Bsize <= 0 {
+		return 0, 0, 0, fmt.Errorf("statfs returned unexpected Bsize %d", stat.Bsize)
+	}
+	bsize := uint64(stat.Bsize) //nolint:gosec // checked positive above
 	totalBytes := stat.Blocks * bsize
 	freeBytes := stat.Bfree * bsize
+	if freeBytes > totalBytes {
+		// Should not happen on a well-formed filesystem, but guard against
+		// uint underflow producing a wildly incorrect used-space value.
+		return 0, 0, 0, fmt.Errorf("statfs: freeBytes (%d) > totalBytes (%d)", freeBytes, totalBytes)
+	}
 	usedBytes := totalBytes - freeBytes
 
 	total := float64(totalBytes) / 1024 / 1024


### PR DESCRIPTION
Addresses Copilot review comment on #433.

## Problem

In `collectDiskSpaceViaStatfs`, `stat.Bsize` was cast to `uint64` with a linter suppression comment claiming it is "always positive" — but `Bsize` is an `int64` that could theoretically be zero. If zero, the conversion is harmless but the suppression comment is misleading.

More critically, `usedBytes := totalBytes - freeBytes` is unsigned subtraction. If `freeBytes > totalBytes` for any reason, this silently wraps to a huge value, producing wildly incorrect `/tmp` metrics and a potential false positive on the disk-space threat check.

## Fix

- Validate `stat.Bsize > 0` before conversion; return an error on failure so the `incus exec df` fallback fires.
- Guard `freeBytes > totalBytes` and return an error rather than underflowing.

## Test plan

- [ ] `go test ./internal/monitor/... -short` passes
- [ ] Build passes