### PR TITLE
fix(update): warn-and-refuse dev builds before querying GitHub (de-flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Bug Fixes
 
+- **`coi update` on a dev build no longer fails (or hides its guidance) when the GitHub API is unavailable** — a development build cannot be version-compared, but `update` queried the GitHub releases API *before* printing the dev-build notice, so a transient API error (rate-limit/403/network) returned `failed to check for updates` and suppressed the "use `--force`" guidance entirely. A dev build that isn't `--force`/`--check` now warns and refuses *before* any network call (the API result is irrelevant in that case), so the behavior is deterministic and offline-safe. The `--force`/`--check` dev paths are unchanged.
+
 - **`DirExists` and `FileExists` now handle paths with spaces or shell metacharacters** — both methods previously built shell test expressions via `fmt.Sprintf("[ -d %s ]", path)` and executed them through `bash -c`, which split paths containing spaces into multiple tokens causing the check to always return false. They now use `ExecArgs([]string{"test", "-d/-f", path})` so the path is passed verbatim without shell interpretation.
 
 - **Bridge iptables rules are no longer removed when `incus list` output cannot be parsed** — `Teardown` previously defaulted `hasOtherContainers` to `false` (remove rules) and only set it to `true` inside a successful JSON parse. A malformed or empty `incus list` response silently triggered rule removal, potentially breaking other running containers. The default is now `true` (keep rules); rules are only removed when parsing succeeds and confirms no other containers are running. The decision logic is extracted into `otherContainersRunning` for unit-testability.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -102,6 +102,18 @@ func updateCoreCommand(cmd *cobra.Command, args []string) error {
 	currentVersion := Version
 	isDev := currentVersion == "dev"
 
+	// A dev build cannot be version-compared. Unless the user is forcing the
+	// install or just checking, refuse immediately — before any GitHub query —
+	// so a transient API failure can't suppress this guidance (and we avoid a
+	// pointless network call). Handles the sudo re-exec case (updateVersion set)
+	// too, where a dev build still shouldn't proceed without --force.
+	if isDev && !updateForce && !updateCheck {
+		fmt.Printf("Current version: %s (development build)\n", currentVersion)
+		fmt.Println("\nWarning: Development builds cannot be version-compared.")
+		fmt.Println("Use --force to install the latest release anyway.")
+		return nil
+	}
+
 	// Determine latest version
 	var release *githubRelease
 	var latestTag string
@@ -123,13 +135,10 @@ func updateCoreCommand(cmd *cobra.Command, args []string) error {
 
 	// Show version comparison
 	if isDev {
+		// Reached only with --force or --check (the no-force dev case returned
+		// above, before the GitHub query).
 		fmt.Printf("Current version: %s (development build)\n", currentVersion)
 		fmt.Printf("Latest release:  v%s\n", latestVersion)
-		if !updateForce && !updateCheck {
-			fmt.Println("\nWarning: Development builds cannot be version-compared.")
-			fmt.Println("Use --force to install the latest release anyway.")
-			return nil
-		}
 	} else {
 		fmt.Printf("Current version: v%s\n", currentVersion)
 		fmt.Printf("Latest release:  v%s\n", latestVersion)


### PR DESCRIPTION
## Problem

`coi update` on a **dev build** queried the GitHub releases API *before* printing the dev-build notice:

```go
isDev := currentVersion == "dev"
...
release, err = fetchLatestRelease()      // network call
if err != nil { return fmt.Errorf("failed to check for updates: %w", err) }  // <-- returns here
...
if isDev && !--force && !--check { warn "use --force"; return }   // never reached on API error
```

So a transient GitHub failure (rate-limit / 403 / network) made `coi update`:
- return `failed to check for updates` instead of the dev-build guidance, and
- made `tests/update/update_dev_version.py::test_update_dev_version_refuses_without_force` flaky (empty output → assertion failure), which intermittently red-lined CI.

A dev build *cannot be version-compared* anyway, so the latest release is irrelevant when we're just going to refuse.

## Fix

Refuse a non-`--force`, non-`--check` dev build **before** any network call, and drop the now-unreachable inner dev branch. The `--force` and `--check` dev paths (which legitimately need the latest version) are unchanged.

Deterministic + offline-safe; de-flakes the test by construction (no GitHub dependency on the refuse path).

## Verification
`go build ./...`, `golangci-lint` (0 issues), `go test ./internal/cli/` green. CHANGELOG updated.