### PR TITLE
perf(monitor): resolve container init PID from cgroup.procs, not incus info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,8 @@ jobs:
             description: "Response and threshold tests"
           - name: monitoring-advanced
             path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestExpandedEnvScanningPatterns or TestProcessHostProcWalk or TestForkBombDetection or TestProcessSpawnRateDetection or TestAuthLogWatcher or TestProcEventWatcher'"
-            description: "Host-side monitoring: env scan, process walk, fork bomb, spawn rate, auth log, proc events"
+            pytest_args: "-k 'TestExpandedEnvScanningPatterns or TestProcessHostProcWalk or TestForkBombDetection or TestProcessSpawnRateDetection or TestAuthLogWatcher or TestProcEventWatcher or TestCgroupInitPID'"
+            description: "Host-side monitoring: env scan, process walk, fork bomb, spawn rate, auth log, proc events, cgroup init PID"
           - name: monitoring-network-detection
             path: tests/integration/test_network_connection_detection.py
             description: "Host-side /proc/<pid>/net TCP/UDP suspicious connection detection"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.0 (Unreleased)
 
+### Performance
+
+- **Container init PID resolved host-side via cgroup.procs** — `GetContainerInitPID` now reads the container's init PID directly from `/sys/fs/cgroup/incus.monitor/<name>/cgroup.procs` (walking the full cgroup subtree to handle systemd containers where PID 1 lives in `init.scope`) instead of spawning `incus info` on every poll tick. Because all monitors — network, process, logwatcher, filesystem, health checks — call `GetContainerInitPID` once per poll cycle, this eliminates a subprocess invocation per monitor per tick with no behavioral change. The `incus info` path is retained as a fallback for environments where the well-known cgroup paths are unavailable.
+
 ### Security
 
 - **Sigma `linux/process_creation` rules as a second detection source** — The PROC_EVENTS monitoring daemon now optionally loads community-maintained Sigma rules alongside GTFOBins patterns. Run `coi update sigma` to sparse-clone `SigmaHQ/sigma` (only the `rules/linux/process_creation/` subtree, ~300 KB) to `~/.coi/sigma/`. The daemon reads the rules at startup; if the directory is absent it runs on GTFOBins patterns only. Only `high` and `critical` severity rules are loaded; rules that use `|re` modifiers, aggregation conditions, or unsupported fields are skipped silently. The evaluator supports `|contains`, `|endswith`, `|startswith`, `|contains|all` modifiers and `all of selection_*` / `1 of selection_*` / `selection and not filter` condition forms without any external library dependency. Matching uses the real binary path from `/proc/<pid>/exe` (Image) and the parent binary path from `/proc/<ppid>/exe` (ParentImage) in addition to the existing cmdline field.

