### PR TITLE
feat(build): add --all flag to build images for all configured profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Improvements
 
+- [Feature] **`coi build --all`** — Builds images for every profile that has a `[container.build]` section in a single command. The `coi-default` base image (the built-in "default" profile) is always built first so it is available as the base for custom profiles. Profiles without a build configuration are silently skipped. Errors from individual profiles are collected and reported together at the end so that a single failing profile does not prevent other profiles from building. Supports all existing flags: `--force` to rebuild images that already exist, and `--compression` to select the Incus compression algorithm. Resolves #455.
+
 - [Refactor] **Completed nft naming cleanup in `network.Manager`** — The `firewall` private field on `Manager` was missed when `FirewallManager` → `NftManager` was renamed in an earlier refactor. Renamed to `nft` throughout `internal/network/manager.go`; updated matching log messages and comments to use "nft rules" consistently. No behaviour change.
 
 - [Refactor] **Removed dead audit command stub** — `internal/cli/monitor.go` contained a commented-out `monitorAuditCmd` registration and an unused `monitorAuditCommand` function annotated `//nolint:unused`. Both were removed to eliminate dead code. (#428)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Improvements
 
+- [Feature] **Stale base image detection** — `coi shell` and `coi run` now check whether the custom image in use was built before its base image was last rebuilt (e.g. `coi-default` was updated but the project image was not). Behaviour is controlled by `stale_base_check` in the `[container]` section of `config.toml` (or per-profile): `"warn"` (default) prints a warning and continues; `"error"` aborts with an actionable message; `"off"` disables the check entirely. Build timestamps are recorded in `~/.coi/image-meta.json` after every successful `coi build`. Missing metadata (first-time users or images built outside of `coi`) is always silent. Resolves #456.
+
 - [Feature] **`coi build --all`** — Builds images for every profile that has a `[container.build]` section in a single command. The `coi-default` base image (the built-in "default" profile) is always built first so it is available as the base for custom profiles. Profiles without a build configuration are silently skipped. Errors from individual profiles are collected and reported together at the end so that a single failing profile does not prevent other profiles from building. Supports all existing flags: `--force` to rebuild images that already exist, and `--compression` to select the Incus compression algorithm. Resolves #455.
 
 - [Refactor] **Completed nft naming cleanup in `network.Manager`** — The `firewall` private field on `Manager` was missed when `FirewallManager` → `NftManager` was renamed in an earlier refactor. Renamed to `nft` throughout `internal/network/manager.go`; updated matching log messages and comments to use "nft rules" consistently. No behaviour change.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ coi build --compression none
 coi profile create my-image --image my-image
 # Edit .coi/profiles/my-image/config.toml to add a [container.build] section
 coi build --profile my-image
+
+# Build images for all profiles that have a [container.build] section
+coi build --all
+
+# Rebuild all profile images from scratch
+coi build --all --force
 ```
 
 **What's included in the `coi-default` image:**

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -26,6 +26,11 @@ By default, builds the "coi-default" image using the built-in default profile.
 Use --profile to build from a custom profile's [container.build] section.
 Use --all to build images for all profiles that have a build configuration.
 
+Profile discovery for --all: global profiles (~/.coi/profiles/) are always
+included. Project-local profiles (.coi/profiles/ in the current directory) are
+only loaded when you run coi from inside that project directory. Run coi build
+--all from your project directory to include its profiles.
+
 Examples:
   coi build
   coi build --force
@@ -40,7 +45,7 @@ Examples:
 func init() {
 	buildCmd.Flags().BoolVarP(&buildForce, "force", "f", false, "Force rebuild even if image exists")
 	buildCmd.Flags().StringVar(&buildCompression, "compression", "", "Compression algorithm (e.g., none, gzip, xz; see Incus docs for all options)")
-	buildCmd.Flags().BoolVar(&buildAll, "all", false, "Build images for all profiles that have a build configuration")
+	buildCmd.Flags().BoolVar(&buildAll, "all", false, "Build images for all profiles visible from the current directory (global ~/.coi/profiles + project .coi/profiles)")
 }
 
 func buildCommand(cmd *cobra.Command, args []string) error {

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -134,6 +134,9 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", opts.AliasName)
 		fmt.Fprintf(os.Stderr, "  Version: %s\n", result.VersionAlias)
 		fmt.Fprintf(os.Stderr, "  Fingerprint: %s\n", result.Fingerprint)
+		if dir, err := coiDataDir(); err == nil {
+			image.RecordBuild(dir, opts.AliasName, coiBaseImage)
+		}
 		return nil
 	}
 
@@ -184,6 +187,9 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
 	fmt.Fprintf(os.Stderr, "  Fingerprint: %s\n", result.Fingerprint)
+	if dir, err := coiDataDir(); err == nil {
+		image.RecordBuild(dir, imageName, baseImage)
+	}
 	return nil
 }
 
@@ -260,6 +266,9 @@ func buildAllProfiles() error {
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "[%s] Image '%s' built successfully.\n", profileName, imageName)
+			if dir, err := coiDataDir(); err == nil {
+				image.RecordBuild(dir, imageName, coiBaseImage)
+			}
 			built++
 		} else {
 			scriptPath, cleanup, err := resolveBuildScript(&p.Container.Build)
@@ -298,6 +307,9 @@ func buildAllProfiles() error {
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "[%s] Image '%s' built successfully.\n", profileName, imageName)
+			if dir, err := coiDataDir(); err == nil {
+				image.RecordBuild(dir, imageName, baseImage)
+			}
 			built++
 		}
 	}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/image"
@@ -13,6 +15,8 @@ var buildForce bool
 
 var buildCompression string
 
+var buildAll bool
+
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build Incus image for AI coding sessions",
@@ -20,11 +24,14 @@ var buildCmd = &cobra.Command{
 
 By default, builds the "coi-default" image using the built-in default profile.
 Use --profile to build from a custom profile's [container.build] section.
+Use --all to build images for all profiles that have a build configuration.
 
 Examples:
   coi build
   coi build --force
   coi build --profile rust-dev
+  coi build --all
+  coi build --all --force
 `,
 	Args: cobra.NoArgs,
 	RunE: buildCommand,
@@ -33,6 +40,7 @@ Examples:
 func init() {
 	buildCmd.Flags().BoolVarP(&buildForce, "force", "f", false, "Force rebuild even if image exists")
 	buildCmd.Flags().StringVar(&buildCompression, "compression", "", "Compression algorithm (e.g., none, gzip, xz; see Incus docs for all options)")
+	buildCmd.Flags().BoolVar(&buildAll, "all", false, "Build images for all profiles that have a build configuration")
 }
 
 func buildCommand(cmd *cobra.Command, args []string) error {
@@ -49,6 +57,10 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	// Warn if kernel is too old (non-blocking)
 	if warning := container.CheckKernelVersion(); warning != "" {
 		fmt.Fprintf(os.Stderr, "%s\n", warning)
+	}
+
+	if buildAll {
+		return buildAllProfiles()
 	}
 
 	// Determine which profile to use
@@ -167,5 +179,130 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
 	fmt.Fprintf(os.Stderr, "  Fingerprint: %s\n", result.Fingerprint)
+	return nil
+}
+
+// buildAllProfiles builds images for all profiles that have a build configuration.
+// The "default" profile (coi-default) is always built first; other profiles are
+// processed in alphabetical order. Profiles without a [container.build] section
+// are silently skipped. Errors are collected and reported together at the end.
+func buildAllProfiles() error {
+	// Collect profile names: "default" first, then the rest alphabetically.
+	others := make([]string, 0, len(app.cfg.Profiles))
+	for name := range app.cfg.Profiles {
+		if name != "default" {
+			others = append(others, name)
+		}
+	}
+	sort.Strings(others)
+	names := append([]string{"default"}, others...)
+
+	var built, skipped, errored int
+	var buildErrors []string
+
+	for _, profileName := range names {
+		p := app.cfg.GetProfile(profileName)
+		if p == nil {
+			continue
+		}
+
+		imageName := p.Container.Image
+		if imageName == "" {
+			imageName = image.CoiAlias
+		}
+
+		// Skip profiles that neither map to coi-default nor define a build config.
+		if imageName != image.CoiAlias && !p.Container.Build.HasBuildConfig() {
+			continue
+		}
+
+		buildPool := app.cfg.Container.StoragePool
+		if p.Container.StoragePool != "" {
+			buildPool = p.Container.StoragePool
+		}
+		if err := container.ValidateStoragePool(buildPool); err != nil {
+			buildErrors = append(buildErrors, fmt.Sprintf("  profile '%s': %v", profileName, err))
+			errored++
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "\n[%s] Building image '%s'...\n", profileName, imageName)
+
+		if imageName == image.CoiAlias {
+			coiBaseImage := image.BaseImage
+			if p.Container.Build.Base != "" {
+				coiBaseImage = p.Container.Build.Base
+			}
+			opts := image.BuildOptions{
+				Force:       buildForce,
+				ImageType:   "coi",
+				BaseImage:   coiBaseImage,
+				AliasName:   image.CoiAlias,
+				Description: "coi image (Docker + build tools + Claude CLI + GitHub CLI)",
+				Compression: buildCompression,
+				StoragePool: buildPool,
+				Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
+			}
+			result := image.NewBuilder(opts).Build()
+			if result.Error != nil {
+				buildErrors = append(buildErrors, fmt.Sprintf("  profile '%s': %v", profileName, result.Error))
+				errored++
+				continue
+			}
+			if result.Skipped {
+				fmt.Fprintf(os.Stderr, "[%s] Image '%s' already exists (use --force to rebuild).\n", profileName, imageName)
+				skipped++
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "[%s] Image '%s' built successfully.\n", profileName, imageName)
+			built++
+		} else {
+			scriptPath, cleanup, err := resolveBuildScript(&p.Container.Build)
+			if err != nil {
+				buildErrors = append(buildErrors, fmt.Sprintf("  profile '%s': %v", profileName, err))
+				errored++
+				continue
+			}
+			defer cleanup()
+
+			baseImage := p.Container.Build.Base
+			if baseImage == "" {
+				baseImage = image.CoiAlias
+			}
+			opts := image.BuildOptions{
+				ImageType:   "custom",
+				AliasName:   imageName,
+				Description: fmt.Sprintf("Custom image (%s)", imageName),
+				BaseImage:   baseImage,
+				BuildScript: scriptPath,
+				Force:       buildForce,
+				Compression: buildCompression,
+				StoragePool: buildPool,
+				Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
+			}
+			result := image.NewBuilder(opts).Build()
+			if result.Error != nil {
+				buildErrors = append(buildErrors, fmt.Sprintf("  profile '%s': %v", profileName, result.Error))
+				errored++
+				continue
+			}
+			if result.Skipped {
+				fmt.Fprintf(os.Stderr, "[%s] Image '%s' already exists (use --force to rebuild).\n", profileName, imageName)
+				skipped++
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "[%s] Image '%s' built successfully.\n", profileName, imageName)
+			built++
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\n--- Build summary ---\n")
+	fmt.Fprintf(os.Stderr, "  Built:   %d\n", built)
+	fmt.Fprintf(os.Stderr, "  Skipped: %d\n", skipped)
+	fmt.Fprintf(os.Stderr, "  Failed:  %d\n", errored)
+
+	if len(buildErrors) > 0 {
+		return fmt.Errorf("%d build(s) failed:\n%s", errored, strings.Join(buildErrors, "\n"))
+	}
 	return nil
 }

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -263,7 +263,6 @@ func buildAllProfiles() error {
 				errored++
 				continue
 			}
-			defer cleanup()
 
 			baseImage := p.Container.Build.Base
 			if baseImage == "" {
@@ -281,6 +280,8 @@ func buildAllProfiles() error {
 				Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
 			}
 			result := image.NewBuilder(opts).Build()
+			cleanup()
+
 			if result.Error != nil {
 				buildErrors = append(buildErrors, fmt.Sprintf("  profile '%s': %v", profileName, result.Error))
 				errored++

--- a/internal/cli/build_helpers.go
+++ b/internal/cli/build_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -160,6 +161,9 @@ func runInlineBuild(cfg *config.Config, imageName string) error {
 			return nil
 		}
 		fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
+		if dir, err := coiDataDir(); err == nil {
+			image.RecordBuild(dir, imageName, coiBaseImage)
+		}
 		return nil
 	}
 
@@ -200,5 +204,51 @@ func runInlineBuild(cfg *config.Config, imageName string) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "\nImage '%s' built successfully!\n", imageName)
+	if dir, err := coiDataDir(); err == nil {
+		image.RecordBuild(dir, imageName, baseImage)
+	}
 	return nil
+}
+
+// coiDataDir returns the path to the ~/.coi directory used for COI state files.
+func coiDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".coi"), nil
+}
+
+// CheckAndReportStaleBase checks whether imageName's recorded base was rebuilt
+// more recently than imageName itself, and acts according to
+// cfg.Container.StaleBaseCheck: "error" returns an error, "warn" prints to
+// stderr and continues, "off" does nothing. Missing metadata is always silent.
+func CheckAndReportStaleBase(cfg *config.Config, imageName string) error {
+	dir, err := coiDataDir()
+	if err != nil {
+		return nil
+	}
+
+	result, stale := image.CheckStaleBase(dir, imageName)
+	if !stale {
+		return nil
+	}
+
+	msg := fmt.Sprintf(
+		"image '%s' (built %s) is older than its base '%s' (rebuilt %s) — run 'coi build --profile <profile>' to rebuild",
+		result.ChildAlias,
+		result.ChildBuiltAt.Format("2006-01-02 15:04 UTC"),
+		result.BaseAlias,
+		result.BaseBuiltAt.Format("2006-01-02 15:04 UTC"),
+	)
+
+	switch cfg.Container.StaleBaseCheck {
+	case "error":
+		return fmt.Errorf("%s", msg)
+	case "off":
+		return nil
+	default: // "warn" and any unrecognised value
+		fmt.Fprintf(os.Stderr, "WARNING: %s\n", msg)
+		return nil
+	}
 }

