### PR TITLE
docs(network): document rule-ordering behaviour in ReplaceAllowlist

### DIFF
--- a/internal/network/nft_filter.go
+++ b/internal/network/nft_filter.go
@@ -133,6 +133,14 @@ func (f *NftManager) RemoveRules() error {
 // deletes only the old handles. The container therefore always has an active
 // rule set during the transition — there is never a window where all rules are
 // absent and the chain's default-accept policy would pass all traffic through.
+//
+// Rule-ordering note: nft evaluates rules in append order. During the brief
+// window between ApplyAllowlist (which appends new rules) and the deletion of
+// old handles, the chain contains both old and new rule sets. Because the old
+// default-reject rule precedes the new allow rules, any IP that is only in the
+// new set is unreachable until the old rules are deleted. This is intentional —
+// the transition errs toward denial rather than briefly permitting unintended
+// traffic.
 func (f *NftManager) ReplaceAllowlist(cfg *config.NetworkConfig, allowedIPs []string) error {
 	if f.containerIP == "" {
 		return nil


### PR DESCRIPTION
## Summary

- Adds a `Rule-ordering note` paragraph to the `ReplaceAllowlist` doc comment explaining that during the brief transition window between `ApplyAllowlist` and old-handle deletion, newly-added IPs are temporarily unreachable.
- This is intentional (the transition errs toward denial rather than briefly permitting unintended traffic), but was previously undocumented — only the "rule set is never empty" property was mentioned.

## Motivation

Raised in the review of PR #466: the existing comment correctly documented the "no empty window" guarantee but was silent on the ordering implication, which could surprise a future maintainer.