### PR TITLE
test: de-flake monitoring CI; fix release-notes template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,14 +174,14 @@ jobs:
           ## Requirements
 
           - **Incus** - Linux container manager
-          - **Go 1.21+** - For building from source
+          - **Go 1.25+** - For building from source
           - **incus-admin group** - User must be in incus-admin group
 
           ## Documentation
 
           - [README](https://github.com/mensfeld/code-on-incus/blob/master/README.md)
-          - [PERSISTENT_MODE.md](https://github.com/mensfeld/code-on-incus/blob/master/PERSISTENT_MODE.md)
-          - [Integration Tests](https://github.com/mensfeld/code-on-incus/blob/master/INTE.md)
+          - [Wiki](https://github.com/mensfeld/code-on-incus/wiki)
+          - [CHANGELOG](https://github.com/mensfeld/code-on-incus/blob/master/CHANGELOG.md)
           EOF
 
       - name: Create GitHub Release

--- a/tests/integration/test_log_watcher_inotify.py
+++ b/tests/integration/test_log_watcher_inotify.py
@@ -31,7 +31,7 @@ def get_container_name_from_workspace(workspace):
     return f"coi-{hash_digest}-1"
 
 
-def wait_for_container_running(name, timeout=30):
+def wait_for_container_running(name, timeout=60):
     for _ in range(timeout):
         result = subprocess.run(
             ["incus", "list", name, "--format=json"], capture_output=True, text=True, timeout=10

--- a/tests/integration/test_nft_monitoring.py
+++ b/tests/integration/test_nft_monitoring.py
@@ -1094,7 +1094,7 @@ class TestNFTCOIRuleCleanupOnAutoKill:
 
             # Wait for responder to detect threat and kill container
             killed = False
-            for _ in range(15):
+            for _ in range(30):
                 time.sleep(1)
                 state = get_container_state(container_name)
                 if state in ("Stopped", "Unknown"):
@@ -1103,9 +1103,11 @@ class TestNFTCOIRuleCleanupOnAutoKill:
 
             assert killed, f"Container should have been killed but state is {state}"
 
-            # Verify nft coi forward rules are cleaned up (may take a moment after kill)
+            # Verify nft coi forward rules are cleaned up. Rule removal happens in
+            # COI's network teardown, which runs asynchronously after the kill — under
+            # CI load this can lag well past the kill itself, so poll generously.
             cleaned = False
-            for _ in range(15):
+            for _ in range(60):
                 if not check_nft_coi_rules_exist(container_ip):
                     cleaned = True
                     break


### PR DESCRIPTION
## CI flakes (why recent runs failed)

Recent PR CI failures (on #499/#500 docs PRs and others) were **load-sensitive monitoring flakes**, not real regressions:

- **`test_nft_coi_rules_cleaned_on_auto_kill`** (monitoring-nft) — the failing assertion was the *cleanup* check, not the kill. nft rule removal runs in COI's **async network teardown** after the auto-kill; the 15s cleanup poll was too tight under CI load. → cleanup poll **15s → 60s**, kill-detection **15s → 30s**.
- **`test_event_detected_promptly`** & siblings (monitoring-log-inotify) — failed with "Container did not start"; container boot can exceed the **30s** `wait_for_container_running` default under load (the nft test already uses 60s). → default **30s → 60s**.

Both only widen happy-path-early-exit poll loops, so they don't slow passing runs.

## Release-notes template fix

`.github/workflows/release.yml` generates every release body and had stale content (visible in the published v0.9.0 notes):
- `Go 1.21+` → **1.25+** (matches `go.mod`)
- dead links `PERSISTENT_MODE.md` / `INTE.md` (files don't exist) → replaced with **Wiki** + **CHANGELOG**

(The already-published v0.9.0 release body is being corrected separately.)