### PR TITLE
refactor(cli): App methods + monitor daemon interfaces (Issues 2 & 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.9.0 (Unreleased)
 
+### Refactoring
+
+- **Command handlers converted to `App` struct methods** — All CLI command handlers (`shellCommand`, `runCommand`, `buildCommand`, `cleanCommand`, `monitorCommand`, `attachCommand`, and all profile sub-commands) are now methods on `*App` rather than free functions that access the package-level `app` singleton directly. Phase builder functions in `phases_shell.go` are likewise methods on `App`. This enables creating an isolated `App` instance in tests with a controlled config and workspace without relying on global state. The `app` singleton and `Execute()` reset semantics are unchanged for normal operation.
+
+- **Monitor daemon interfaces at subsystem boundaries** — `monitor.MonitorDaemon` and `nftmonitor.NFTMonitorDaemon` interfaces are defined so that callers (`shellState`, `startMonitoringDaemon`, `startNFTMonitoringDaemon`) depend on the interface rather than the concrete `*Daemon` pointer. Combined with the existing `container.ContainerManager`, `network.NetworkManager`, and `limits.LimitsApplier` interfaces, all four major infrastructure subsystems now have stable interface boundaries that enable test stubs without a live Incus environment.
+
+
 ### Performance
 
 - **Container init PID resolved host-side via cgroup.procs** — `GetContainerInitPID` now reads the container's init PID directly from `/sys/fs/cgroup/incus.monitor/<name>/cgroup.procs` (walking the full cgroup subtree to handle systemd containers where PID 1 lives in `init.scope`) instead of spawning `incus info` on every poll tick. Because all monitors — network, process, logwatcher, filesystem, health checks — call `GetContainerInitPID` once per poll cycle, this eliminates a subprocess invocation per monitor per tick with no behavioral change. The `incus info` path is retained as a fallback for environments where the well-known cgroup paths are unavailable.

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -32,7 +32,7 @@ Examples:
   coi attach --slot=1           # Attach to slot 1 for current workspace
   coi attach --bash             # Attach to bash shell instead of tmux session
   coi attach coi-123 --bash     # Attach to specific container with bash`,
-	RunE: attachCommand,
+	RunE: app.attachCommand,
 }
 
 func init() {
@@ -40,13 +40,13 @@ func init() {
 	attachCmd.Flags().IntVar(&attachSlot, "slot", 0, "Slot number to attach to (requires workspace context)")
 }
 
-func attachCommand(cmd *cobra.Command, args []string) error {
+func (a *App) attachCommand(cmd *cobra.Command, args []string) error {
 	var targetContainer string
 
 	// If --slot is provided, calculate container name from workspace and slot
 	if attachSlot > 0 {
 		// Resolve workspace path
-		workspacePath, err := filepath.Abs(app.workspace)
+		workspacePath, err := filepath.Abs(a.workspace)
 		if err != nil {
 			return fmt.Errorf("failed to resolve workspace path: %w", err)
 		}

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -60,7 +60,7 @@ func runAudit(cmd *cobra.Command, args []string) error {
 		return audit.HostAuditTail(auditFile, auditFollow, "", "", os.Stdout)
 	}
 
-	containerName, err := resolveMonitorContainer(args)
+	containerName, err := app.resolveMonitorContainer(args)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -39,7 +39,7 @@ Examples:
   coi build --all --force
 `,
 	Args: cobra.NoArgs,
-	RunE: buildCommand,
+	RunE: app.buildCommand,
 }
 
 func init() {
@@ -48,7 +48,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&buildAll, "all", false, "Build images for all profiles visible from the current directory (global ~/.coi/profiles + project .coi/profiles)")
 }
 
-func buildCommand(cmd *cobra.Command, args []string) error {
+func (a *App) buildCommand(cmd *cobra.Command, args []string) error {
 	// Check if Incus is available
 	if !container.Available() {
 		return container.IncusNotAvailableError()
@@ -65,16 +65,16 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if buildAll {
-		return buildAllProfiles()
+		return a.buildAllProfiles()
 	}
 
 	// Determine which profile to use
-	profileName := app.profile // from --profile flag
+	profileName := a.profile // from --profile flag
 	if profileName == "" {
 		profileName = "default"
 	}
 
-	p := app.cfg.GetProfile(profileName)
+	p := a.cfg.GetProfile(profileName)
 	if p == nil {
 		return fmt.Errorf("profile '%s' not found", profileName)
 	}
@@ -89,7 +89,7 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 	// pool and let the selected profile override it only when it sets a
 	// non-empty storage_pool value. Validate before any container work so a
 	// missing pool fails loud and early.
-	buildPool := app.cfg.Container.StoragePool
+	buildPool := a.cfg.Container.StoragePool
 	if p.Container.StoragePool != "" {
 		buildPool = p.Container.StoragePool
 	}
@@ -197,10 +197,10 @@ func buildCommand(cmd *cobra.Command, args []string) error {
 // The "default" profile (coi-default) is always built first; other profiles are
 // processed in alphabetical order. Profiles without a [container.build] section
 // are silently skipped. Errors are collected and reported together at the end.
-func buildAllProfiles() error {
+func (a *App) buildAllProfiles() error {
 	// Collect profile names: "default" first, then the rest alphabetically.
-	others := make([]string, 0, len(app.cfg.Profiles))
-	for name := range app.cfg.Profiles {
+	others := make([]string, 0, len(a.cfg.Profiles))
+	for name := range a.cfg.Profiles {
 		if name != "default" {
 			others = append(others, name)
 		}
@@ -212,7 +212,7 @@ func buildAllProfiles() error {
 	var buildErrors []string
 
 	for _, profileName := range names {
-		p := app.cfg.GetProfile(profileName)
+		p := a.cfg.GetProfile(profileName)
 		if p == nil {
 			continue
 		}
@@ -227,7 +227,7 @@ func buildAllProfiles() error {
 			continue
 		}
 
-		buildPool := app.cfg.Container.StoragePool
+		buildPool := a.cfg.Container.StoragePool
 		if p.Container.StoragePool != "" {
 			buildPool = p.Container.StoragePool
 		}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -49,7 +49,7 @@ Examples:
   coi clean --all --force      # Clean without confirmation
   coi clean --orphans --dry-run # Show what orphans would be cleaned
 `,
-	RunE: cleanCommand,
+	RunE: app.cleanCommand,
 }
 
 func init() {
@@ -61,9 +61,9 @@ func init() {
 	cleanCmd.Flags().BoolVar(&cleanDryRun, "dry-run", false, "Show what would be cleaned without making changes")
 }
 
-func cleanCommand(cmd *cobra.Command, args []string) error {
+func (a *App) cleanCommand(cmd *cobra.Command, args []string) error {
 	// Get configured tool to determine tool-specific sessions directory
-	toolInstance, err := getConfiguredTool(app.cfg)
+	toolInstance, err := getConfiguredTool(a.cfg)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func cleanCommand(cmd *cobra.Command, args []string) error {
 
 	// Clean COI containers in unreferenced storage pools
 	if cleanAll || cleanPools {
-		count, cancelled, err := cleanUnreferencedPools()
+		count, cancelled, err := a.cleanUnreferencedPools()
 		if err != nil {
 			return err
 		}
@@ -374,11 +374,11 @@ func doCleanOrphanedResources(orphans *cleanup.OrphanedResources) int {
 // root pool.
 //
 // Returns (count cleaned, was cancelled, error).
-func cleanUnreferencedPools() (int, bool, error) {
+func (a *App) cleanUnreferencedPools() (int, bool, error) {
 	fmt.Println("\nScanning storage pools for unreferenced COI containers...")
 
 	// Build referenced pool set from the loaded config + profiles.
-	referenced := referencedPoolSet()
+	referenced := a.referencedPoolSet()
 
 	// List all pools known to Incus.
 	pools, err := container.ListStoragePools()
@@ -492,13 +492,13 @@ func cleanUnreferencedPools() (int, bool, error) {
 // pool as referenced even when the effective pool is a non-empty global
 // cfg.Container.StoragePool. The empty string ("") is only present when
 // the global entry itself is empty (meaning "use Incus default pool").
-func referencedPoolSet() map[string]bool {
+func (a *App) referencedPoolSet() map[string]bool {
 	set := map[string]bool{}
-	if app.cfg == nil {
+	if a.cfg == nil {
 		return set
 	}
-	set[app.cfg.Container.StoragePool] = true
-	for _, profile := range app.cfg.Profiles {
+	set[a.cfg.Container.StoragePool] = true
+	for _, profile := range a.cfg.Profiles {
 		if profile.Container.StoragePool != "" {
 			set[profile.Container.StoragePool] = true
 		}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -42,7 +42,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	containerName, err := resolveMonitorContainer(args)
+	containerName, err := app.resolveMonitorContainer(args)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -50,10 +50,10 @@ Examples:
   coi monitor --format json      # JSON output
   coi monitor --json             # JSON output (backward-compatible alias)
   coi monitor --watch 2          # Update every 2 seconds`,
-	RunE: monitorCommand,
+	RunE: app.monitorCommand,
 }
 
-func monitorCommand(cmd *cobra.Command, args []string) error {
+func (a *App) monitorCommand(cmd *cobra.Command, args []string) error {
 	// Reconcile --json flag with --format flag (backward compatibility)
 	if monitorJSON {
 		monitorFormat = "json"
@@ -75,7 +75,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 	// 1. Positional argument
 	// 2. COI_CONTAINER environment variable
 	// 3. Auto-detect from workspace
-	containerName, err := resolveMonitorContainer(args)
+	containerName, err := a.resolveMonitorContainer(args)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 
 	// Get allowed CIDRs from network config
 	allowedCIDRs := []string{}
-	if app.cfg.Network.Mode == config.NetworkModeAllowlist {
+	if a.cfg.Network.Mode == config.NetworkModeAllowlist {
 		// Convert allowed domains to CIDRs (simplified - in full implementation would resolve)
 		// For now, just pass empty list
 		allowedCIDRs = []string{}
@@ -91,7 +91,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 
 	// Create collector
 	collector := monitor.NewCollector(containerName, "", "", allowedCIDRs)
-	detector := monitor.NewDetector(app.cfg.Monitoring.FileReadThresholdMB, app.cfg.Monitoring.FileReadRateMBPerSec)
+	detector := monitor.NewDetector(a.cfg.Monitoring.FileReadThresholdMB, a.cfg.Monitoring.FileReadRateMBPerSec)
 
 	// Watch mode or one-shot
 	if monitorWatch > 0 {
@@ -125,7 +125,7 @@ func monitorCommand(cmd *cobra.Command, args []string) error {
 // 1. Use positional arg if provided
 // 2. Check COI_CONTAINER environment variable
 // 3. Find container for current workspace
-func resolveMonitorContainer(args []string) (string, error) {
+func (a *App) resolveMonitorContainer(args []string) (string, error) {
 	// 1. Use positional arg if provided (with alias resolution)
 	if len(args) > 0 {
 		name := args[0]
@@ -159,7 +159,7 @@ func resolveMonitorContainer(args []string) (string, error) {
 	}
 
 	// 3. Find container for current workspace
-	absWorkspace, err := filepath.Abs(app.workspace)
+	absWorkspace, err := filepath.Abs(a.workspace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve workspace path: %w", err)
 	}

--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -40,18 +40,18 @@ type shellState struct {
 	result *session.SetupResult
 
 	// After start-monitoring
-	monitorDaemon *monitor.Daemon
-	nftDaemon     *nftmonitor.Daemon
+	monitorDaemon monitor.MonitorDaemon
+	nftDaemon     nftmonitor.NFTMonitorDaemon
 }
 
 // resolveWorkspacePhase resolves the absolute workspace path from --workspace
 // or alias, overlays the workspace's project config, and applies any alias
 // profile/slot inherited from the registry.
-func resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
+func (a *App) resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "resolve-workspace",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
-			absWorkspace, err := filepath.Abs(app.workspace)
+			absWorkspace, err := filepath.Abs(a.workspace)
 			if err != nil {
 				return nil, fmt.Errorf("invalid workspace path: %w", err)
 			}
@@ -61,10 +61,10 @@ func resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
 			if s.aliasArg == "" {
 				if cwd, err := os.Getwd(); err == nil {
 					if absCWD, err := filepath.Abs(cwd); err == nil && absWorkspace != absCWD {
-						if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+						if err := a.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 							return nil, fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 						}
-						container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
+						container.Configure(a.cfg.Incus.Project, a.cfg.Incus.CodeUser, a.cfg.Incus.CodeUID)
 					}
 				}
 			}
@@ -77,19 +77,19 @@ func resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
 				}
 				absWorkspace = resolved.Workspace
 
-				if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+				if err := a.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 					return nil, fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 				}
 
 				if resolved.Profile != "" && !cmd.Flags().Changed("profile") {
-					app.profile = resolved.Profile
-					if err := app.cfg.ApplyProfile(app.profile); err != nil {
+					a.profile = resolved.Profile
+					if err := a.cfg.ApplyProfile(a.profile); err != nil {
 						return nil, err
 					}
 				}
-				container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
+				container.Configure(a.cfg.Incus.Project, a.cfg.Incus.CodeUser, a.cfg.Incus.CodeUID)
 				if resolved.Slot > 0 && !cmd.Flags().Changed("slot") {
-					app.slot = resolved.Slot
+					a.slot = resolved.Slot
 				}
 			}
 
@@ -102,14 +102,14 @@ func resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.Phase {
 // validateEnvPhase determines the effective tmux mode (config default vs
 // explicit flag) and verifies that Incus is available and at the minimum
 // required version.
-func validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase {
+func (a *App) validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "validate-env",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
 			// Config default, overridden by explicit --tmux flag.
 			useTmuxDefault := true
-			if app.cfg.Shell.UseTmux != nil {
-				useTmuxDefault = *app.cfg.Shell.UseTmux
+			if a.cfg.Shell.UseTmux != nil {
+				useTmuxDefault = *a.cfg.Shell.UseTmux
 			}
 			if cmd.Flags().Changed("tmux") {
 				s.useTmux = useTmux // cobra already set the package-level var
@@ -136,15 +136,15 @@ func validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase {
 // slot, and constructs the SetupOptions for the container.
 //
 //nolint:gocyclo // Many configuration paths — sequential by design
-func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
+func (a *App) configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "configure-session",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
 			// Override tool from --tool flag.
 			if toolFlag != "" {
-				app.cfg.Tool.Name = toolFlag
+				a.cfg.Tool.Name = toolFlag
 			}
-			ti, err := getConfiguredTool(app.cfg)
+			ti, err := getConfiguredTool(a.cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -162,9 +162,9 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 			s.sessionsDir = sessionsDir
 
 			// Resolve the resume/continue ID.
-			resumeID := app.resume
-			if app.continueSession != "" {
-				resumeID = app.continueSession
+			resumeID := a.resume
+			if a.continueSession != "" {
+				resumeID = a.continueSession
 			}
 			resumeFlagSet := cmd.Flags().Changed("resume") || cmd.Flags().Changed("continue")
 
@@ -201,18 +201,18 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 				metadataPath := filepath.Join(sessionsDir, resumeID, "metadata.json")
 				if metadata, err := session.LoadSessionMetadata(metadataPath); err == nil {
 					if !cmd.Flags().Changed("profile") && metadata.ProfileName != "" {
-						app.profile = metadata.ProfileName
-						if err := app.cfg.ApplyProfile(app.profile); err != nil {
-							return nil, fmt.Errorf("failed to apply saved profile '%s': %w", app.profile, err)
+						a.profile = metadata.ProfileName
+						if err := a.cfg.ApplyProfile(a.profile); err != nil {
+							return nil, fmt.Errorf("failed to apply saved profile '%s': %w", a.profile, err)
 						}
 						if !cmd.Flags().Changed("persistent") {
-							app.persistent = config.BoolVal(app.cfg.Container.Persistent)
+							a.persistent = config.BoolVal(a.cfg.Container.Persistent)
 						}
-						fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", app.profile)
+						fmt.Fprintf(os.Stderr, "Inherited profile '%s' from session\n", a.profile)
 					}
 					if !cmd.Flags().Changed("persistent") {
-						app.persistent = metadata.Persistent
-						if app.persistent {
+						a.persistent = metadata.Persistent
+						if a.persistent {
 							fmt.Fprintf(os.Stderr, "Inherited persistent mode from session\n")
 						}
 					}
@@ -236,7 +236,7 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 			}
 
 			// Allocate slot.
-			slotNum := app.slot
+			slotNum := a.slot
 			if resumeSlot > 0 && slotNum == 0 {
 				slotNum = resumeSlot
 				fmt.Fprintf(os.Stderr, "Reusing original slot %d from session\n", slotNum)
@@ -263,32 +263,32 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 			s.slotNum = slotNum
 
 			// Resolve image and auto-build if needed.
-			img := ResolveImageName(app.imageName, app.cfg)
-			if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
+			img := ResolveImageName(a.imageName, a.cfg)
+			if err := AutoBuildIfNeeded(a.cfg, img); err != nil {
 				return nil, err
 			}
-			if err := CheckAndReportStaleBase(app.cfg, img); err != nil {
+			if err := CheckAndReportStaleBase(a.cfg, img); err != nil {
 				return nil, err
 			}
 
 			// Build config-derived options.
-			networkConfig := app.cfg.Network
-			limitsConfig := &app.cfg.Limits
+			networkConfig := a.cfg.Network
+			limitsConfig := &a.cfg.Limits
 			var protectedPaths []string
-			if !app.cfg.Security.DisableProtection {
-				protectedPaths = app.cfg.Security.GetEffectiveProtectedPaths()
+			if !a.cfg.Security.DisableProtection {
+				protectedPaths = a.cfg.Security.GetEffectiveProtectedPaths()
 			}
-			protectedPaths = filterWritableGitHooks(protectedPaths, app.cfg)
+			protectedPaths = filterWritableGitHooks(protectedPaths, a.cfg)
 
 			var cliConfigPath string
 			if configDirName := ti.ConfigDirName(); configDirName != "" {
 				cliConfigPath = filepath.Join(homeDir, configDirName)
 			}
 
-			resolvedForwardedEnvVars := resolveForwardedEnvVarNames(app.cfg.Defaults.ForwardEnv)
-			resolvedTimezone := resolveTimezone(app.cfg)
+			resolvedForwardedEnvVars := resolveForwardedEnvVarNames(a.cfg.Defaults.ForwardEnv)
+			resolvedTimezone := resolveTimezone(a.cfg)
 
-			mountConfig, err := ParseMountConfig(app.cfg)
+			mountConfig, err := ParseMountConfig(a.cfg)
 			if err != nil {
 				return nil, fmt.Errorf("invalid mount configuration: %w", err)
 			}
@@ -296,8 +296,8 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 				return nil, fmt.Errorf("mount validation failed: %w", err)
 			}
 
-			if app.cfg.Container.Alias != "" {
-				if err := alias.ValidateAlias(app.cfg.Container.Alias); err != nil {
+			if a.cfg.Container.Alias != "" {
+				if err := alias.ValidateAlias(a.cfg.Container.Alias); err != nil {
 					return nil, fmt.Errorf("invalid container alias: %w", err)
 				}
 			}
@@ -305,7 +305,7 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 			s.setupOpts = session.SetupOptions{
 				WorkspacePath:         s.absWorkspace,
 				Image:                 img,
-				Persistent:            app.persistent,
+				Persistent:            a.persistent,
 				ResumeFromID:          resumeID,
 				Slot:                  slotNum,
 				MountConfig:           mountConfig,
@@ -313,20 +313,20 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 				CLIConfigPath:         cliConfigPath,
 				Tool:                  ti,
 				NetworkConfig:         &networkConfig,
-				DisableShift:          app.cfg.Incus.DisableShift,
+				DisableShift:          a.cfg.Incus.DisableShift,
 				LimitsConfig:          limitsConfig,
-				IncusProject:          app.cfg.Incus.Project,
+				IncusProject:          a.cfg.Incus.Project,
 				ProtectedPaths:        protectedPaths,
-				HostImmutable:         app.cfg.Security.IsHostImmutableEnabled(),
-				PreserveWorkspacePath: app.cfg.Paths.PreserveWorkspacePath,
-				ForwardSSHAgent:       config.BoolVal(app.cfg.SSH.ForwardAgent),
+				HostImmutable:         a.cfg.Security.IsHostImmutableEnabled(),
+				PreserveWorkspacePath: a.cfg.Paths.PreserveWorkspacePath,
+				ForwardSSHAgent:       config.BoolVal(a.cfg.SSH.ForwardAgent),
 				ForwardedEnvVars:      resolvedForwardedEnvVars,
-				ContextFilePath:       app.cfg.Tool.ContextFile,
-				ProfileContextFile:    app.cfg.ProfileContextFile,
-				AutoContext:           app.cfg.Tool.AutoContext,
+				ContextFilePath:       a.cfg.Tool.ContextFile,
+				ProfileContextFile:    a.cfg.ProfileContextFile,
+				AutoContext:           a.cfg.Tool.AutoContext,
 				ContainerName:         containerName,
 				Timezone:              resolvedTimezone,
-				Alias:                 app.cfg.Container.Alias,
+				Alias:                 a.cfg.Container.Alias,
 			}
 			return nil, nil
 		},
@@ -337,7 +337,7 @@ func configureSessionPhase(cmd *cobra.Command, s *shellState) session.Phase {
 // and registers the alias in the global registry. Its teardown calls
 // session.Cleanup so the container and session data are handled correctly on
 // all exit paths.
-func setupContainerPhase(s *shellState) session.Phase {
+func (a *App) setupContainerPhase(s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "setup-container",
 		RunFn: func(ctx context.Context) (session.Teardown, error) {
@@ -348,13 +348,13 @@ func setupContainerPhase(s *shellState) session.Phase {
 			}
 			s.result = result
 
-			if err := session.SaveMetadataEarly(s.sessionsDir, s.sessionID, result.ContainerName, s.absWorkspace, app.persistent, app.profile); err != nil {
+			if err := session.SaveMetadataEarly(s.sessionsDir, s.sessionID, result.ContainerName, s.absWorkspace, a.persistent, a.profile); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to save early metadata: %v\n", err)
 			}
 
-			if effectiveAlias := app.cfg.Container.Alias; effectiveAlias != "" {
+			if effectiveAlias := a.cfg.Container.Alias; effectiveAlias != "" {
 				if reg, err := alias.Load(); err == nil {
-					if err := reg.Register(effectiveAlias, s.absWorkspace, app.profile); err != nil {
+					if err := reg.Register(effectiveAlias, s.absWorkspace, a.profile); err != nil {
 						return nil, fmt.Errorf("alias conflict: %w", err)
 					}
 					if err := reg.Save(); err != nil {
@@ -371,8 +371,8 @@ func setupContainerPhase(s *shellState) session.Phase {
 				cleanupOpts := session.CleanupOptions{
 					ContainerName:  s.result.ContainerName,
 					SessionID:      s.sessionID,
-					Persistent:     app.persistent,
-					ProfileName:    app.profile,
+					Persistent:     a.persistent,
+					ProfileName:    a.profile,
 					SessionsDir:    s.sessionsDir,
 					SaveSession:    true,
 					Workspace:      s.absWorkspace,
@@ -391,20 +391,20 @@ func setupContainerPhase(s *shellState) session.Phase {
 
 // startMonitoringPhase starts the traditional and NFT monitoring daemons when
 // enabled in config. Its teardown stops both daemons.
-func startMonitoringPhase(s *shellState) session.Phase {
+func (a *App) startMonitoringPhase(s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "start-monitoring",
 		RunFn: func(ctx context.Context) (session.Teardown, error) {
-			if !config.BoolVal(app.cfg.Monitoring.Enabled) {
+			if !config.BoolVal(a.cfg.Monitoring.Enabled) {
 				return nil, nil
 			}
 
-			if err := startMonitoringDaemon(ctx, s.result.ContainerName, s.absWorkspace, app.cfg, s.result.Logger, &s.monitorDaemon); err != nil {
+			if err := startMonitoringDaemon(ctx, s.result.ContainerName, s.absWorkspace, a.cfg, s.result.Logger, &s.monitorDaemon); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to start monitoring daemon: %v\n", err)
 			}
 
-			if config.BoolVal(app.cfg.Monitoring.NFT.Enabled) {
-				if err := startNFTMonitoringDaemon(ctx, s.result.ContainerName, app.cfg, s.result.Logger, &s.nftDaemon); err != nil {
+			if config.BoolVal(a.cfg.Monitoring.NFT.Enabled) {
+				if err := startNFTMonitoringDaemon(ctx, s.result.ContainerName, a.cfg, s.result.Logger, &s.nftDaemon); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: Failed to start NFT monitoring: %v\n", err)
 				}
 			}
@@ -428,7 +428,7 @@ func startMonitoringPhase(s *shellState) session.Phase {
 
 // runToolPhase executes the AI coding tool (via tmux or direct mode) and
 // normalises expected exit conditions (SIGINT, container shutdown) to nil.
-func runToolPhase(s *shellState) session.Phase {
+func (a *App) runToolPhase(s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "run-tool",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
@@ -437,8 +437,8 @@ func runToolPhase(s *shellState) session.Phase {
 			fmt.Fprintf(os.Stderr, "Container: %s\n", s.result.ContainerName)
 			fmt.Fprintf(os.Stderr, "Workspace: %s\n", s.absWorkspace)
 
-			useResumeFlag := (s.resumeID != "") && app.persistent
-			restoreOnly := (s.resumeID != "") && !app.persistent
+			useResumeFlag := (s.resumeID != "") && a.persistent
+			restoreOnly := (s.resumeID != "") && !a.persistent
 
 			var runErr error
 			if s.useTmux {
@@ -453,7 +453,7 @@ func runToolPhase(s *shellState) session.Phase {
 					fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
 				}
 				fmt.Fprintf(os.Stderr, "\n")
-				runErr = runCLIInTmux(s.result, s.sessionID, background, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
+				runErr = a.runCLIInTmux(s.result, s.sessionID, background, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
 			} else {
 				fmt.Fprintf(os.Stderr, "Mode: Direct (no tmux)\n")
 				if restoreOnly {
@@ -462,7 +462,7 @@ func runToolPhase(s *shellState) session.Phase {
 					fmt.Fprintf(os.Stderr, "Resume mode: Persistent session\n")
 				}
 				fmt.Fprintf(os.Stderr, "\n")
-				runErr = runCLI(s.result, s.sessionID, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
+				runErr = a.runCLI(s.result, s.sessionID, useResumeFlag, restoreOnly, s.sessionsDir, s.resumeID, s.toolInstance)
 			}
 
 			// Normalise expected exit conditions so the pipeline doesn't log

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -128,6 +128,7 @@ Examples:
 	RunE: app.profileInfoRunE,
 }
 
+//nolint:gocyclo // Profile info rendering has many optional fields — sequential by design
 func (a *App) profileInfoRunE(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	p := a.cfg.GetProfile(name)
@@ -586,8 +587,9 @@ func (a *App) profileEditRunE(cmd *cobra.Command, args []string) error {
 		editor = "vi"
 	}
 
-	// Use sh -c to support multi-word editor values like "code --wait"
-	editorCmd := exec.Command("sh", "-c", editor+" "+shellQuote(sourcePath))
+	// Use sh -c to support multi-word editor values like "code --wait".
+	// editor comes from $VISUAL/$EDITOR set by the user — taint is intentional.
+	editorCmd := exec.Command("sh", "-c", editor+" "+shellQuote(sourcePath)) //nolint:gosec
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -34,84 +34,86 @@ Profiles are defined as directories under profiles/, each containing a config.to
 Examples:
   coi profile list
   coi profile list --format json`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if profileFormat != "text" && profileFormat != "json" {
-			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format '%s': must be 'text' or 'json'", profileFormat)}
-		}
+	RunE: app.profileListRunE,
+}
 
-		if len(app.cfg.Profiles) == 0 {
-			if profileFormat == "json" {
-				fmt.Println("[]")
-				return nil
-			}
-			fmt.Fprintln(os.Stderr, "No profiles configured.")
-			return nil
-		}
+func (a *App) profileListRunE(cmd *cobra.Command, args []string) error {
+	if profileFormat != "text" && profileFormat != "json" {
+		return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format '%s': must be 'text' or 'json'", profileFormat)}
+	}
 
-		// Sort profile names for consistent output
-		names := make([]string, 0, len(app.cfg.Profiles))
-		for name := range app.cfg.Profiles {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-
+	if len(a.cfg.Profiles) == 0 {
 		if profileFormat == "json" {
-			type profileEntry struct {
-				Name        string `json:"name"`
-				Image       string `json:"image"`
-				Persistent  *bool  `json:"persistent"`
-				StoragePool string `json:"storage_pool,omitempty"`
-				Inherits    string `json:"inherits,omitempty"`
-				Source      string `json:"source,omitempty"`
-			}
-			entries := make([]profileEntry, 0, len(names))
-			for _, name := range names {
-				p := app.cfg.Profiles[name]
-				entries = append(entries, profileEntry{
-					Name:        name,
-					Image:       p.Container.Image,
-					Persistent:  p.Container.Persistent,
-					StoragePool: p.Container.StoragePool,
-					Inherits:    p.Inherits,
-					Source:      p.Source,
-				})
-			}
-			jsonData, err := json.MarshalIndent(entries, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to marshal JSON: %v", err)
-			}
-			fmt.Println(string(jsonData))
+			fmt.Println("[]")
 			return nil
 		}
-
-		tbl := NewTable("NAME", "IMAGE", "PERSISTENT", "INHERITS", "SOURCE")
-		for _, name := range names {
-			p := app.cfg.Profiles[name]
-			image := p.Container.Image
-			if image == "" {
-				image = "(default)"
-			}
-			persistent := "-"
-			if p.Container.Persistent != nil {
-				if *p.Container.Persistent {
-					persistent = "true"
-				} else {
-					persistent = "false"
-				}
-			}
-			inherits := "-"
-			if p.Inherits != "" {
-				inherits = p.Inherits
-			}
-			source := p.Source
-			if source == "" {
-				source = "(unknown)"
-			}
-			tbl.AddRow(name, image, persistent, inherits, source)
-		}
-		tbl.Render()
+		fmt.Fprintln(os.Stderr, "No profiles configured.")
 		return nil
-	},
+	}
+
+	// Sort profile names for consistent output
+	names := make([]string, 0, len(a.cfg.Profiles))
+	for name := range a.cfg.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if profileFormat == "json" {
+		type profileEntry struct {
+			Name        string `json:"name"`
+			Image       string `json:"image"`
+			Persistent  *bool  `json:"persistent"`
+			StoragePool string `json:"storage_pool,omitempty"`
+			Inherits    string `json:"inherits,omitempty"`
+			Source      string `json:"source,omitempty"`
+		}
+		entries := make([]profileEntry, 0, len(names))
+		for _, name := range names {
+			p := a.cfg.Profiles[name]
+			entries = append(entries, profileEntry{
+				Name:        name,
+				Image:       p.Container.Image,
+				Persistent:  p.Container.Persistent,
+				StoragePool: p.Container.StoragePool,
+				Inherits:    p.Inherits,
+				Source:      p.Source,
+			})
+		}
+		jsonData, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %v", err)
+		}
+		fmt.Println(string(jsonData))
+		return nil
+	}
+
+	tbl := NewTable("NAME", "IMAGE", "PERSISTENT", "INHERITS", "SOURCE")
+	for _, name := range names {
+		p := a.cfg.Profiles[name]
+		image := p.Container.Image
+		if image == "" {
+			image = "(default)"
+		}
+		persistent := "-"
+		if p.Container.Persistent != nil {
+			if *p.Container.Persistent {
+				persistent = "true"
+			} else {
+				persistent = "false"
+			}
+		}
+		inherits := "-"
+		if p.Inherits != "" {
+			inherits = p.Inherits
+		}
+		source := p.Source
+		if source == "" {
+			source = "(unknown)"
+		}
+		tbl.AddRow(name, image, persistent, inherits, source)
+	}
+	tbl.Render()
+	return nil
 }
 
 // profileInfoCmd shows details of a specific profile
@@ -123,213 +125,215 @@ var profileInfoCmd = &cobra.Command{
 Examples:
   coi profile info rust-dev`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
-		p := app.cfg.GetProfile(name)
-		if p == nil {
-			return fmt.Errorf("profile '%s' not found", name)
-		}
+	RunE: app.profileInfoRunE,
+}
 
-		fmt.Printf("Profile: %s\n", name)
-		if p.Source != "" {
-			fmt.Printf("Source:  %s\n", p.Source)
-		}
+func (a *App) profileInfoRunE(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	p := a.cfg.GetProfile(name)
+	if p == nil {
+		return fmt.Errorf("profile '%s' not found", name)
+	}
+
+	fmt.Printf("Profile: %s\n", name)
+	if p.Source != "" {
+		fmt.Printf("Source:  %s\n", p.Source)
+	}
+	fmt.Println()
+
+	if p.Inherits != "" {
+		fmt.Printf("inherits = %q\n", p.Inherits)
+	}
+	if p.Context != "" {
+		fmt.Printf("context = %q\n", p.Context)
+	}
+	if p.Model != "" {
+		fmt.Printf("model = %q\n", p.Model)
+	}
+	if len(p.ForwardEnv) > 0 {
+		fmt.Printf("forward_env = [%s]\n", formatStringSlice(p.ForwardEnv))
+	}
+
+	if p.Container.HasContainerConfig() {
 		fmt.Println()
+		fmt.Println("[container]")
+		if p.Container.Image != "" {
+			fmt.Printf("image = %q\n", p.Container.Image)
+		}
+		if p.Container.Persistent != nil {
+			fmt.Printf("persistent = %v\n", *p.Container.Persistent)
+		}
+		if p.Container.StoragePool != "" {
+			fmt.Printf("storage_pool = %q\n", p.Container.StoragePool)
+		}
+	}
 
-		if p.Inherits != "" {
-			fmt.Printf("inherits = %q\n", p.Inherits)
+	if len(p.Environment) > 0 {
+		fmt.Println()
+		fmt.Println("[environment]")
+		keys := make([]string, 0, len(p.Environment))
+		for k := range p.Environment {
+			keys = append(keys, k)
 		}
-		if p.Context != "" {
-			fmt.Printf("context = %q\n", p.Context)
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("%s = %q\n", k, p.Environment[k])
 		}
-		if p.Model != "" {
-			fmt.Printf("model = %q\n", p.Model)
-		}
-		if len(p.ForwardEnv) > 0 {
-			fmt.Printf("forward_env = [%s]\n", formatStringSlice(p.ForwardEnv))
-		}
+	}
 
-		if p.Container.HasContainerConfig() {
+	if p.Tool != nil {
+		fmt.Println()
+		fmt.Println("[tool]")
+		if p.Tool.Name != "" {
+			fmt.Printf("name = %q\n", p.Tool.Name)
+		}
+		if p.Tool.Binary != "" {
+			fmt.Printf("binary = %q\n", p.Tool.Binary)
+		}
+		if p.Tool.PermissionMode != "" {
+			fmt.Printf("permission_mode = %q\n", p.Tool.PermissionMode)
+		}
+		if p.Tool.ContextFile != "" {
+			fmt.Printf("context_file = %q\n", p.Tool.ContextFile)
+		}
+		if p.Tool.AutoContext != nil {
+			fmt.Printf("auto_context = %v\n", *p.Tool.AutoContext)
+		}
+		if p.Tool.Claude.EffortLevel != "" {
 			fmt.Println()
-			fmt.Println("[container]")
-			if p.Container.Image != "" {
-				fmt.Printf("image = %q\n", p.Container.Image)
-			}
-			if p.Container.Persistent != nil {
-				fmt.Printf("persistent = %v\n", *p.Container.Persistent)
-			}
-			if p.Container.StoragePool != "" {
-				fmt.Printf("storage_pool = %q\n", p.Container.StoragePool)
-			}
+			fmt.Println("[tool.claude]")
+			fmt.Printf("effort_level = %q\n", p.Tool.Claude.EffortLevel)
 		}
+	}
 
-		if len(p.Environment) > 0 {
+	if p.Container.Build.HasBuildConfig() {
+		fmt.Println()
+		fmt.Println("[container.build]")
+		if p.Container.Build.Base != "" {
+			fmt.Printf("base = %q\n", p.Container.Build.Base)
+		}
+		if p.Container.Build.Script != "" {
+			fmt.Printf("script = %q\n", p.Container.Build.Script)
+		}
+		if len(p.Container.Build.Commands) > 0 {
+			fmt.Printf("commands = [%s]\n", formatStringSlice(p.Container.Build.Commands))
+		}
+	}
+
+	if len(p.Mounts) > 0 {
+		for _, m := range p.Mounts {
 			fmt.Println()
-			fmt.Println("[environment]")
-			keys := make([]string, 0, len(p.Environment))
-			for k := range p.Environment {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				fmt.Printf("%s = %q\n", k, p.Environment[k])
-			}
+			fmt.Println("[[mounts]]")
+			fmt.Printf("host = %q\n", m.Host)
+			fmt.Printf("container = %q\n", m.Container)
 		}
+	}
 
-		if p.Tool != nil {
-			fmt.Println()
-			fmt.Println("[tool]")
-			if p.Tool.Name != "" {
-				fmt.Printf("name = %q\n", p.Tool.Name)
-			}
-			if p.Tool.Binary != "" {
-				fmt.Printf("binary = %q\n", p.Tool.Binary)
-			}
-			if p.Tool.PermissionMode != "" {
-				fmt.Printf("permission_mode = %q\n", p.Tool.PermissionMode)
-			}
-			if p.Tool.ContextFile != "" {
-				fmt.Printf("context_file = %q\n", p.Tool.ContextFile)
-			}
-			if p.Tool.AutoContext != nil {
-				fmt.Printf("auto_context = %v\n", *p.Tool.AutoContext)
-			}
-			if p.Tool.Claude.EffortLevel != "" {
-				fmt.Println()
-				fmt.Println("[tool.claude]")
-				fmt.Printf("effort_level = %q\n", p.Tool.Claude.EffortLevel)
-			}
+	if p.Network != nil {
+		fmt.Println()
+		fmt.Println("[network]")
+		if p.Network.Mode != "" {
+			fmt.Printf("mode = %q\n", string(p.Network.Mode))
 		}
-
-		if p.Container.Build.HasBuildConfig() {
-			fmt.Println()
-			fmt.Println("[container.build]")
-			if p.Container.Build.Base != "" {
-				fmt.Printf("base = %q\n", p.Container.Build.Base)
-			}
-			if p.Container.Build.Script != "" {
-				fmt.Printf("script = %q\n", p.Container.Build.Script)
-			}
-			if len(p.Container.Build.Commands) > 0 {
-				fmt.Printf("commands = [%s]\n", formatStringSlice(p.Container.Build.Commands))
-			}
+		if len(p.Network.AllowedDomains) > 0 {
+			fmt.Printf("allowed_domains = [%s]\n", formatStringSlice(p.Network.AllowedDomains))
 		}
+	}
 
-		if len(p.Mounts) > 0 {
-			for _, m := range p.Mounts {
-				fmt.Println()
-				fmt.Println("[[mounts]]")
-				fmt.Printf("host = %q\n", m.Host)
-				fmt.Printf("container = %q\n", m.Container)
-			}
+	if p.Limits != nil {
+		printLimits(p.Limits)
+	}
+
+	if p.Paths != nil {
+		fmt.Println()
+		fmt.Println("[paths]")
+		if p.Paths.SessionsDir != "" {
+			fmt.Printf("sessions_dir = %q\n", p.Paths.SessionsDir)
 		}
-
-		if p.Network != nil {
-			fmt.Println()
-			fmt.Println("[network]")
-			if p.Network.Mode != "" {
-				fmt.Printf("mode = %q\n", string(p.Network.Mode))
-			}
-			if len(p.Network.AllowedDomains) > 0 {
-				fmt.Printf("allowed_domains = [%s]\n", formatStringSlice(p.Network.AllowedDomains))
-			}
+		if p.Paths.StorageDir != "" {
+			fmt.Printf("storage_dir = %q\n", p.Paths.StorageDir)
 		}
-
-		if p.Limits != nil {
-			printLimits(p.Limits)
+		if p.Paths.LogsDir != "" {
+			fmt.Printf("logs_dir = %q\n", p.Paths.LogsDir)
 		}
-
-		if p.Paths != nil {
-			fmt.Println()
-			fmt.Println("[paths]")
-			if p.Paths.SessionsDir != "" {
-				fmt.Printf("sessions_dir = %q\n", p.Paths.SessionsDir)
-			}
-			if p.Paths.StorageDir != "" {
-				fmt.Printf("storage_dir = %q\n", p.Paths.StorageDir)
-			}
-			if p.Paths.LogsDir != "" {
-				fmt.Printf("logs_dir = %q\n", p.Paths.LogsDir)
-			}
-			if p.Paths.PreserveWorkspacePath {
-				fmt.Println("preserve_workspace_path = true")
-			}
+		if p.Paths.PreserveWorkspacePath {
+			fmt.Println("preserve_workspace_path = true")
 		}
+	}
 
-		if p.Incus != nil {
-			fmt.Println()
-			fmt.Println("[incus]")
-			if p.Incus.Project != "" {
-				fmt.Printf("project = %q\n", p.Incus.Project)
-			}
-			if p.Incus.Group != "" {
-				fmt.Printf("group = %q\n", p.Incus.Group)
-			}
-			if p.Incus.CodeUID != 0 {
-				fmt.Printf("code_uid = %d\n", p.Incus.CodeUID)
-			}
-			if p.Incus.CodeUser != "" {
-				fmt.Printf("code_user = %q\n", p.Incus.CodeUser)
-			}
+	if p.Incus != nil {
+		fmt.Println()
+		fmt.Println("[incus]")
+		if p.Incus.Project != "" {
+			fmt.Printf("project = %q\n", p.Incus.Project)
 		}
-
-		if p.Git != nil {
-			fmt.Println()
-			fmt.Println("[git]")
-			if p.Git.WritableHooks != nil {
-				fmt.Printf("writable_hooks = %v\n", *p.Git.WritableHooks)
-			}
+		if p.Incus.Group != "" {
+			fmt.Printf("group = %q\n", p.Incus.Group)
 		}
-
-		if p.SSH != nil {
-			fmt.Println()
-			fmt.Println("[ssh]")
-			if p.SSH.ForwardAgent != nil {
-				fmt.Printf("forward_agent = %v\n", *p.SSH.ForwardAgent)
-			}
+		if p.Incus.CodeUID != 0 {
+			fmt.Printf("code_uid = %d\n", p.Incus.CodeUID)
 		}
-
-		if p.Security != nil {
-			fmt.Println()
-			fmt.Println("[security]")
-			if len(p.Security.ProtectedPaths) > 0 {
-				fmt.Printf("protected_paths = [%s]\n", formatStringSlice(p.Security.ProtectedPaths))
-			}
-			if len(p.Security.AdditionalProtectedPaths) > 0 {
-				fmt.Printf("additional_protected_paths = [%s]\n", formatStringSlice(p.Security.AdditionalProtectedPaths))
-			}
-			if p.Security.DisableProtection {
-				fmt.Println("disable_protection = true")
-			}
+		if p.Incus.CodeUser != "" {
+			fmt.Printf("code_user = %q\n", p.Incus.CodeUser)
 		}
+	}
 
-		if p.Monitoring != nil {
-			fmt.Println()
-			fmt.Println("[monitoring]")
-			if p.Monitoring.Enabled != nil {
-				fmt.Printf("enabled = %v\n", *p.Monitoring.Enabled)
-			}
-			if p.Monitoring.AutoPauseOnHigh != nil {
-				fmt.Printf("auto_pause_on_high = %v\n", *p.Monitoring.AutoPauseOnHigh)
-			}
-			if p.Monitoring.AutoKillOnCritical != nil {
-				fmt.Printf("auto_kill_on_critical = %v\n", *p.Monitoring.AutoKillOnCritical)
-			}
+	if p.Git != nil {
+		fmt.Println()
+		fmt.Println("[git]")
+		if p.Git.WritableHooks != nil {
+			fmt.Printf("writable_hooks = %v\n", *p.Git.WritableHooks)
 		}
+	}
 
-		if p.Timezone != nil {
-			fmt.Println()
-			fmt.Println("[timezone]")
-			if p.Timezone.Mode != "" {
-				fmt.Printf("mode = %q\n", p.Timezone.Mode)
-			}
-			if p.Timezone.Name != "" {
-				fmt.Printf("name = %q\n", p.Timezone.Name)
-			}
+	if p.SSH != nil {
+		fmt.Println()
+		fmt.Println("[ssh]")
+		if p.SSH.ForwardAgent != nil {
+			fmt.Printf("forward_agent = %v\n", *p.SSH.ForwardAgent)
 		}
+	}
 
-		return nil
-	},
+	if p.Security != nil {
+		fmt.Println()
+		fmt.Println("[security]")
+		if len(p.Security.ProtectedPaths) > 0 {
+			fmt.Printf("protected_paths = [%s]\n", formatStringSlice(p.Security.ProtectedPaths))
+		}
+		if len(p.Security.AdditionalProtectedPaths) > 0 {
+			fmt.Printf("additional_protected_paths = [%s]\n", formatStringSlice(p.Security.AdditionalProtectedPaths))
+		}
+		if p.Security.DisableProtection {
+			fmt.Println("disable_protection = true")
+		}
+	}
+
+	if p.Monitoring != nil {
+		fmt.Println()
+		fmt.Println("[monitoring]")
+		if p.Monitoring.Enabled != nil {
+			fmt.Printf("enabled = %v\n", *p.Monitoring.Enabled)
+		}
+		if p.Monitoring.AutoPauseOnHigh != nil {
+			fmt.Printf("auto_pause_on_high = %v\n", *p.Monitoring.AutoPauseOnHigh)
+		}
+		if p.Monitoring.AutoKillOnCritical != nil {
+			fmt.Printf("auto_kill_on_critical = %v\n", *p.Monitoring.AutoKillOnCritical)
+		}
+	}
+
+	if p.Timezone != nil {
+		fmt.Println()
+		fmt.Println("[timezone]")
+		if p.Timezone.Mode != "" {
+			fmt.Printf("mode = %q\n", p.Timezone.Mode)
+		}
+		if p.Timezone.Name != "" {
+			fmt.Printf("name = %q\n", p.Timezone.Name)
+		}
+	}
+
+	return nil
 }
 
 // shellQuote wraps a string in single quotes for safe shell interpolation.
@@ -403,12 +407,12 @@ var profileShowCmd = &cobra.Command{
 	Short:  profileInfoCmd.Short,
 	Long:   profileInfoCmd.Long,
 	Args:   profileInfoCmd.Args,
-	RunE:   profileInfoCmd.RunE,
+	RunE:   app.profileInfoRunE,
 	Hidden: true,
 }
 
 // resolveProfileDir determines the target directory for a new profile.
-func resolveProfileDir(name string, forceUser, forceProject bool) (string, error) {
+func (a *App) resolveProfileDir(name string, forceUser, forceProject bool) (string, error) {
 	if forceUser {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -418,7 +422,7 @@ func resolveProfileDir(name string, forceUser, forceProject bool) (string, error
 	}
 
 	if forceProject {
-		absWorkspace, err := filepath.Abs(app.workspace)
+		absWorkspace, err := filepath.Abs(a.workspace)
 		if err != nil {
 			return "", fmt.Errorf("cannot resolve workspace: %w", err)
 		}
@@ -426,7 +430,7 @@ func resolveProfileDir(name string, forceUser, forceProject bool) (string, error
 	}
 
 	// Default: project if .coi/ exists, otherwise user home
-	absWorkspace, err := filepath.Abs(app.workspace)
+	absWorkspace, err := filepath.Abs(a.workspace)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve workspace: %w", err)
 	}
@@ -460,86 +464,88 @@ Examples:
   coi profile create rust-dev --image coi-rust --inherits default
   coi profile create my-profile --persistent --project`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+	RunE: app.profileCreateRunE,
+}
 
-		// Validate name
-		if name == "" {
-			return fmt.Errorf("profile name cannot be empty")
-		}
-		if strings.Contains(name, "/") || strings.Contains(name, "\\") {
-			return fmt.Errorf("profile name cannot contain slashes")
-		}
-		if strings.Trim(name, ".") == "" {
-			return fmt.Errorf("profile name cannot be '.', '..', or consist only of dots")
-		}
-		if name == "default" {
-			return fmt.Errorf("cannot create a profile named 'default' (reserved for built-in profile)")
-		}
+func (a *App) profileCreateRunE(cmd *cobra.Command, args []string) error {
+	name := args[0]
 
-		forceUser, _ := cmd.Flags().GetBool("user")
-		forceProject, _ := cmd.Flags().GetBool("project")
-		if forceUser && forceProject {
-			return fmt.Errorf("--user and --project are mutually exclusive")
-		}
+	// Validate name
+	if name == "" {
+		return fmt.Errorf("profile name cannot be empty")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("profile name cannot contain slashes")
+	}
+	if strings.Trim(name, ".") == "" {
+		return fmt.Errorf("profile name cannot be '.', '..', or consist only of dots")
+	}
+	if name == "default" {
+		return fmt.Errorf("cannot create a profile named 'default' (reserved for built-in profile)")
+	}
 
-		// Check if a profile with this name already exists in any config source
-		if existing := app.cfg.GetProfile(name); existing != nil {
-			return fmt.Errorf("profile '%s' already exists (source: %s)", name, existing.Source)
-		}
+	forceUser, _ := cmd.Flags().GetBool("user")
+	forceProject, _ := cmd.Flags().GetBool("project")
+	if forceUser && forceProject {
+		return fmt.Errorf("--user and --project are mutually exclusive")
+	}
 
-		profileDir, err := resolveProfileDir(name, forceUser, forceProject)
-		if err != nil {
-			return err
-		}
+	// Check if a profile with this name already exists in any config source
+	if existing := a.cfg.GetProfile(name); existing != nil {
+		return fmt.Errorf("profile '%s' already exists (source: %s)", name, existing.Source)
+	}
 
-		// Check directory doesn't already exist on disk
-		if _, statErr := os.Stat(profileDir); statErr == nil {
-			return fmt.Errorf("profile directory already exists: %s", profileDir)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("failed to check profile directory %s: %w", profileDir, statErr)
-		}
+	profileDir, err := a.resolveProfileDir(name, forceUser, forceProject)
+	if err != nil {
+		return err
+	}
 
-		// Build TOML content from flags
-		// Note: --image and --persistent are inherited from root PersistentFlags
-		var topLines []string
-		var containerLines []string
-		if inherits, _ := cmd.Flags().GetString("inherits"); inherits != "" {
-			topLines = append(topLines, fmt.Sprintf("inherits = %q", inherits))
-		}
-		if cmd.Flags().Changed("image") {
-			containerLines = append(containerLines, fmt.Sprintf("image = %q", app.imageName))
-		}
-		if cmd.Flags().Changed("persistent") {
-			containerLines = append(containerLines, "persistent = true")
-		}
+	// Check directory doesn't already exist on disk
+	if _, statErr := os.Stat(profileDir); statErr == nil {
+		return fmt.Errorf("profile directory already exists: %s", profileDir)
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("failed to check profile directory %s: %w", profileDir, statErr)
+	}
 
-		var content string
-		if len(topLines) > 0 {
-			content += strings.Join(topLines, "\n") + "\n"
-		}
-		if len(containerLines) > 0 {
-			if content != "" {
-				content += "\n"
-			}
-			content += "[container]\n" + strings.Join(containerLines, "\n") + "\n"
-		}
+	// Build TOML content from flags
+	// Note: --image and --persistent are inherited from root PersistentFlags
+	var topLines []string
+	var containerLines []string
+	if inherits, _ := cmd.Flags().GetString("inherits"); inherits != "" {
+		topLines = append(topLines, fmt.Sprintf("inherits = %q", inherits))
+	}
+	if cmd.Flags().Changed("image") {
+		containerLines = append(containerLines, fmt.Sprintf("image = %q", a.imageName))
+	}
+	if cmd.Flags().Changed("persistent") {
+		containerLines = append(containerLines, "persistent = true")
+	}
 
-		// Create directory and write config
-		if err := os.MkdirAll(profileDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create profile directory: %w", err)
+	var content string
+	if len(topLines) > 0 {
+		content += strings.Join(topLines, "\n") + "\n"
+	}
+	if len(containerLines) > 0 {
+		if content != "" {
+			content += "\n"
 		}
+		content += "[container]\n" + strings.Join(containerLines, "\n") + "\n"
+	}
 
-		configPath := filepath.Join(profileDir, "config.toml")
-		if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
-			// Clean up directory on write failure
-			os.RemoveAll(profileDir)
-			return fmt.Errorf("failed to write config.toml: %w", err)
-		}
+	// Create directory and write config
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create profile directory: %w", err)
+	}
 
-		fmt.Fprintf(os.Stderr, "Created profile '%s' at %s\n", name, configPath)
-		return nil
-	},
+	configPath := filepath.Join(profileDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		// Clean up directory on write failure
+		os.RemoveAll(profileDir)
+		return fmt.Errorf("failed to write config.toml: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Created profile '%s' at %s\n", name, configPath)
+	return nil
 }
 
 // profileEditCmd opens a profile's config in an editor
@@ -555,50 +561,52 @@ Examples:
   coi profile edit rust-dev
   EDITOR=nano coi profile edit my-profile`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+	RunE: app.profileEditRunE,
+}
 
-		p := app.cfg.GetProfile(name)
-		if p == nil {
-			return fmt.Errorf("profile '%s' not found", name)
-		}
-		if p.Source == "(built-in)" {
-			return fmt.Errorf("cannot edit built-in profile 'default'")
-		}
+func (a *App) profileEditRunE(cmd *cobra.Command, args []string) error {
+	name := args[0]
 
-		sourcePath := p.Source
+	p := a.cfg.GetProfile(name)
+	if p == nil {
+		return fmt.Errorf("profile '%s' not found", name)
+	}
+	if p.Source == "(built-in)" {
+		return fmt.Errorf("cannot edit built-in profile 'default'")
+	}
 
-		// Determine editor
-		editor := os.Getenv("VISUAL")
-		if editor == "" {
-			editor = os.Getenv("EDITOR")
-		}
-		if editor == "" {
-			editor = "vi"
-		}
+	sourcePath := p.Source
 
-		// Use sh -c to support multi-word editor values like "code --wait"
-		editorCmd := exec.Command("sh", "-c", editor+" "+shellQuote(sourcePath))
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
+	// Determine editor
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		editor = "vi"
+	}
 
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor exited with error: %w", err)
-		}
+	// Use sh -c to support multi-word editor values like "code --wait"
+	editorCmd := exec.Command("sh", "-c", editor+" "+shellQuote(sourcePath))
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
 
-		// Re-parse and validate
-		var profileCfg config.ProfileConfig
-		if _, err := toml.DecodeFile(sourcePath, &profileCfg); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %s contains invalid TOML: %v\n", sourcePath, err)
-			return nil
-		}
-		if err := profileCfg.Validate(name); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: profile validation failed: %v\n", err)
-		}
+	if err := editorCmd.Run(); err != nil {
+		return fmt.Errorf("editor exited with error: %w", err)
+	}
 
+	// Re-parse and validate
+	var profileCfg config.ProfileConfig
+	if _, err := toml.DecodeFile(sourcePath, &profileCfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %s contains invalid TOML: %v\n", sourcePath, err)
 		return nil
-	},
+	}
+	if err := profileCfg.Validate(name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: profile validation failed: %v\n", err)
+	}
+
+	return nil
 }
 
 // profileDeleteCmd deletes a profile directory
@@ -613,35 +621,37 @@ Examples:
   coi profile delete rust-dev
   coi profile delete old-profile --force`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+	RunE: app.profileDeleteRunE,
+}
 
-		p := app.cfg.GetProfile(name)
-		if p == nil {
-			return fmt.Errorf("profile '%s' not found", name)
+func (a *App) profileDeleteRunE(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	p := a.cfg.GetProfile(name)
+	if p == nil {
+		return fmt.Errorf("profile '%s' not found", name)
+	}
+	if p.Source == "(built-in)" {
+		return fmt.Errorf("cannot delete built-in profile 'default'")
+	}
+
+	profileDir := filepath.Dir(p.Source)
+	force, _ := cmd.Flags().GetBool("force")
+
+	if !force {
+		fmt.Fprintf(os.Stderr, "This will delete profile '%s' at %s\n", name, profileDir)
+		if !confirmAction("Continue?") {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
 		}
-		if p.Source == "(built-in)" {
-			return fmt.Errorf("cannot delete built-in profile 'default'")
-		}
+	}
 
-		profileDir := filepath.Dir(p.Source)
-		force, _ := cmd.Flags().GetBool("force")
+	if err := os.RemoveAll(profileDir); err != nil {
+		return fmt.Errorf("failed to delete profile directory: %w", err)
+	}
 
-		if !force {
-			fmt.Fprintf(os.Stderr, "This will delete profile '%s' at %s\n", name, profileDir)
-			if !confirmAction("Continue?") {
-				fmt.Fprintln(os.Stderr, "Aborted.")
-				return nil
-			}
-		}
-
-		if err := os.RemoveAll(profileDir); err != nil {
-			return fmt.Errorf("failed to delete profile directory: %w", err)
-		}
-
-		fmt.Fprintf(os.Stderr, "Deleted profile '%s' (%s)\n", name, profileDir)
-		return nil
-	},
+	fmt.Fprintf(os.Stderr, "Deleted profile '%s' (%s)\n", name, profileDir)
+	return nil
 }
 
 func init() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -30,12 +30,12 @@ Examples:
   coi run --workspace ~/project "make build"
 `,
 	Args: cobra.MinimumNArgs(1),
-	RunE: runCommand,
+	RunE: app.runCommand,
 }
 
-func runCommand(cmd *cobra.Command, args []string) error {
+func (a *App) runCommand(cmd *cobra.Command, args []string) error {
 	// Get absolute workspace path
-	absWorkspace, err := filepath.Abs(app.workspace)
+	absWorkspace, err := filepath.Abs(a.workspace)
 	if err != nil {
 		return fmt.Errorf("invalid workspace path: %w", err)
 	}
@@ -44,13 +44,13 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// process CWD. config.Load() already loads <CWD>/.coi/config.toml via
 	// GetConfigPaths, so we only need to overlay when the user pointed --workspace
 	// at a different directory to avoid loading the same file twice.
-	if err := overlayWorkspaceConfig(absWorkspace); err != nil {
+	if err := a.overlayWorkspaceConfig(absWorkspace); err != nil {
 		return err
 	}
 
 	// Validate max_duration early so the user gets a clear error before any container work.
-	if app.cfg.Limits.Runtime.MaxDuration != "" {
-		if _, err := limits.ParseDuration(app.cfg.Limits.Runtime.MaxDuration); err != nil {
+	if a.cfg.Limits.Runtime.MaxDuration != "" {
+		if _, err := limits.ParseDuration(a.cfg.Limits.Runtime.MaxDuration); err != nil {
 			return fmt.Errorf("invalid max_duration: %w", err)
 		}
 	}
@@ -71,7 +71,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Allocate slot if not specified
-	slotNum := app.slot
+	slotNum := a.slot
 	if slotNum == 0 {
 		slotNum, err = session.AllocateSlot(absWorkspace, 10)
 		if err != nil {
@@ -84,25 +84,25 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	containerName := session.ContainerName(absWorkspace, slotNum)
 
 	// Determine image: CLI --image flag > config defaults.image > "coi-default"
-	img := ResolveImageName(app.imageName, app.cfg)
+	img := ResolveImageName(a.imageName, a.cfg)
 
 	// Check if image exists, auto-build from config if possible
-	if err := AutoBuildIfNeeded(app.cfg, img); err != nil {
+	if err := AutoBuildIfNeeded(a.cfg, img); err != nil {
 		return err
 	}
-	if err := CheckAndReportStaleBase(app.cfg, img); err != nil {
+	if err := CheckAndReportStaleBase(a.cfg, img); err != nil {
 		return err
 	}
 
 	// Validate the storage pool exists before doing any container work so the
 	// user gets an actionable "create with `incus storage create`" error
 	// instead of a cryptic Incus failure midway through launch.
-	if err := container.ValidateStoragePool(app.cfg.Container.StoragePool); err != nil {
+	if err := container.ValidateStoragePool(a.cfg.Container.StoragePool); err != nil {
 		return err
 	}
 
 	// Validate and prepare alias if configured
-	effectiveAlias, err := validateAndPrepareAlias(app.cfg.Container.Alias)
+	effectiveAlias, err := validateAndPrepareAlias(a.cfg.Container.Alias)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to check if container exists: %w", err)
 	}
 
-	if err := launchOrReuseContainer(mgr, img, app.cfg.Container.StoragePool, containerExists, app.persistent); err != nil {
+	if err := launchOrReuseContainer(mgr, img, a.cfg.Container.StoragePool, containerExists, a.persistent); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 
 	// 1. Container (registered first → executes last in LIFO)
 	pipeline.AddTeardown(func() {
-		if !app.persistent {
+		if !a.persistent {
 			fmt.Fprintf(os.Stderr, "Cleaning up container %s...\n", containerName)
 			_ = mgr.Delete(true)
 		} else {
@@ -170,9 +170,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	})
 
 	// Apply resource limits (only for new containers, not restarted persistent ones)
-	wasRestarted := containerExists && app.persistent
+	wasRestarted := containerExists && a.persistent
 	if !wasRestarted {
-		limitsConfig := &app.cfg.Limits
+		limitsConfig := &a.cfg.Limits
 		if limitsConfig != nil && hasAnyLimits(limitsConfig) {
 			fmt.Fprintf(os.Stderr, "Applying resource limits...\n")
 			applyOpts := limits.ApplyOptions{
@@ -196,7 +196,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 				Runtime: limits.RuntimeLimits{
 					MaxProcesses: limitsConfig.Runtime.MaxProcesses,
 				},
-				Project: app.cfg.Incus.Project,
+				Project: a.cfg.Incus.Project,
 			}
 			if err := limits.ApplyResourceLimits(applyOpts); err != nil {
 				return fmt.Errorf("failed to apply resource limits: %w", err)
@@ -224,26 +224,26 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Determine container workspace path (respects preserve_workspace_path config)
-	containerWorkspacePath := resolveContainerWorkspacePath(absWorkspace)
+	containerWorkspacePath := a.resolveContainerWorkspacePath(absWorkspace)
 
 	// Mount workspace (skip if restarting existing persistent container)
-	useShift := !app.cfg.Incus.DisableShift
-	if err := applyWorkspaceMounts(mgr, containerName, absWorkspace, &containerWorkspacePath, useShift, wasRestarted); err != nil {
+	useShift := !a.cfg.Incus.DisableShift
+	if err := a.applyWorkspaceMounts(mgr, containerName, absWorkspace, &containerWorkspacePath, useShift, wasRestarted); err != nil {
 		return err
 	}
 
 	// Forward SSH agent and apply network isolation if configured
-	sshAgentSocketPath, err := applySSHAgentForwarding(mgr, containerName)
+	sshAgentSocketPath, err := a.applySSHAgentForwarding(mgr, containerName)
 	if err != nil {
 		return err
 	}
-	networkMgr, err = applyNetworkIsolation(containerName)
+	networkMgr, err = a.applyNetworkIsolation(containerName)
 	if err != nil {
 		return err
 	}
 
 	// Configure timezone in container filesystem
-	tz := applyContainerTimezone(mgr)
+	tz := a.applyContainerTimezone(mgr)
 
 	// Auto-trust mise config files in the workspace
 	session.SetupMiseTrust(mgr, containerWorkspacePath, func(msg string) {
@@ -254,15 +254,15 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// The monitor runs in a background goroutine and stops the container when
 	// the duration elapses, which causes the blocking incus exec below to return.
 	var timeoutMon *limits.TimeoutMonitor
-	if app.cfg.Limits.Runtime.MaxDuration != "" {
-		maxDur, _ := limits.ParseDuration(app.cfg.Limits.Runtime.MaxDuration) // already validated above
-		autoStop := config.BoolVal(app.cfg.Limits.Runtime.AutoStop)
-		if app.cfg.Limits.Runtime.AutoStop == nil {
+	if a.cfg.Limits.Runtime.MaxDuration != "" {
+		maxDur, _ := limits.ParseDuration(a.cfg.Limits.Runtime.MaxDuration) // already validated above
+		autoStop := config.BoolVal(a.cfg.Limits.Runtime.AutoStop)
+		if a.cfg.Limits.Runtime.AutoStop == nil {
 			autoStop = true // default: auto-stop when limit reached
 		}
-		stopGraceful := config.BoolVal(app.cfg.Limits.Runtime.StopGraceful)
+		stopGraceful := config.BoolVal(a.cfg.Limits.Runtime.StopGraceful)
 		runLog := logger.NewDiscard()
-		timeoutMon = limits.NewTimeoutMonitor(cmd.Context(), containerName, maxDur, autoStop, stopGraceful, app.cfg.Incus.Project, runLog)
+		timeoutMon = limits.NewTimeoutMonitor(cmd.Context(), containerName, maxDur, autoStop, stopGraceful, a.cfg.Incus.Project, runLog)
 		timeoutMon.Start()
 		defer timeoutMon.Stop()
 	}
@@ -277,7 +277,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add all environment variables (timezone, config, forward_env)
-	incusArgs = appendEnvArgs(incusArgs, tz, sshAgentSocketPath)
+	incusArgs = a.appendEnvArgs(incusArgs, tz, sshAgentSocketPath)
 
 	incusArgs = append(incusArgs, "--")
 	incusArgs = append(incusArgs, args...)
@@ -399,7 +399,7 @@ func remapContainerUserIfNeeded(mgr container.ContainerManager, wasRestarted boo
 // to an incus exec args slice.
 // tz is the resolved timezone name (may be empty).
 // sshAgentSocketPath is the container-side SSH agent socket (may be empty).
-func appendEnvArgs(incusArgs []string, tz, sshAgentSocketPath string) []string {
+func (a *App) appendEnvArgs(incusArgs []string, tz, sshAgentSocketPath string) []string {
 	// Timezone (lowest priority — user can override with config env)
 	if tz != "" {
 		incusArgs = append(incusArgs, "--env", fmt.Sprintf("TZ=%s", tz))
@@ -411,12 +411,12 @@ func appendEnvArgs(incusArgs []string, tz, sshAgentSocketPath string) []string {
 	}
 
 	// Static environment from config (defaults.environment + profile environment)
-	for k, v := range app.cfg.Defaults.Environment {
+	for k, v := range a.cfg.Defaults.Environment {
 		incusArgs = append(incusArgs, "--env", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	// Resolve forward_env from config, look up host values
-	for _, name := range app.cfg.Defaults.ForwardEnv {
+	for _, name := range a.cfg.Defaults.ForwardEnv {
 		if val, ok := os.LookupEnv(name); ok {
 			incusArgs = append(incusArgs, "--env", fmt.Sprintf("%s=%s", name, val))
 		} else {
@@ -505,7 +505,7 @@ func applyContainerAlias(effectiveAlias, containerName, absWorkspace string) err
 // the global config when --workspace points to a directory other than the CWD.
 // config.Load() already loads <CWD>/.coi/config.toml, so skipping the overlay
 // when they match avoids doubling entries like AdditionalProtectedPaths.
-func overlayWorkspaceConfig(absWorkspace string) error {
+func (a *App) overlayWorkspaceConfig(absWorkspace string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -517,18 +517,18 @@ func overlayWorkspaceConfig(absWorkspace string) error {
 	if absWorkspace == absCWD {
 		return nil
 	}
-	if err := app.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
+	if err := a.cfg.OverlayProjectConfig(absWorkspace); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to load project config from %s: %w", absWorkspace, err)
 	}
-	container.Configure(app.cfg.Incus.Project, app.cfg.Incus.CodeUser, app.cfg.Incus.CodeUID)
+	container.Configure(a.cfg.Incus.Project, a.cfg.Incus.CodeUser, a.cfg.Incus.CodeUID)
 	return nil
 }
 
 // resolveContainerWorkspacePath returns the path inside the container where the
 // workspace should be mounted. When preserve_workspace_path is set it mirrors
 // the host path, falling back to /workspace if the path conflicts with system dirs.
-func resolveContainerWorkspacePath(absWorkspace string) string {
-	if !app.cfg.Paths.PreserveWorkspacePath {
+func (a *App) resolveContainerWorkspacePath(absWorkspace string) string {
+	if !a.cfg.Paths.PreserveWorkspacePath {
 		return "/workspace"
 	}
 	cleanPath := filepath.Clean(absWorkspace)
@@ -547,7 +547,7 @@ func resolveContainerWorkspacePath(absWorkspace string) string {
 // applyWorkspaceMounts mounts the workspace and all configured additional directories
 // into the container, then applies security (read-only) mounts. For restarted persistent
 // containers it retrieves the existing workspace path from the container config instead.
-func applyWorkspaceMounts(mgr container.ContainerManager, containerName, absWorkspace string, containerWorkspacePath *string, useShift, wasRestarted bool) error {
+func (a *App) applyWorkspaceMounts(mgr container.ContainerManager, containerName, absWorkspace string, containerWorkspacePath *string, useShift, wasRestarted bool) error {
 	if wasRestarted {
 		fmt.Fprintf(os.Stderr, "Reusing existing workspace mount...\n")
 		*containerWorkspacePath = mgr.GetWorkspacePath()
@@ -563,7 +563,7 @@ func applyWorkspaceMounts(mgr container.ContainerManager, containerName, absWork
 		return fmt.Errorf("failed to mount workspace: %w", err)
 	}
 
-	mountConfig, err := ParseMountConfig(app.cfg)
+	mountConfig, err := ParseMountConfig(a.cfg)
 	if err != nil {
 		return fmt.Errorf("invalid mount configuration: %w", err)
 	}
@@ -578,8 +578,8 @@ func applyWorkspaceMounts(mgr container.ContainerManager, containerName, absWork
 		}
 	}
 
-	if !app.cfg.Security.DisableProtection {
-		if err := applySecurityMounts(mgr, absWorkspace, *containerWorkspacePath, containerName, useShift); err != nil {
+	if !a.cfg.Security.DisableProtection {
+		if err := a.applySecurityMounts(mgr, absWorkspace, *containerWorkspacePath, containerName, useShift); err != nil {
 			return err
 		}
 	}
@@ -610,8 +610,8 @@ func addMount(mgr container.ContainerManager, mount session.MountEntry, useShift
 }
 
 // applySecurityMounts sets up read-only protection mounts and optional host immutable flags.
-func applySecurityMounts(mgr container.ContainerManager, absWorkspace, containerWorkspacePath, containerName string, useShift bool) error {
-	protectedPaths := filterWritableGitHooks(app.cfg.Security.GetEffectiveProtectedPaths(), app.cfg)
+func (a *App) applySecurityMounts(mgr container.ContainerManager, absWorkspace, containerWorkspacePath, containerName string, useShift bool) error {
+	protectedPaths := filterWritableGitHooks(a.cfg.Security.GetEffectiveProtectedPaths(), a.cfg)
 	if len(protectedPaths) == 0 {
 		return nil
 	}
@@ -623,7 +623,7 @@ func applySecurityMounts(mgr container.ContainerManager, absWorkspace, container
 			fmt.Fprintf(os.Stderr, "Protected paths (mounted read-only): %s\n", strings.Join(actualPaths, ", "))
 		}
 	}
-	if app.cfg.Security.IsHostImmutableEnabled() {
+	if a.cfg.Security.IsHostImmutableEnabled() {
 		logFn := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
 		immutablePaths := session.ApplyImmutable(absWorkspace, protectedPaths, containerName, logFn)
 		if len(immutablePaths) > 0 {
@@ -635,8 +635,8 @@ func applySecurityMounts(mgr container.ContainerManager, absWorkspace, container
 
 // applySSHAgentForwarding forwards the host SSH agent into the container when
 // ssh.forward_agent is true in config. Returns the container-side socket path.
-func applySSHAgentForwarding(mgr container.ContainerManager, containerName string) (string, error) {
-	if !config.BoolVal(app.cfg.SSH.ForwardAgent) {
+func (a *App) applySSHAgentForwarding(mgr container.ContainerManager, containerName string) (string, error) {
+	if !config.BoolVal(a.cfg.SSH.ForwardAgent) {
 		return "", nil
 	}
 	logger := func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) }
@@ -654,8 +654,8 @@ func applySSHAgentForwarding(mgr container.ContainerManager, containerName strin
 // applyNetworkIsolation installs firewall rules for the container when
 // network.mode is set to something other than "open" in config.
 // Returns the Manager so the caller can Teardown before container deletion.
-func applyNetworkIsolation(containerName string) (*network.Manager, error) {
-	networkConfig := app.cfg.Network
+func (a *App) applyNetworkIsolation(containerName string) (*network.Manager, error) {
+	networkConfig := a.cfg.Network
 	if networkConfig.Mode == "" || networkConfig.Mode == config.NetworkModeOpen {
 		return nil, nil
 	}
@@ -674,8 +674,8 @@ func applyNetworkIsolation(containerName string) (*network.Manager, error) {
 
 // applyContainerTimezone resolves the timezone and configures it inside the container.
 // Returns the resolved timezone name (empty for UTC).
-func applyContainerTimezone(mgr container.ContainerManager) string {
-	tz := resolveTimezone(app.cfg)
+func (a *App) applyContainerTimezone(mgr container.ContainerManager) string {
+	tz := resolveTimezone(a.cfg)
 	if tz != "" {
 		tzCmd := fmt.Sprintf(
 			"ln -sf /usr/share/zoneinfo/%s /etc/localtime && echo %s > /etc/timezone",

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -65,7 +65,7 @@ Examples:
   coi shell --debug                 # Launch bash for debugging
 `,
 	Args: cobra.MaximumNArgs(1),
-	RunE: shellCommand,
+	RunE: app.shellCommand,
 }
 
 func init() {
@@ -76,7 +76,7 @@ func init() {
 	shellCmd.Flags().StringVar(&toolFlag, "tool", "", "Override AI tool (e.g. claude, opencode, aider)")
 }
 
-func shellCommand(cmd *cobra.Command, args []string) error {
+func (a *App) shellCommand(cmd *cobra.Command, args []string) error {
 	// Create a context that is cancelled on SIGINT/SIGTERM so session.Setup
 	// can abort container provisioning on Ctrl+C instead of leaving orphaned
 	// containers.
@@ -120,12 +120,12 @@ func shellCommand(cmd *cobra.Command, args []string) error {
 	}()
 
 	return pipeline.Run(ctx,
-		resolveWorkspacePhase(cmd, s),
-		validateEnvPhase(cmd, s),
-		configureSessionPhase(cmd, s),
-		setupContainerPhase(s),
-		startMonitoringPhase(s),
-		runToolPhase(s),
+		a.resolveWorkspacePhase(cmd, s),
+		a.validateEnvPhase(cmd, s),
+		a.configureSessionPhase(cmd, s),
+		a.setupContainerPhase(s),
+		a.startMonitoringPhase(s),
+		a.runToolPhase(s),
 	)
 }
 
@@ -200,7 +200,7 @@ func buildCLICommand(sessionID string, useResumeFlag, restoreOnly bool, sessions
 
 // buildContainerEnv constructs the environment variables map and user pointer for container execution.
 // It sets HOME, TERM (sanitized), IS_SANDBOX, merges config environment, and resolves forward_env from config.
-func buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
+func (a *App) buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
 	user := container.CodeUID
 	if result.RunAsRoot {
 		user = 0
@@ -224,12 +224,12 @@ func buildContainerEnv(result *session.SetupResult) (map[string]string, *int) {
 	}
 
 	// Apply static environment from config (defaults.environment + profile environment)
-	for k, v := range app.cfg.Defaults.Environment {
+	for k, v := range a.cfg.Defaults.Environment {
 		containerEnv[k] = v
 	}
 
 	// Resolve forward_env from config, deduplicate, then look up host values
-	for _, name := range app.cfg.Defaults.ForwardEnv {
+	for _, name := range a.cfg.Defaults.ForwardEnv {
 		if val, ok := os.LookupEnv(name); ok {
 			containerEnv[name] = val
 		} else {
@@ -288,9 +288,9 @@ func mergeToolEnv(env map[string]string, t tool.Tool, workspacePath string) {
 }
 
 // runCLI executes the CLI tool in the container interactively
-func runCLI(result *session.SetupResult, sessionID string, useResumeFlag, restoreOnly bool, sessionsDir, resumeID string, t tool.Tool) error {
+func (a *App) runCLI(result *session.SetupResult, sessionID string, useResumeFlag, restoreOnly bool, sessionsDir, resumeID string, t tool.Tool) error {
 	cmdToRun := buildCLICommand(sessionID, useResumeFlag, restoreOnly, sessionsDir, resumeID, t)
-	containerEnv, userPtr := buildContainerEnv(result)
+	containerEnv, userPtr := a.buildContainerEnv(result)
 
 	workspacePath := result.ContainerWorkspacePath
 	if workspacePath == "" {
@@ -357,7 +357,7 @@ func buildTmuxSetEnvironmentCmds(sessionName string, env map[string]string) []st
 }
 
 // runCLIInTmux executes CLI tool in a tmux session for background/monitoring support
-func runCLIInTmux(result *session.SetupResult, sessionID string, detached bool, useResumeFlag, restoreOnly bool, sessionsDir, resumeID string, t tool.Tool) error {
+func (a *App) runCLIInTmux(result *session.SetupResult, sessionID string, detached bool, useResumeFlag, restoreOnly bool, sessionsDir, resumeID string, t tool.Tool) error {
 	tmuxSessionName := fmt.Sprintf("coi-%s", result.ContainerName)
 
 	// Get workspace path (with fallback for backwards compatibility)
@@ -367,7 +367,7 @@ func runCLIInTmux(result *session.SetupResult, sessionID string, detached bool, 
 	}
 
 	cliCmd := buildCLICommand(sessionID, useResumeFlag, restoreOnly, sessionsDir, resumeID, t)
-	containerEnv, userPtr := buildContainerEnv(result)
+	containerEnv, userPtr := a.buildContainerEnv(result)
 	mergeToolEnv(containerEnv, t, workspacePath)
 
 	// Ensure tmux server is running first (critical for CI and new containers)
@@ -526,7 +526,7 @@ func detectHostTimezone() string {
 }
 
 // startMonitoringDaemon starts the background monitoring daemon
-func startMonitoringDaemon(ctx context.Context, containerName, workspacePath string, cfg *config.Config, log *logger.SessionLogger, daemon **monitor.Daemon) error {
+func startMonitoringDaemon(ctx context.Context, containerName, workspacePath string, cfg *config.Config, log *logger.SessionLogger, daemon *monitor.MonitorDaemon) error {
 	// Get home directory for audit log
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -580,7 +580,7 @@ func startMonitoringDaemon(ctx context.Context, containerName, workspacePath str
 }
 
 // startNFTMonitoringDaemon starts the nftables network monitoring daemon
-func startNFTMonitoringDaemon(ctx context.Context, containerName string, cfg *config.Config, log *logger.SessionLogger, daemon **nftmonitor.Daemon) error {
+func startNFTMonitoringDaemon(ctx context.Context, containerName string, cfg *config.Config, log *logger.SessionLogger, daemon *nftmonitor.NFTMonitorDaemon) error {
 	// Get container IP
 	containerIP, err := network.GetContainerIPWithRetries(containerName, 3)
 	if err != nil {

--- a/internal/monitor/interfaces.go
+++ b/internal/monitor/interfaces.go
@@ -1,0 +1,11 @@
+package monitor
+
+// MonitorDaemon is the interface implemented by *Daemon.
+// Callers should accept this interface rather than the concrete *Daemon type
+// so they can substitute a no-op stub in tests.
+type MonitorDaemon interface {
+	Stop() error
+}
+
+// Compile-time assertion: *Daemon must satisfy MonitorDaemon.
+var _ MonitorDaemon = (*Daemon)(nil)

--- a/internal/nftmonitor/interfaces.go
+++ b/internal/nftmonitor/interfaces.go
@@ -1,0 +1,11 @@
+package nftmonitor
+
+// NFTMonitorDaemon is the interface implemented by *Daemon.
+// Callers should accept this interface rather than the concrete *Daemon type
+// so they can substitute a no-op stub in tests.
+type NFTMonitorDaemon interface {
+	Stop() error
+}
+
+// Compile-time assertion: *Daemon must satisfy NFTMonitorDaemon.
+var _ NFTMonitorDaemon = (*Daemon)(nil)


### PR DESCRIPTION
## Summary

Closes Issues 2 and 3 from the architecture backlog (REF.md).

**Issue 2 — Global mutable state makes commands untestable**

- All CLI command handlers (`shellCommand`, `runCommand`, `buildCommand`, `cleanCommand`, `monitorCommand`, `attachCommand`, and all profile sub-commands) converted from free functions into methods on `*App`
- All shell pipeline phase builder functions in `phases_shell.go` likewise converted to `*App` methods
- `app.xxx` references inside those functions replaced with `a.xxx` (method receiver)
- `RunE` registrations updated to method values: `RunE: app.shellCommand`, etc.
- A test can now construct `&App{cfg: testCfg, workspace: "/tmp/ws"}` and call `a.shellCommand(cmd, args)` without touching the global singleton

**Issue 3 — No interfaces at subsystem boundaries**

- `monitor.MonitorDaemon` interface (`Stop() error`) added in `internal/monitor/interfaces.go`
- `nftmonitor.NFTMonitorDaemon` interface (`Stop() error`) added in `internal/nftmonitor/interfaces.go`
- Compile-time assertions verify `*Daemon` satisfies each interface
- `shellState.monitorDaemon` and `shellState.nftDaemon` fields changed from concrete pointer types to their respective interfaces
- `startMonitoringDaemon` and `startNFTMonitoringDaemon` signatures updated to accept `*monitor.MonitorDaemon` / `*nftmonitor.NFTMonitorDaemon`
- Completes four-boundary coverage alongside the already-present `container.ContainerManager`, `network.NetworkManager`, and `limits.LimitsApplier` interfaces

## Test plan

- [ ] `go build ./...` — no errors
- [ ] `go test ./...` — all existing tests pass
- [ ] CI integration tests pass