### PR TITLE
fix(session): use encoding/json for metadata save and load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.0 (Unreleased)
 
+### Bug Fixes
+
+- **Session metadata no longer corrupts on paths or profile names with special characters** — `saveMetadata` previously used `fmt.Sprintf` to hand-build a JSON string, leaving field values unescaped. A workspace path containing a double-quote, backslash, or newline would produce malformed JSON, breaking `coi list` (which reads metadata to show session status) and `--resume` (which reads metadata to locate the session). `LoadSessionMetadata` used a matching hand-rolled line-by-line parser that had no way to recover from the malformed output. Both functions have been replaced with `json.MarshalIndent` / `json.Unmarshal`, and the dead `extractJSONValue` helper has been removed.
+
 ### Refactoring
 
 - **Command handlers converted to `App` struct methods** — All CLI command handlers (`shellCommand`, `runCommand`, `buildCommand`, `cleanCommand`, `monitorCommand`, `attachCommand`, and all profile sub-commands) are now methods on `*App` rather than free functions that access the package-level `app` singleton directly. Phase builder functions in `phases_shell.go` are likewise methods on `App`. This enables creating an isolated `App` instance in tests with a controlled config and workspace without relying on global state. The `app` singleton and `Execute()` reset semantics are unchanged for normal operation.

--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,18 +236,11 @@ type SessionMetadata struct {
 
 // saveMetadata saves session metadata to a JSON file
 func saveMetadata(path string, metadata SessionMetadata) error {
-	// Simple JSON marshaling
-	content := fmt.Sprintf(`{
-  "session_id": "%s",
-  "container_name": "%s",
-  "persistent": %t,
-  "profile_name": "%s",
-  "workspace": "%s",
-  "saved_at": "%s"
-}
-`, metadata.SessionID, metadata.ContainerName, metadata.Persistent, metadata.ProfileName, metadata.Workspace, metadata.SavedAt)
-
-	return os.WriteFile(path, []byte(content), 0o644)
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
 }
 
 // getCurrentTime returns current time in RFC3339 format
@@ -408,23 +402,8 @@ func LoadSessionMetadata(path string) (*SessionMetadata, error) {
 	}
 
 	var metadata SessionMetadata
-	// Simple JSON parsing
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "\"session_id\"") {
-			metadata.SessionID = extractJSONValue(line)
-		} else if strings.Contains(line, "\"container_name\"") {
-			metadata.ContainerName = extractJSONValue(line)
-		} else if strings.Contains(line, "\"persistent\"") {
-			metadata.Persistent = strings.Contains(line, "true")
-		} else if strings.Contains(line, "\"profile_name\"") {
-			metadata.ProfileName = extractJSONValue(line)
-		} else if strings.Contains(line, "\"workspace\"") {
-			metadata.Workspace = extractJSONValue(line)
-		} else if strings.Contains(line, "\"saved_at\"") {
-			metadata.SavedAt = extractJSONValue(line)
-		}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse metadata: %w", err)
 	}
 
 	if metadata.SessionID == "" {
@@ -432,19 +411,6 @@ func LoadSessionMetadata(path string) (*SessionMetadata, error) {
 	}
 
 	return &metadata, nil
-}
-
-// extractJSONValue extracts the value from a JSON line like `"key": "value",`
-func extractJSONValue(line string) string {
-	// Find the value between quotes after the colon
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) != 2 {
-		return ""
-	}
-
-	value := strings.TrimSpace(parts[1])
-	value = strings.Trim(value, `",`)
-	return value
 }
 
 // GetCLISessionID extracts the CLI tool's session ID from a saved coi session.