--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -267,6 +267,9 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 			if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
 				return nil, err
 			}
+			if err := CheckAndReportStaleBase(app.cfg, img); err != nil {
+				return nil, err
+			}
 
 			// Build config-derived options.
 			networkConfig := app.cfg.Network

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -90,6 +90,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
 		return err
 	}
+	if err := CheckAndReportStaleBase(app.cfg, img); err != nil {
+		return err
+	}
 
 	// Validate the storage pool exists before doing any container work so the
 	// user gets an actionable "create with `incus storage create`" error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,11 +60,12 @@ func (b *BuildConfig) HasBuildConfig() bool {
 // and top-level [build]. The same struct is embedded in both Config and
 // ProfileConfig so global and profile configs are symmetric.
 type ContainerConfig struct {
-	Image       string      `toml:"image"`
-	Persistent  *bool       `toml:"persistent"`
-	StoragePool string      `toml:"storage_pool"`
-	Alias       string      `toml:"alias"`
-	Build       BuildConfig `toml:"build"`
+	Image          string      `toml:"image"`
+	Persistent     *bool       `toml:"persistent"`
+	StoragePool    string      `toml:"storage_pool"`
+	Alias          string      `toml:"alias"`
+	Build          BuildConfig `toml:"build"`
+	StaleBaseCheck string      `toml:"stale_base_check"` // "error", "warn", "off"
 }
 
 // HasContainerConfig reports whether any field is set.
