### PR TITLE
fix(network): eliminate firewall gap during allowlist IP refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- **Allowlist firewall rules no longer drop to zero during DNS refresh** — `refreshAllowedIPs` previously applied the new nftables rules, then called `RemoveRules` (removing everything, including the rules just added), then reapplied them — creating a brief window where all container traffic was unrestricted regardless of the configured allowlist. The three-step sequence is replaced by a new `NftManager.ReplaceAllowlist` method that snapshots the existing rule handles first, appends the new rules, and then deletes only the old handles. At no point during the transition is the rule set empty. A new `nftRuler` interface was introduced to allow the calling logic in `Manager` to be unit-tested without the real `nft` binary.
+
 - **Session metadata no longer corrupts on paths or profile names with special characters** — `saveMetadata` previously used `fmt.Sprintf` to hand-build a JSON string, leaving field values unescaped. A workspace path containing a double-quote, backslash, or newline would produce malformed JSON, breaking `coi list` (which reads metadata to show session status) and `--resume` (which reads metadata to locate the session). `LoadSessionMetadata` used a matching hand-rolled line-by-line parser that had no way to recover from the malformed output. Both functions have been replaced with `json.MarshalIndent` / `json.Unmarshal`, and the dead `extractJSONValue` helper has been removed.
 
 ### Refactoring

--- a/internal/network/interfaces.go
+++ b/internal/network/interfaces.go
@@ -1,6 +1,10 @@
 package network
 
-import "context"
+import (
+	"context"
+
+	"github.com/mensfeld/code-on-incus/internal/config"
+)
 
 // NetworkManager is the interface implemented by *Manager.
 // Defining it here enables session and cli packages to accept a stub