--- a/internal/session/cleanup_metadata_test.go
+++ b/internal/session/cleanup_metadata_test.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadMetadata_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+
+	in := SessionMetadata{
+		SessionID:     "abc123",
+		ContainerName: "claude-aabbcc-1",
+		Persistent:    true,
+		ProfileName:   "default",
+		Workspace:     "/home/user/myproject",
+		SavedAt:       "2024-01-15T10:30:00Z",
+	}
+
+	if err := saveMetadata(path, in); err != nil {
+		t.Fatalf("saveMetadata: %v", err)
+	}
+
+	out, err := LoadSessionMetadata(path)
+	if err != nil {
+		t.Fatalf("LoadSessionMetadata: %v", err)
+	}
+
+	if *out != in {
+		t.Errorf("roundtrip mismatch:\n got  %+v\n want %+v", *out, in)
+	}
+}
+
+func TestSaveAndLoadMetadata_SpecialCharsInPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+
+	// Characters that would break fmt.Sprintf hand-built JSON
+	in := SessionMetadata{
+		SessionID:     "sess-99",
+		ContainerName: "claude-ff0011-2",
+		Persistent:    false,
+		ProfileName:   `my"special"profile`,
+		Workspace:     `/home/user/path with spaces/and "quotes" and \backslash`,
+		SavedAt:       "2024-06-01T00:00:00Z",
+	}
+
+	if err := saveMetadata(path, in); err != nil {
+		t.Fatalf("saveMetadata: %v", err)
+	}
+
+	out, err := LoadSessionMetadata(path)
+	if err != nil {
+		t.Fatalf("LoadSessionMetadata: %v", err)
+	}
+
+	if *out != in {
+		t.Errorf("roundtrip mismatch for special chars:\n got  %+v\n want %+v", *out, in)
+	}
+}
+
+func TestSaveMetadata_ProducesValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+
+	in := SessionMetadata{
+		SessionID:     "json-check",
+		ContainerName: "claude-001122-3",
+		Persistent:    false,
+		ProfileName:   "default",
+		Workspace:     "/workspace",
+		SavedAt:       "2024-01-01T00:00:00Z",
+	}
+
+	if err := saveMetadata(path, in); err != nil {
+		t.Fatalf("saveMetadata: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Errorf("saved file is not valid JSON: %v\ncontent: %s", err, data)
+	}
+}
+
+func TestLoadSessionMetadata_MissingSessionID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+
+	if err := os.WriteFile(path, []byte(`{"container_name":"c","persistent":false}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadSessionMetadata(path)
+	if err == nil {
+		t.Fatal("expected error for missing session_id, got nil")
+	}
+}
+
+func TestLoadSessionMetadata_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+
+	if err := os.WriteFile(path, []byte(`not json at all`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadSessionMetadata(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestLoadSessionMetadata_FileNotFound(t *testing.T) {
+	_, err := LoadSessionMetadata("/nonexistent/path/metadata.json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestSaveMetadata_PersistentFlagRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, persistent := range []bool{true, false} {
+		path := filepath.Join(dir, "meta.json")
+		in := SessionMetadata{
+			SessionID:     "p-test",
+			ContainerName: "claude-aabb-1",
+			Persistent:    persistent,
+			ProfileName:   "default",
+			Workspace:     "/workspace",
+			SavedAt:       "2024-01-01T00:00:00Z",
+		}
+		if err := saveMetadata(path, in); err != nil {
+			t.Fatalf("saveMetadata(persistent=%v): %v", persistent, err)
+		}
+		out, err := LoadSessionMetadata(path)
+		if err != nil {
+			t.Fatalf("LoadSessionMetadata(persistent=%v): %v", persistent, err)
+		}
+		if out.Persistent != persistent {
+			t.Errorf("Persistent=%v roundtrip: got %v", persistent, out.Persistent)
+		}
+	}
+}
+
+func TestSaveMetadataEarly_CreatesFileAndDirectory(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := filepath.Join(dir, "sessions")
+
+	err := SaveMetadataEarly(sessionsDir, "early-sess", "claude-early-1", "/workspace", false, "default")
+	if err != nil {
+		t.Fatalf("SaveMetadataEarly: %v", err)
+	}
+
+	metaPath := filepath.Join(sessionsDir, "early-sess", "metadata.json")
+	out, err := LoadSessionMetadata(metaPath)
+	if err != nil {
+		t.Fatalf("LoadSessionMetadata after SaveMetadataEarly: %v", err)
+	}
+
+	if out.SessionID != "early-sess" {
+		t.Errorf("SessionID: got %q, want %q", out.SessionID, "early-sess")
+	}
+	if out.ContainerName != "claude-early-1" {
+		t.Errorf("ContainerName: got %q, want %q", out.ContainerName, "claude-early-1")
+	}
+	if out.Workspace != "/workspace" {
+		t.Errorf("Workspace: got %q, want %q", out.Workspace, "/workspace")
+	}
+	if out.ProfileName != "default" {
+		t.Errorf("ProfileName: got %q, want %q", out.ProfileName, "default")
+	}
+}


### PR DESCRIPTION
## Problem

`saveMetadata` hand-built its JSON output with `fmt.Sprintf`, leaving every string field unescaped:

```go
content := fmt.Sprintf(`{
  "workspace": "%s",
  ...
}`, ..., metadata.Workspace, ...)
```

A workspace path or profile name containing `"`, `\`, or a newline produced syntactically invalid JSON. `LoadSessionMetadata` used a matching hand-rolled line-by-line parser that silently returned empty or wrong values on malformed input. The net effect:

- `coi list` showed blank or wrong session data for any user whose workspace path contained special characters
- `coi shell --resume` / `coi run --resume` failed to locate the saved session

## Fix

- Replace `saveMetadata` with `json.MarshalIndent`
- Replace `LoadSessionMetadata` with `json.Unmarshal`
- Remove the now-dead `extractJSONValue` helper (~20 lines)

## Tests added (`internal/session/cleanup_metadata_test.go`)

| Test | Covers |
|------|--------|
| `TestSaveAndLoadMetadata_RoundTrip` | Normal field values survive save→load |
| `TestSaveAndLoadMetadata_SpecialCharsInPaths` | `"`, `\`, spaces in Workspace and ProfileName |
| `TestSaveMetadata_ProducesValidJSON` | Output is always parseable by `encoding/json` |
| `TestSaveMetadata_PersistentFlagRoundTrip` | `true` and `false` both survive |
| `TestSaveMetadataEarly_CreatesFileAndDirectory` | Public helper writes a valid file |
| `TestLoadSessionMetadata_MissingSessionID` | Returns error when session_id is absent |
| `TestLoadSessionMetadata_InvalidJSON` | Returns error on corrupt file |
| `TestLoadSessionMetadata_FileNotFound` | Returns error when file is missing |

All 8 tests pass.