### PR TITLE
docs(readme): 0.9 upgrade-guide pointer + coi trust/audit in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ coi monitor
 coi logs                        # Auto-detect container from current workspace
 coi logs coi-abc123-1 -f        # Tail logs live
 
+# Stream the structured (JSON Lines) threat-event audit log for a session
+coi audit coi-abc123-1 -f
+
+# Approve out-of-workspace mounts / forwarded sockets from a project .coi/config.toml
+coi trust                       # approve   (coi trust --list to view, coi untrust to revoke)
+
 # List active containers and saved sessions
 coi list --all
 
@@ -290,6 +296,8 @@ coi clean --pools             # Detect containers in unused storage pools
 # Update coi to the latest release
 coi update
 ```
+
+> **Upgrading to 0.9?** 0.9 is a security-hardening release that tightens what an untrusted project `.coi/config.toml` can do (out-of-workspace mounts and forwarded sockets now require `coi trust`; project configs can no longer weaken network isolation). See the [Upgrading from 0.8 to 0.9 guide](https://github.com/mensfeld/code-on-incus/wiki/Migration-Guide#upgrading-from-08-to-09).
 
 ### Container Aliases
 


### PR DESCRIPTION
Small README touch-ups for the 0.9 release (companion to the wiki updates pushed alongside).

- **Upgrading to 0.9 callout** under the update command, linking the new wiki [Upgrading from 0.8 to 0.9](https://github.com/mensfeld/code-on-incus/wiki/Migration-Guide#upgrading-from-08-to-09) guide.
- Add **`coi audit`** and **`coi trust` / `coi untrust`** to the Basic Commands list.

(README already covered `[[sockets]]`, `[defaults.env_commands]`, and `pi` from earlier PRs.) Docs-only.

### Wiki updated in parallel (pushed directly to the wiki repo)
- **Migration-Guide**: new "Upgrading from 0.8 to 0.9" section (trust gate, network sanitize, read-only `.coi`, protected git paths, allowlist/IPv6 tightening; new features: sockets, env_commands, `coi trust`/`audit`, pi).
- **Configuration**: documented `[[sockets]]` and `[defaults.env_commands]`; corrected default `protected_paths`; added `pi` to tool names.
- **Supported-Tools**: added a `pi` section.
- **Home**: linked the upgrade guide.