@@ -12,3 +16,18 @@ type NetworkManager interface {
 
 // Compile-time assertion: *Manager must satisfy NetworkManager.
 var _ NetworkManager = (*Manager)(nil)
+
+// nftRuler is the subset of NftManager behaviour required by Manager.
+// It is unexported so that only this package can produce implementations;
+// callers outside the package always receive a *Manager via NewManager.
+// Tests inside the package may substitute a stub to exercise Manager logic
+// without invoking the real nft binary.
+type nftRuler interface {
+	ApplyAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error
+	ApplyRestricted(cfg *config.NetworkConfig) error
+	RemoveRules() error
+	ReplaceAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error
+}
+
+// Compile-time assertion: *NftManager must satisfy nftRuler.
+var _ nftRuler = (*NftManager)(nil)

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -35,7 +35,7 @@ config.toml):
 // Manager provides high-level network isolation management for containers
 type Manager struct {
 	config        *config.NetworkConfig
-	nft           *NftManager
+	nft           nftRuler
 	resolver      *Resolver
 	cacheManager  *CacheManager
 	containerName string
@@ -359,19 +359,12 @@ func (m *Manager) refreshAllowedIPs() (uint32, error) {
 	totalIPs := countIPs(newIPs)
 	m.logger.Printf("IP refresh: updating nft rules with %d IPs", totalIPs)
 
-	// Apply new rules BEFORE removing old ones to avoid a gap where no rules exist.
-	// nft add rule is idempotent by handle; applying new rules before removing old avoids gaps.
+	// Replace rules atomically: snapshot old handles, append new rules, then
+	// delete only the old handles. This avoids any window where all rules are
+	// absent and the chain's default-accept policy would pass all traffic.
 	allowedIPs := collectUniqueIPs(newIPs)
-	if err := m.nft.ApplyAllowlist(m.config, allowedIPs); err != nil {
+	if err := m.nft.ReplaceAllowlist(m.config, allowedIPs); err != nil {
 		return newMinTTL, fmt.Errorf("failed to update nft rules: %w", err)
-	}
-
-	// Now remove all rules (including stale ones) and reapply to clean up
-	if err := m.nft.RemoveRules(); err != nil {
-		m.logger.Errorf("Warning: failed to remove old rules: %v", err)
-	}
-	if err := m.nft.ApplyAllowlist(m.config, allowedIPs); err != nil {
-		m.logger.Errorf("Warning: failed to reapply rules after cleanup: %v", err)
 	}
 
 	// Update cache

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -12,8 +12,9 @@ import (
 // stubNft records which nftRuler methods are called, in order.
 // Set failOn to the method name to make that call return an error.
 type stubNft struct {
-	calls  []string
-	failOn string
+	calls          []string
+	failOn         string
+	lastAllowedIPs []string // IPs passed to the most recent ReplaceAllowlist call
 }
 
 func (s *stubNft) ApplyAllowlist(_ *config.NetworkConfig, allowedIPs []string) error {
@@ -40,8 +41,9 @@ func (s *stubNft) RemoveRules() error {
 	return nil
 }
 
-func (s *stubNft) ReplaceAllowlist(_ *config.NetworkConfig, _ []string) error {
+func (s *stubNft) ReplaceAllowlist(_ *config.NetworkConfig, allowedIPs []string) error {
 	s.calls = append(s.calls, "ReplaceAllowlist")
+	s.lastAllowedIPs = allowedIPs
 	if s.failOn == "ReplaceAllowlist" {
 		return errors.New("stub: ReplaceAllowlist failed")
 	}
@@ -104,6 +106,18 @@ func TestRefreshAllowedIPs_CallsReplaceAllowlistOnChange(t *testing.T) {
 			t.Errorf("ApplyAllowlist should not be called directly from refreshAllowedIPs; calls: %v", stub.calls)
 			break
 		}
+	}
+
+	// The resolved IP for the raw domain "8.8.8.8" must be passed through.
+	found := false
+	for _, ip := range stub.lastAllowedIPs {
+		if ip == "8.8.8.8" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected \"8.8.8.8\" in allowedIPs passed to ReplaceAllowlist, got: %v", stub.lastAllowedIPs)
 	}
 }
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -1,0 +1,172 @@
+package network
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/config"
+	"github.com/mensfeld/code-on-incus/internal/logger"
+)
+
+// stubNft records which nftRuler methods are called, in order.
+// Set failOn to the method name to make that call return an error.
+type stubNft struct {
+	calls  []string
+	failOn string
+}
+
+func (s *stubNft) ApplyAllowlist(_ *config.NetworkConfig, allowedIPs []string) error {
+	s.calls = append(s.calls, "ApplyAllowlist")
+	if s.failOn == "ApplyAllowlist" {
+		return errors.New("stub: ApplyAllowlist failed")
+	}
+	return nil
+}
+
+func (s *stubNft) ApplyRestricted(_ *config.NetworkConfig) error {
+	s.calls = append(s.calls, "ApplyRestricted")
+	if s.failOn == "ApplyRestricted" {
+		return errors.New("stub: ApplyRestricted failed")
+	}
+	return nil
+}
+
+func (s *stubNft) RemoveRules() error {
+	s.calls = append(s.calls, "RemoveRules")
+	if s.failOn == "RemoveRules" {
+		return errors.New("stub: RemoveRules failed")
+	}
+	return nil
+}
+
+func (s *stubNft) ReplaceAllowlist(_ *config.NetworkConfig, _ []string) error {
+	s.calls = append(s.calls, "ReplaceAllowlist")
+	if s.failOn == "ReplaceAllowlist" {
+		return errors.New("stub: ReplaceAllowlist failed")
+	}
+	return nil
+}
+
+func (s *stubNft) called(method string) bool {
+	for _, c := range s.calls {
+		if c == method {
+			return true
+		}
+	}
+	return false
+}
+
+// newManagerForRefreshTest builds a Manager wired for refreshAllowedIPs tests.
+// Use raw IPv4 strings as "domains" to avoid real DNS lookups: ResolveDomain
+// returns them immediately without a network call.
+func newManagerForRefreshTest(t *testing.T, stub *stubNft, cachedIPs map[string][]string, domains []string) *Manager {
+	t.Helper()
+	cache := &IPCache{
+		Domains: cachedIPs,
+		TTLs:    make(map[string]uint32),
+	}
+	return &Manager{
+		config:       &config.NetworkConfig{AllowedDomains: domains},
+		nft:          stub,
+		resolver:     NewResolver(cache),
+		cacheManager: NewCacheManager(t.TempDir()),
+		logger:       logger.NewDiscard(),
+	}
+}
+
+// TestRefreshAllowedIPs_CallsReplaceAllowlistOnChange verifies that when the
+// resolved IPs differ from the cache, refreshAllowedIPs calls ReplaceAllowlist
+// and never calls the old Remove+reapply sequence.
+func TestRefreshAllowedIPs_CallsReplaceAllowlistOnChange(t *testing.T) {
+	stub := &stubNft{}
+	// Cache holds "9.9.9.9"; resolving the raw IP "8.8.8.8" returns "8.8.8.8",
+	// so IPsUnchanged returns false and the update path runs.
+	m := newManagerForRefreshTest(t, stub,
+		map[string][]string{"8.8.8.8": {"9.9.9.9"}},
+		[]string{"8.8.8.8"},
+	)
+
+	if _, err := m.refreshAllowedIPs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !stub.called("ReplaceAllowlist") {
+		t.Errorf("ReplaceAllowlist was not called; calls: %v", stub.calls)
+	}
+	if stub.called("RemoveRules") {
+		t.Errorf("RemoveRules must not be called from refreshAllowedIPs; calls: %v", stub.calls)
+	}
+	// The old 3-step sequence was: ApplyAllowlist, RemoveRules, ApplyAllowlist.
+	// After the fix neither RemoveRules nor a bare ApplyAllowlist should appear.
+	for _, c := range stub.calls {
+		if c == "ApplyAllowlist" {
+			t.Errorf("ApplyAllowlist should not be called directly from refreshAllowedIPs; calls: %v", stub.calls)
+			break
+		}
+	}
+}
+
+// TestRefreshAllowedIPs_NoNftCallsWhenUnchanged verifies that when resolved IPs
+// match the cache, refreshAllowedIPs makes no nft calls at all.
+func TestRefreshAllowedIPs_NoNftCallsWhenUnchanged(t *testing.T) {
+	stub := &stubNft{}
+	// Cache and resolution both return "8.8.8.8" → IPsUnchanged = true.
+	m := newManagerForRefreshTest(t, stub,
+		map[string][]string{"8.8.8.8": {"8.8.8.8"}},
+		[]string{"8.8.8.8"},
+	)
+
+	if _, err := m.refreshAllowedIPs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(stub.calls) != 0 {
+		t.Errorf("expected no nft calls when IPs are unchanged, got: %v", stub.calls)
+	}
+}
+
+// TestRefreshAllowedIPs_PropagatesReplaceAllowlistError verifies that a failure
+// in ReplaceAllowlist is surfaced as an error from refreshAllowedIPs.
+func TestRefreshAllowedIPs_PropagatesReplaceAllowlistError(t *testing.T) {
+	stub := &stubNft{failOn: "ReplaceAllowlist"}
+	m := newManagerForRefreshTest(t, stub,
+		map[string][]string{"8.8.8.8": {"9.9.9.9"}},
+		[]string{"8.8.8.8"},
+	)
+
+	_, err := m.refreshAllowedIPs()
+	if err == nil {
+		t.Fatal("expected an error when ReplaceAllowlist fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to update nft rules") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestRefreshAllowedIPs_ReplaceAllowlistCalledOnce verifies that even when
+// multiple domains change, ReplaceAllowlist is called exactly once.
+func TestRefreshAllowedIPs_ReplaceAllowlistCalledOnce(t *testing.T) {
+	stub := &stubNft{}
+	m := newManagerForRefreshTest(t, stub,
+		map[string][]string{
+			"1.1.1.1": {"9.9.9.9"}, // stale IP for domain "1.1.1.1"
+			"8.8.8.8": {"9.9.9.9"}, // stale IP for domain "8.8.8.8"
+		},
+		[]string{"1.1.1.1", "8.8.8.8"},
+	)
+
+	if _, err := m.refreshAllowedIPs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	count := 0
+	for _, c := range stub.calls {
+		if c == "ReplaceAllowlist" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected ReplaceAllowlist called exactly once, got %d; calls: %v", count, stub.calls)
+	}
+}

--- a/internal/network/nft_filter.go
+++ b/internal/network/nft_filter.go
@@ -128,6 +128,33 @@ func (f *NftManager) RemoveRules() error {
 	return deleteNFTRulesByComment("coi-" + f.containerIP)
 }
 
+// ReplaceAllowlist atomically replaces the allowlist rules for this container.
+// It snapshots the existing rule handles first, appends the new rules, then
+// deletes only the old handles. The container therefore always has an active
+// rule set during the transition — there is never a window where all rules are
+// absent and the chain's default-accept policy would pass all traffic through.
+func (f *NftManager) ReplaceAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error {
+	// Capture current handles before appending new rules so we can surgically
+	// remove them afterwards without touching the freshly-added entries.
+	oldHandles, err := nftGetHandlesByComment("coi-" + f.containerIP)
+	if err != nil {
+		return fmt.Errorf("failed to list current nft rules: %w", err)
+	}
+
+	if err := f.ApplyAllowlist(cfg, allowedIPs); err != nil {
+		return err
+	}
+
+	// Remove only the old handles. New rules are already in the chain, so the
+	// container is never left without a filtering rule set.
+	for _, h := range oldHandles {
+		if _, delErr := runNFTCommand("delete", "rule", "ip", "coi", "forward", "handle", h); delErr != nil {
+			log.Printf("Warning: failed to delete stale nft rule handle %s: %v", h, delErr)
+		}
+	}
+	return nil
+}
+
 // EnsureBaseRules creates the ip coi table/chain and adds the shared conntrack rule.
 func EnsureBaseRules() error {
 	if err := ensureCOITableAndChain(); err != nil {

--- a/internal/network/nft_filter.go
+++ b/internal/network/nft_filter.go
@@ -134,6 +134,10 @@ func (f *NftManager) RemoveRules() error {
 // rule set during the transition — there is never a window where all rules are
 // absent and the chain's default-accept policy would pass all traffic through.
 func (f *NftManager) ReplaceAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error {
+	if f.containerIP == "" {
+		return nil
+	}
+
 	// Capture current handles before appending new rules so we can surgically
 	// remove them afterwards without touching the freshly-added entries.
 	oldHandles, err := nftGetHandlesByComment("coi-" + f.containerIP)


### PR DESCRIPTION
## Problem

`refreshAllowedIPs` updated the nftables allowlist with a three-step sequence:

```
1. ApplyAllowlist  — appends new rules after existing ones
2. RemoveRules     — deletes ALL rules (including the ones just added) ← GAP
3. ApplyAllowlist  — re-adds the rules
```

Step 2 left the container with **zero firewall rules**. Because the `ip coi forward` chain has `policy accept`, all outbound traffic was unrestricted during that window — every DNS-driven refresh cycle briefly defeated the allowlist.

The comment above the code said *"Apply new rules BEFORE removing old ones to avoid a gap"*, but the `RemoveRules` call on the next line undid exactly that.

## Fix

**`NftManager.ReplaceAllowlist`** (new method in `nft_filter.go`):
1. Snapshot the existing rule handles **before** appending anything
2. `ApplyAllowlist` — append new rules (now both old and new rules are live)
3. Delete only the snapshotted old handles

At no point is the chain empty. The container transitions from *old rules* → *old + new rules* → *new rules only*.

**`nftRuler` interface** (new, unexported, in `interfaces.go`):  
Covers the four `NftManager` methods used by `Manager`. Lets tests substitute a stub without a real `nft` binary. `*NftManager` satisfies it via a compile-time assertion.

**`Manager.nft` field** changed from `*NftManager` → `nftRuler` (no external API change).

**`refreshAllowedIPs`** now calls `m.nft.ReplaceAllowlist` instead of the three-step sequence.

## Tests (`internal/network/manager_test.go`, 4 tests, all green)

| Test | Covers |
|------|--------|
| `TestRefreshAllowedIPs_CallsReplaceAllowlistOnChange` | Update path calls `ReplaceAllowlist`; `RemoveRules` and bare `ApplyAllowlist` are never called |
| `TestRefreshAllowedIPs_NoNftCallsWhenUnchanged` | No nft calls when resolved IPs match the cache |
| `TestRefreshAllowedIPs_PropagatesReplaceAllowlistError` | Failure in `ReplaceAllowlist` surfaces as an error |
| `TestRefreshAllowedIPs_ReplaceAllowlistCalledOnce` | `ReplaceAllowlist` is called exactly once regardless of how many domains changed |

All existing unit tests continue to pass.