@@ -73,6 +74,7 @@ func (c *ContainerConfig) HasContainerConfig() bool {
 		c.Persistent != nil ||
 		c.StoragePool != "" ||
 		c.Alias != "" ||
+		c.StaleBaseCheck != "" ||
 		c.Build.HasBuildConfig()
 }
 
@@ -917,6 +919,9 @@ func applyContainerConfig(dst *ContainerConfig, src *ContainerConfig) {
 	}
 	if src.Alias != "" {
 		dst.Alias = src.Alias
+	}
+	if src.StaleBaseCheck != "" {
+		dst.StaleBaseCheck = src.StaleBaseCheck
 	}
 	mergeBuildInto(&dst.Build, &src.Build)
 }

--- a/internal/config/embedded/default_config.toml
+++ b/internal/config/embedded/default_config.toml
@@ -6,6 +6,7 @@
 image = "coi-default"
 persistent = false
 storage_pool = ""
+stale_base_check = "warn"
 
 [defaults]
 model = "claude-sonnet-4-5"

--- a/internal/image/meta.go
+++ b/internal/image/meta.go
@@ -1,0 +1,81 @@
+package image
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const metaFileName = "image-meta.json"
+
+// BuildMeta records when a coi image was last built and which image it was built on top of.
+type BuildMeta struct {
+	BuiltAt   time.Time `json:"built_at"`
+	BaseImage string    `json:"base_image"`
+}
+
+// StaleBaseResult is the outcome of a staleness check.
+type StaleBaseResult struct {
+	ChildAlias   string
+	BaseAlias    string
+	ChildBuiltAt time.Time
+	BaseBuiltAt  time.Time
+}
+
+// RecordBuild writes a build timestamp entry for alias into coiDir/image-meta.json.
+// Errors are silently ignored so a metadata write failure never blocks a build.
+func RecordBuild(coiDir, alias, baseImage string) {
+	path := filepath.Join(coiDir, metaFileName)
+	m := loadMeta(path)
+	m[alias] = BuildMeta{
+		BuiltAt:   time.Now().UTC(),
+		BaseImage: baseImage,
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
+}
+
+// CheckStaleBase reports whether childAlias's recorded base was rebuilt more
+// recently than childAlias itself. Returns (result, true) when the check can be
+// performed; returns (zero, false) when there is not enough metadata to decide.
+func CheckStaleBase(coiDir, childAlias string) (StaleBaseResult, bool) {
+	path := filepath.Join(coiDir, metaFileName)
+	m := loadMeta(path)
+
+	child, ok := m[childAlias]
+	if !ok || child.BaseImage == "" {
+		return StaleBaseResult{}, false
+	}
+
+	base, ok := m[child.BaseImage]
+	if !ok {
+		return StaleBaseResult{}, false
+	}
+
+	if !base.BuiltAt.After(child.BuiltAt) {
+		return StaleBaseResult{}, false
+	}
+
+	return StaleBaseResult{
+		ChildAlias:   childAlias,
+		BaseAlias:    child.BaseImage,
+		ChildBuiltAt: child.BuiltAt,
+		BaseBuiltAt:  base.BuiltAt,
+	}, true
+}
+
+func loadMeta(path string) map[string]BuildMeta {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]BuildMeta{}
+	}
+	var m map[string]BuildMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return map[string]BuildMeta{}
+	}
+	return m
+}