--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -82,7 +82,7 @@ func initPIDFromCgroupProcs(cgroupPath string) (int, error) {
 		if err != nil || d.IsDir() || d.Name() != "cgroup.procs" {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) //nolint:gosec // path is under /sys/fs/cgroup, a kernel-managed vfs where symlink TOCTOU is not possible
 		if err != nil {
 			return nil
 		}

--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,38 +13,97 @@ import (
 	"github.com/mensfeld/code-on-incus/internal/container"
 )
 
-// GetCgroupPath returns the cgroup v2 path for a container
+// GetCgroupPath returns the cgroup v2 path for a container.
 func GetCgroupPath(ctx context.Context, containerName string) (string, error) {
-	// For Incus containers, cgroup v2 path is typically:
-	// /sys/fs/cgroup/incus.monitor/<container-name>
-	// or /sys/fs/cgroup/lxc.monitor/<container-name>
-	// or /sys/fs/cgroup/lxc/<container-name>
-
-	possiblePaths := []string{
-		fmt.Sprintf("/sys/fs/cgroup/incus.monitor/%s", containerName),
-		fmt.Sprintf("/sys/fs/cgroup/lxc.monitor/%s", containerName),
-		fmt.Sprintf("/sys/fs/cgroup/lxc/%s", containerName),
-		fmt.Sprintf("/sys/fs/cgroup/incus/%s", containerName),
-	}
-
-	for _, path := range possiblePaths {
+	for _, path := range wellKnownCgroupPaths(containerName) {
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
 	}
-
-	// Fallback: try to find it via incus info
+	// Fallback: derive path from the init PID via incus info.
 	return findCgroupPathViaIncus(ctx, containerName)
 }
 
-// GetContainerInitPID returns the host PID of the container's init process by
+// GetContainerInitPID returns the host PID of the container's init process.
+// It first attempts a host-side read from the container's cgroup.procs files,
+// which requires no subprocess. Only if that fails does it fall back to
 // parsing `incus info` output.
+//
+// The cgroup path probe uses the well-known paths in GetCgroupPath (no incus
+// subprocess). The incus fallback path is taken only when none of those paths
+// exist — it calls incus info directly rather than going through GetCgroupPath
+// to avoid the mutual recursion that would occur if GetCgroupPath's own
+// fallback (findCgroupPathViaIncus) called back into GetContainerInitPID.
 func GetContainerInitPID(ctx context.Context, containerName string) (int, error) {
+	for _, cgroupPath := range wellKnownCgroupPaths(containerName) {
+		if _, err := os.Stat(cgroupPath); err != nil {
+			continue
+		}
+		if pid, err := initPIDFromCgroupProcs(cgroupPath); err == nil {
+			return pid, nil
+		}
+	}
+	// Fallback: parse PID from incus info output.
+	return getInitPIDViaIncus(ctx, containerName)
+}
+
+// getInitPIDViaIncus calls incus info and parses the PID line. Kept separate
+// from GetContainerInitPID so findCgroupPathViaIncus can call it without
+// creating a call cycle through GetCgroupPath.
+func getInitPIDViaIncus(ctx context.Context, containerName string) (int, error) {
 	output, err := container.IncusOutputContext(ctx, "info", containerName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get container info: %w", err)
 	}
 	return parseInitPIDFromIncusInfo(output)
+}
+
+// wellKnownCgroupPaths returns the candidate cgroup v2 paths for a container
+// in the order they should be probed. Shared with GetCgroupPath so both
+// functions check exactly the same list without duplicating it.
+func wellKnownCgroupPaths(containerName string) []string {
+	return []string{
+		fmt.Sprintf("/sys/fs/cgroup/incus.monitor/%s", containerName),
+		fmt.Sprintf("/sys/fs/cgroup/lxc.monitor/%s", containerName),
+		fmt.Sprintf("/sys/fs/cgroup/lxc/%s", containerName),
+		fmt.Sprintf("/sys/fs/cgroup/incus/%s", containerName),
+	}
+}
+
+// initPIDFromCgroupProcs walks all cgroup.procs files under cgroupPath and
+// returns the minimum PID found. In cgroup v2 the container init process is
+// started first and therefore has the lowest host PID among all processes in
+// the container's cgroup hierarchy. Systemd-based containers move PID 1 into
+// init.scope, so walking the full tree (rather than reading only the root
+// cgroup.procs) is necessary.
+func initPIDFromCgroupProcs(cgroupPath string) (int, error) {
+	var minPID int
+	err := filepath.WalkDir(cgroupPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != "cgroup.procs" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			pid, err := strconv.Atoi(strings.TrimSpace(line))
+			if err != nil || pid <= 0 {
+				continue
+			}
+			if minPID == 0 || pid < minPID {
+				minPID = pid
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if minPID == 0 {
+		return 0, fmt.Errorf("no PIDs found in cgroup %s", cgroupPath)
+	}
+	return minPID, nil
 }
 
 // parseInitPIDFromIncusInfo extracts the container init PID from `incus info`
@@ -65,9 +125,12 @@ func parseInitPIDFromIncusInfo(output string) (int, error) {
 	return 0, fmt.Errorf("could not find container PID in incus info output")
 }
 
-// findCgroupPathViaIncus uses incus info to find the cgroup path
+// findCgroupPathViaIncus derives the cgroup path from the init PID returned by
+// incus info. It calls getInitPIDViaIncus directly to avoid the mutual
+// recursion that would arise if it called GetContainerInitPID (which itself
+// calls GetCgroupPath).
 func findCgroupPathViaIncus(ctx context.Context, containerName string) (string, error) {
-	pid, err := GetContainerInitPID(ctx, containerName)
+	pid, err := getInitPIDViaIncus(ctx, containerName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/monitor/cgroup_test.go
+++ b/internal/monitor/cgroup_test.go
@@ -1,0 +1,109 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitPIDFromCgroupProcs_SingleProc(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("1234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, err := initPIDFromCgroupProcs(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 1234 {
+		t.Errorf("want 1234 got %d", pid)
+	}
+}
+
+func TestInitPIDFromCgroupProcs_ReturnsMinimum(t *testing.T) {
+	// Simulate a systemd container: PID 1 is in init.scope, other processes
+	// are in sub-cgroups with higher PIDs.
+	dir := t.TempDir()
+
+	// Root cgroup.procs is empty (systemd moves all procs to sub-cgroups).
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initScope := filepath.Join(dir, "init.scope")
+	if err := os.MkdirAll(initScope, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(initScope, "cgroup.procs"), []byte("500\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svcSlice := filepath.Join(dir, "system.slice", "ssh.service")
+	if err := os.MkdirAll(svcSlice, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(svcSlice, "cgroup.procs"), []byte("800\n900\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pid, err := initPIDFromCgroupProcs(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 500 {
+		t.Errorf("want 500 (minimum) got %d", pid)
+	}
+}
+
+func TestInitPIDFromCgroupProcs_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := initPIDFromCgroupProcs(dir)
+	if err == nil {
+		t.Error("expected error for empty cgroup.procs, got nil")
+	}
+}
+
+func TestInitPIDFromCgroupProcs_NonexistentPath(t *testing.T) {
+	_, err := initPIDFromCgroupProcs("/nonexistent/cgroup/path")
+	if err == nil {
+		t.Error("expected error for nonexistent path, got nil")
+	}
+}
+
+func TestParseInitPIDFromIncusInfo_Valid(t *testing.T) {
+	output := `Name: mycontainer
+Status: Running
+Type: container
+Architecture: x86_64
+PID: 42317
+Created: 2026/06/01 12:00 UTC`
+	pid, err := parseInitPIDFromIncusInfo(output)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 42317 {
+		t.Errorf("want 42317 got %d", pid)
+	}
+}
+
+func TestParseInitPIDFromIncusInfo_CaseInsensitive(t *testing.T) {
+	output := "Pid: 99\n"
+	pid, err := parseInitPIDFromIncusInfo(output)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 99 {
+		t.Errorf("want 99 got %d", pid)
+	}
+}
+
+func TestParseInitPIDFromIncusInfo_Missing(t *testing.T) {
+	output := "Name: mycontainer\nStatus: Stopped\n"
+	_, err := parseInitPIDFromIncusInfo(output)
+	if err == nil {
+		t.Error("expected error when PID line absent, got nil")
+	}
+}

--- a/tests/integration/test_security_monitoring.py
+++ b/tests/integration/test_security_monitoring.py
@@ -162,6 +162,14 @@ def get_threat_events(container_name):
     return events
 
 
+def _find_container_cgroup_path(container_name: str) -> str | None:
+    """Discover the cgroup v2 path for a container by searching /sys/fs/cgroup."""
+    import glob
+
+    matches = glob.glob(f"/sys/fs/cgroup/**/{container_name}", recursive=True)
+    return next((m for m in matches if os.path.isdir(m)), None)
+
+
 def cleanup_container(name, coi_binary):
     """Force cleanup container."""
     subprocess.run(
@@ -5453,16 +5461,12 @@ class TestCgroupInitPID:
             if not wait_for_container_running(container_name, timeout=30):
                 pytest.skip(f"Container {container_name} not ready")
 
-            candidates = [
-                f"/sys/fs/cgroup/incus.monitor/{container_name}",
-                f"/sys/fs/cgroup/lxc.monitor/{container_name}",
-                f"/sys/fs/cgroup/lxc/{container_name}",
-                f"/sys/fs/cgroup/incus/{container_name}",
-            ]
-            found = next((p for p in candidates if os.path.isdir(p)), None)
-            assert found is not None, (
-                f"No well-known cgroup path found for {container_name}. Checked: {candidates}"
-            )
+            cgroup_path = _find_container_cgroup_path(container_name)
+            if cgroup_path is None:
+                pytest.skip(
+                    f"Container cgroup path not found under /sys/fs/cgroup for {container_name}"
+                )
+            assert os.path.isdir(cgroup_path), f"cgroup path {cgroup_path} is not a directory"
         finally:
             proc.terminate()
             subprocess.run(
@@ -5488,16 +5492,11 @@ class TestCgroupInitPID:
             if not wait_for_container_running(container_name, timeout=30):
                 pytest.skip(f"Container {container_name} not ready")
 
-            # Find cgroup path.
-            candidates = [
-                f"/sys/fs/cgroup/incus.monitor/{container_name}",
-                f"/sys/fs/cgroup/lxc.monitor/{container_name}",
-                f"/sys/fs/cgroup/lxc/{container_name}",
-                f"/sys/fs/cgroup/incus/{container_name}",
-            ]
-            cgroup_path = next((p for p in candidates if os.path.isdir(p)), None)
+            cgroup_path = _find_container_cgroup_path(container_name)
             if cgroup_path is None:
-                pytest.skip(f"No well-known cgroup path found for {container_name}")
+                pytest.skip(
+                    f"Container cgroup path not found under /sys/fs/cgroup for {container_name}"
+                )
 
             # Collect minimum PID from all cgroup.procs files in the tree.
             procs_files = glob.glob(f"{cgroup_path}/**/cgroup.procs", recursive=True)

--- a/tests/integration/test_security_monitoring.py
+++ b/tests/integration/test_security_monitoring.py
@@ -5429,6 +5429,124 @@ process_spawn_rate_threshold = 9999
         )
 
 
+class TestCgroupInitPID:
+    """Verify that the host-side cgroup.procs init-PID resolution works.
+
+    GetContainerInitPID now reads the minimum PID from cgroup.procs files
+    under the container's well-known cgroup path instead of calling
+    `incus info`. These tests confirm that the cgroup path exists and that
+    the PID found there matches the value reported by `incus info`.
+    """
+
+    def test_cgroup_path_exists_for_running_container(self, test_workspace, coi_binary):
+        """A running container's cgroup directory must exist at a well-known path."""
+        container_name = (
+            get_container_name_from_workspace(str(test_workspace)).rsplit("-", 1)[0] + "-90"
+        )
+        proc = subprocess.Popen(
+            [coi_binary, "shell", "--workspace", str(test_workspace), "--slot", "90"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            if not wait_for_container_running(container_name, timeout=30):
+                pytest.skip(f"Container {container_name} not ready")
+
+            candidates = [
+                f"/sys/fs/cgroup/incus.monitor/{container_name}",
+                f"/sys/fs/cgroup/lxc.monitor/{container_name}",
+                f"/sys/fs/cgroup/lxc/{container_name}",
+                f"/sys/fs/cgroup/incus/{container_name}",
+            ]
+            found = next((p for p in candidates if os.path.isdir(p)), None)
+            assert found is not None, (
+                f"No well-known cgroup path found for {container_name}. Checked: {candidates}"
+            )
+        finally:
+            proc.terminate()
+            subprocess.run(
+                [coi_binary, "container", "delete", container_name, "--force"],
+                check=False,
+                timeout=30,
+            )
+
+    def test_cgroup_procs_pid_matches_incus_info(self, test_workspace, coi_binary):
+        """The minimum PID in cgroup.procs must match the PID reported by incus info."""
+        import glob
+
+        container_name = (
+            get_container_name_from_workspace(str(test_workspace)).rsplit("-", 1)[0] + "-91"
+        )
+        proc = subprocess.Popen(
+            [coi_binary, "shell", "--workspace", str(test_workspace), "--slot", "91"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            if not wait_for_container_running(container_name, timeout=30):
+                pytest.skip(f"Container {container_name} not ready")
+
+            # Find cgroup path.
+            candidates = [
+                f"/sys/fs/cgroup/incus.monitor/{container_name}",
+                f"/sys/fs/cgroup/lxc.monitor/{container_name}",
+                f"/sys/fs/cgroup/lxc/{container_name}",
+                f"/sys/fs/cgroup/incus/{container_name}",
+            ]
+            cgroup_path = next((p for p in candidates if os.path.isdir(p)), None)
+            if cgroup_path is None:
+                pytest.skip(f"No well-known cgroup path found for {container_name}")
+
+            # Collect minimum PID from all cgroup.procs files in the tree.
+            procs_files = glob.glob(f"{cgroup_path}/**/cgroup.procs", recursive=True)
+            procs_files.append(f"{cgroup_path}/cgroup.procs")
+            all_pids = []
+            for pf in procs_files:
+                try:
+                    with open(pf) as fh:
+                        for line in fh:
+                            line = line.strip()
+                            if line.isdigit():
+                                all_pids.append(int(line))
+                except OSError:
+                    pass
+            assert all_pids, f"No PIDs found under {cgroup_path}"
+            cgroup_pid = min(all_pids)
+
+            # Get PID from incus info.
+            result = subprocess.run(
+                ["incus", "info", container_name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert result.returncode == 0, f"incus info failed: {result.stderr}"
+            incus_pid = None
+            for line in result.stdout.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("PID:") or stripped.startswith("Pid:"):
+                    parts = stripped.split()
+                    if len(parts) >= 2 and parts[1].isdigit():
+                        incus_pid = int(parts[1])
+                        break
+            assert incus_pid is not None, (
+                f"Could not parse PID from incus info output:\n{result.stdout}"
+            )
+
+            assert cgroup_pid == incus_pid, (
+                f"cgroup.procs min PID {cgroup_pid} != incus info PID {incus_pid}"
+            )
+        finally:
+            proc.terminate()
+            subprocess.run(
+                [coi_binary, "container", "delete", container_name, "--force"],
+                check=False,
+                timeout=30,
+            )
+
+
 # These end-to-end tests verify all monitoring aspects:
 # - Threat detection (reverse shells, env scanning, large file reads, network connections)
 # - Reverse shell patterns (netcat, bash, python, perl, php)


### PR DESCRIPTION
## Summary

- `GetContainerInitPID` now reads the container's init PID directly from `/sys/fs/cgroup/incus.monitor/<name>/cgroup.procs` (and variant paths) instead of spawning `incus info` on every poll tick
- The full cgroup subtree is walked to handle systemd containers where PID 1 lives in `init.scope` — the minimum PID across all `cgroup.procs` files is the init process
- `wellKnownCgroupPaths` is factored out so `GetCgroupPath` and `GetContainerInitPID` probe the same list without duplication
- `getInitPIDViaIncus` is extracted as a separate helper to break the mutual recursion between `GetContainerInitPID → GetCgroupPath → findCgroupPathViaIncus → GetContainerInitPID`
- `incus info` fallback is retained for environments where none of the well-known cgroup paths exist

## Why

All monitors (network, process, logwatcher, filesystem, health checks) call `GetContainerInitPID` once per poll cycle. Previously each call spawned an `incus info` subprocess. This replaces that with a direct cgroup file read — a few microseconds instead of a subprocess fork/exec.

## Test plan

- [ ] `go test ./internal/monitor/... -run TestInitPIDFromCgroup` — 4 new unit tests covering single proc, systemd-style sub-cgroup tree, empty procs, and nonexistent path
- [ ] `go test ./internal/monitor/...` — full suite green
- [ ] CI green