### PR TITLE
chore(release): date CHANGELOG for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.9.0 (Unreleased)
+## 0.9.0 (2026-06-17)
 
 ### Security
 


### PR DESCRIPTION
Stamp the 0.9.0 CHANGELOG header with the release date ahead of tagging `v0.9.0`. Docs-only.