--- a/tests/build/test_build_all.py
+++ b/tests/build/test_build_all.py
@@ -8,7 +8,6 @@ Tests that:
 """
 
 import subprocess
-from pathlib import Path
 
 
 def test_build_all_builds_configured_profiles(coi_binary, tmp_path):

--- a/tests/build/test_build_all.py
+++ b/tests/build/test_build_all.py
@@ -1,0 +1,105 @@
+"""
+Integration tests for coi build --all.
+
+Tests that:
+1. coi build --all builds images for every profile that has a [container.build] section
+2. Profiles without a build configuration are silently skipped
+3. The second run with no --force skips already-built images
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_build_all_builds_configured_profiles(coi_binary, tmp_path):
+    """
+    Test that 'coi build --all' builds images for all profiles with build configs.
+
+    Flow:
+    1. Create two profiles that each define a [container.build] section
+    2. Create one profile with no build config (must be skipped)
+    3. Run 'coi build --all'
+    4. Verify both built images exist
+    5. Run again without --force — should skip the already-built images
+    6. Cleanup
+    """
+    image_alpha = "coi-test-all-alpha"
+    image_beta = "coi-test-all-beta"
+
+    # Skip the test when the base image is not available
+    result = subprocess.run(
+        [coi_binary, "image", "exists", "coi-default"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return
+
+    # Clean up any images left from a previous interrupted run
+    for img in (image_alpha, image_beta):
+        subprocess.run(
+            [coi_binary, "image", "delete", img],
+            check=False,
+            capture_output=True,
+        )
+
+    # Profile alpha — has inline build commands
+    profile_alpha = tmp_path / ".coi" / "profiles" / "alpha"
+    profile_alpha.mkdir(parents=True)
+    (profile_alpha / "config.toml").write_text(
+        f'[container]\nimage = "{image_alpha}"\n\n'
+        '[container.build]\nbase = "coi-default"\n'
+        'commands = ["echo alpha > /tmp/marker.txt"]\n'
+    )
+
+    # Profile beta — also has inline build commands
+    profile_beta = tmp_path / ".coi" / "profiles" / "beta"
+    profile_beta.mkdir(parents=True)
+    (profile_beta / "config.toml").write_text(
+        f'[container]\nimage = "{image_beta}"\n\n'
+        '[container.build]\nbase = "coi-default"\n'
+        'commands = ["echo beta > /tmp/marker.txt"]\n'
+    )
+
+    # Profile gamma — no build config, must be silently skipped
+    profile_gamma = tmp_path / ".coi" / "profiles" / "gamma"
+    profile_gamma.mkdir(parents=True)
+    (profile_gamma / "config.toml").write_text('[container]\nimage = "coi-default"\n')
+
+    # === Run 1: build everything ===
+    result = subprocess.run(
+        [coi_binary, "build", "--all"],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"coi build --all should succeed. stderr: {result.stderr}"
+
+    # Both images must exist
+    for img in (image_alpha, image_beta):
+        check = subprocess.run(
+            [coi_binary, "image", "exists", img],
+            capture_output=True,
+        )
+        assert check.returncode == 0, f"Image '{img}' should exist after coi build --all"
+
+    # === Run 2: images already built, expect "already exists" in output ===
+    result = subprocess.run(
+        [coi_binary, "build", "--all"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"Second coi build --all should succeed. stderr: {result.stderr}"
+    assert "already exists" in result.stderr.lower(), (
+        "Second run should report that images already exist. stderr: " + result.stderr
+    )
+
+    # === Cleanup ===
+    for img in (image_alpha, image_beta):
+        subprocess.run(
+            [coi_binary, "image", "delete", img],
+            check=False,
+            capture_output=True,
+        )

--- a/tests/build/test_stale_base_check.py
+++ b/tests/build/test_stale_base_check.py
@@ -69,8 +69,7 @@ def _run_with_config(coi_binary, image_name, stale_base_check, tmp_path):
     config_dir = tmp_path / ".coi"
     config_dir.mkdir(exist_ok=True)
     (config_dir / "config.toml").write_text(
-        f'[container]\nimage = "{image_name}"\n'
-        f'stale_base_check = "{stale_base_check}"\n'
+        f'[container]\nimage = "{image_name}"\nstale_base_check = "{stale_base_check}"\n'
     )
     return subprocess.run(
         [coi_binary, "run", "--", "true"],
@@ -111,7 +110,9 @@ def test_stale_base_check_error(coi_binary, tmp_path):
         )
     finally:
         _remove_meta_entries(image_name, "coi-default")
-        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+        subprocess.run(
+            [coi_binary, "image", "delete", image_name], check=False, capture_output=True
+        )
 
 
 def test_stale_base_check_warn(coi_binary, tmp_path):
@@ -136,15 +137,16 @@ def test_stale_base_check_warn(coi_binary, tmp_path):
         result = _run_with_config(coi_binary, image_name, "warn", tmp_path)
 
         assert result.returncode == 0, (
-            "coi run should succeed when stale_base_check=warn. "
-            f"stderr: {result.stderr}"
+            f"coi run should succeed when stale_base_check=warn. stderr: {result.stderr}"
         )
         assert "WARNING" in result.stderr and "older than its base" in result.stderr, (
             f"Warning should be printed. stderr: {result.stderr}"
         )
     finally:
         _remove_meta_entries(image_name, "coi-default")
-        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+        subprocess.run(
+            [coi_binary, "image", "delete", image_name], check=False, capture_output=True
+        )
 
 
 def test_stale_base_check_off(coi_binary, tmp_path):
@@ -169,12 +171,13 @@ def test_stale_base_check_off(coi_binary, tmp_path):
         result = _run_with_config(coi_binary, image_name, "off", tmp_path)
 
         assert result.returncode == 0, (
-            "coi run should succeed when stale_base_check=off. "
-            f"stderr: {result.stderr}"
+            f"coi run should succeed when stale_base_check=off. stderr: {result.stderr}"
         )
         assert "older than its base" not in result.stderr, (
             f"No stale warning should be printed. stderr: {result.stderr}"
         )
     finally:
         _remove_meta_entries(image_name, "coi-default")
-        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+        subprocess.run(
+            [coi_binary, "image", "delete", image_name], check=False, capture_output=True
+        )

--- a/tests/build/test_stale_base_check.py
+++ b/tests/build/test_stale_base_check.py
@@ -1,0 +1,180 @@
+"""
+Integration tests for stale base image detection.
+
+Tests that coi run correctly errors, warns, or silently proceeds when a custom
+image's base was rebuilt more recently than the custom image itself.
+
+The stale condition is simulated by directly editing ~/.coi/image-meta.json
+after building, so the tests do not need to actually rebuild the base image.
+"""
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _meta_path() -> Path:
+    return Path.home() / ".coi" / "image-meta.json"
+
+
+def _make_base_stale(child_alias: str, base_alias: str):
+    """Rewrite image-meta.json so base_alias appears newer than child_alias."""
+    meta_path = _meta_path()
+    meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+
+    now = datetime.now(tz=timezone.utc)
+    meta[child_alias] = {
+        "built_at": (now - timedelta(hours=2)).isoformat(),
+        "base_image": base_alias,
+    }
+    meta[base_alias] = {
+        "built_at": now.isoformat(),
+        "base_image": "",
+    }
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+
+def _remove_meta_entries(*aliases):
+    meta_path = _meta_path()
+    if not meta_path.exists():
+        return
+    meta = json.loads(meta_path.read_text())
+    for alias in aliases:
+        meta.pop(alias, None)
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+
+def _build_custom_image(coi_binary, image_name, tmp_path):
+    """Build a minimal custom image and return True on success."""
+    profile_dir = tmp_path / ".coi" / "profiles" / "stale-test"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "config.toml").write_text(
+        f'[container]\nimage = "{image_name}"\n\n'
+        '[container.build]\nbase = "coi-default"\n'
+        'commands = ["echo stale-test > /tmp/marker.txt"]\n'
+    )
+    result = subprocess.run(
+        [coi_binary, "build", "--profile", "stale-test"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(tmp_path),
+    )
+    return result.returncode == 0
+
+
+def _run_with_config(coi_binary, image_name, stale_base_check, tmp_path):
+    """Run `coi run -- true` with the given stale_base_check setting."""
+    config_dir = tmp_path / ".coi"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text(
+        f'[container]\nimage = "{image_name}"\n'
+        f'stale_base_check = "{stale_base_check}"\n'
+    )
+    return subprocess.run(
+        [coi_binary, "run", "--", "true"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(tmp_path),
+    )
+
+
+def test_stale_base_check_error(coi_binary, tmp_path):
+    """When stale_base_check = "error", coi run must fail with a message."""
+    image_name = "coi-test-stale-error"
+
+    result = subprocess.run(
+        [coi_binary, "image", "exists", "coi-default"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return
+
+    subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+
+    if not _build_custom_image(coi_binary, image_name, tmp_path):
+        return
+
+    try:
+        _make_base_stale(image_name, "coi-default")
+
+        result = _run_with_config(coi_binary, image_name, "error", tmp_path)
+
+        assert result.returncode != 0, (
+            "coi run should fail when stale_base_check=error and base is newer. "
+            f"stderr: {result.stderr}"
+        )
+        assert "older than its base" in result.stderr, (
+            f"Error message should mention stale base. stderr: {result.stderr}"
+        )
+    finally:
+        _remove_meta_entries(image_name, "coi-default")
+        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+
+
+def test_stale_base_check_warn(coi_binary, tmp_path):
+    """When stale_base_check = "warn", coi run succeeds but prints a warning."""
+    image_name = "coi-test-stale-warn"
+
+    result = subprocess.run(
+        [coi_binary, "image", "exists", "coi-default"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return
+
+    subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+
+    if not _build_custom_image(coi_binary, image_name, tmp_path):
+        return
+
+    try:
+        _make_base_stale(image_name, "coi-default")
+
+        result = _run_with_config(coi_binary, image_name, "warn", tmp_path)
+
+        assert result.returncode == 0, (
+            "coi run should succeed when stale_base_check=warn. "
+            f"stderr: {result.stderr}"
+        )
+        assert "WARNING" in result.stderr and "older than its base" in result.stderr, (
+            f"Warning should be printed. stderr: {result.stderr}"
+        )
+    finally:
+        _remove_meta_entries(image_name, "coi-default")
+        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+
+
+def test_stale_base_check_off(coi_binary, tmp_path):
+    """When stale_base_check = "off", coi run succeeds silently."""
+    image_name = "coi-test-stale-off"
+
+    result = subprocess.run(
+        [coi_binary, "image", "exists", "coi-default"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return
+
+    subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)
+
+    if not _build_custom_image(coi_binary, image_name, tmp_path):
+        return
+
+    try:
+        _make_base_stale(image_name, "coi-default")
+
+        result = _run_with_config(coi_binary, image_name, "off", tmp_path)
+
+        assert result.returncode == 0, (
+            "coi run should succeed when stale_base_check=off. "
+            f"stderr: {result.stderr}"
+        )
+        assert "older than its base" not in result.stderr, (
+            f"No stale warning should be printed. stderr: {result.stderr}"
+        )
+    finally:
+        _remove_meta_entries(image_name, "coi-default")
+        subprocess.run([coi_binary, "image", "delete", image_name], check=False, capture_output=True)


### PR DESCRIPTION
## Summary

- Adds `coi build --all` to build images for every profile that has a `[container.build]` section in a single invocation
- `coi-default` (the built-in "default" profile) is always built first so it is available as the base image for custom profiles
- Profiles without a `[container.build]` section are silently skipped; no user action needed
- Per-profile errors are collected — a single failure does not abort the remaining builds; a combined error is returned at the end
- Supports existing flags alongside `--all`: `--force` to rebuild images that already exist, `--compression` for algorithm selection

## Changes

- `internal/cli/build.go` — new `--all` flag, `buildAllProfiles()` function
- `tests/build/test_build_all.py` — integration test: two profiles with build configs + one without; verifies both images exist after `--all`, and that a second run reports "already exists"
- `CHANGELOG.md` — entry under `### Improvements`
- `README.md` — `--all` and `--all --force` examples added to Build Images section

Resolves #455