### PR TITLE
feat(cli)!: remove remaining config-shaped flags (--tmux, --tool, build --compression, shutdown --timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### Breaking Changes
 
-- **The `--image` and `--persistent` CLI flags were removed everywhere** — everything config-shaped goes via config/profiles, not flags. Set `[container] image = "..."` and `[container] persistent = true` in `~/.coi/config.toml`, a project `./.coi/config.toml`, or a profile (then `coi shell|run --profile <name>`). Using the removed flags fails with an actionable migration hint (not a bare "unknown flag") on every command, including `coi profile create` — profiles are authored by editing their `config.toml` (`coi profile edit <name>`); only `--inherits` still seeds the scaffold. Runtime behavior is unchanged once configured: persistent containers are still reused and stopped (not deleted) on exit; images still resolve as `[container] image` > `coi-default`.
+- **All config-shaped CLI flags were removed: `--image`, `--persistent`, `--tmux`, `--tool`, `coi build --compression`, and `coi shutdown --timeout`** — everything config-shaped goes via config/profiles, not flags; flags are only for per-invocation choices (workspace, slot, resume, profile, force, format, ...). The replacements, settable in `~/.coi/config.toml`, a project `./.coi/config.toml`, or a profile (then `coi shell|run --profile <name>`):
+  - `[container] image = "..."` (was `--image`) and `[container] persistent = true` (was `--persistent`)
+  - `[shell] use_tmux = false` (was `coi shell --tmux=false`; previously duplicated as flag + config with a documented override rule — the two-sources-of-truth pattern this release eliminates)
+  - `[tool] name = "opencode"` (was `coi shell --tool` — a per-tool profile also carries the tool's whole setup, not just its name)
+  - `[container.build] compression = "none"` (NEW config key; was the flag-only `coi build --compression` — a profile that defines a build can now declare its compression; `coi image publish --compression` stays, it is raw plumbing)
+  - `[container] shutdown_timeout = 30` (NEW config key, default 60; was the flag-only `coi shutdown --timeout` — a graceful-shutdown window is policy, not a per-invocation whim)
+
+  Using any removed flag fails with an actionable migration hint pointing at the exact replacement key (not a bare "unknown flag"), on every command including `coi profile create` — profiles are authored by editing their `config.toml` (`coi profile edit <name>`); only `--inherits` still seeds the scaffold. Runtime behavior is unchanged once configured: persistent containers are still reused and stopped (not deleted) on exit; images still resolve as `[container] image` > `coi-default`.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   - `[container] image = "..."` (was `--image`) and `[container] persistent = true` (was `--persistent`)
   - `[shell] use_tmux = false` (was `coi shell --tmux=false`; previously duplicated as flag + config with a documented override rule — the two-sources-of-truth pattern this release eliminates)
   - `[tool] name = "opencode"` (was `coi shell --tool` — a per-tool profile also carries the tool's whole setup, not just its name)
-  - `[container.build] compression = "none"` (NEW config key; was the flag-only `coi build --compression` — a profile that defines a build can now declare its compression; `coi image publish --compression` stays, it is raw plumbing)
-  - `[container] shutdown_timeout = 30` (NEW config key, default 60; was the flag-only `coi shutdown --timeout` — a graceful-shutdown window is policy, not a per-invocation whim)
+  - `[container.build] compression = "none"` (NEW config key, settable globally, per project, or per profile like all of `[container]`; was the flag-only `coi build --compression` — a profile that defines a build can now declare its compression; `coi image publish --compression` stays, it is raw plumbing)
+  - `[container] shutdown_timeout = 30` (NEW config key, default 60, settable globally, per project, or per profile like all of `[container]`; was the flag-only `coi shutdown --timeout` — a graceful-shutdown window is policy, not a per-invocation whim)
 
   Using any removed flag fails with an actionable migration hint pointing at the exact replacement key (not a bare "unknown flag"), on every command including `coi profile create` — profiles are authored by editing their `config.toml` (`coi profile edit <name>`); only `--inherits` still seeds the scaffold. Runtime behavior is unchanged once configured: persistent containers are still reused and stopped (not deleted) on exit; images still resolve as `[container] image` > `coi-default`.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ Coming soon:
 - Cursor - AI-first code editor
 - And more...
 
-**Tool selection:**
+**Tool selection** is config/profile-driven:
+```toml
+# ~/.coi/config.toml or ./.coi/config.toml
+[tool]
+name = "opencode"            # or "claude" (default), "pi"
+```
 ```bash
-coi shell                    # Uses default tool (Claude Code)
-coi shell --tool opencode    # Use opencode instead
-coi shell --tool pi          # Use pi instead
+coi shell                    # Uses the configured tool (Claude Code by default)
+coi shell --profile opencode # Or switch via a profile with [tool] name = "opencode"
 ```
 
 **Permission mode** - Control whether AI tools run autonomously or ask before each action:
@@ -144,8 +148,8 @@ coi build
 cd your-project
 coi shell
 
-# Or use opencode instead
-coi shell --tool opencode
+# Or use opencode instead (config-driven: [tool] name = "opencode",
+# or a profile: coi shell --profile opencode)
 
 # That's it! Your AI coding assistant is now running in an isolated container with:
 # - Your project mounted at /workspace
@@ -212,8 +216,9 @@ curl -fsSL https://raw.githubusercontent.com/mensfeld/code-on-incus/master/insta
 # Build the default coi-default image (5-10 minutes)
 coi build
 
-# Build without compression (faster iteration)
-coi build --compression none
+# Build without compression (faster iteration):
+# set [container.build] compression = "none" in config or the profile
+coi build
 
 # Build a custom image via a profile
 coi profile create my-image
@@ -252,8 +257,8 @@ coi build --all --force
 # Interactive session (defaults to Claude Code)
 coi shell
 
-# Use a different AI tool
-coi shell --tool opencode
+# Use a different AI tool (config/profile-driven: [tool] name = "opencode")
+coi shell --profile opencode
 
 # Use specific slot for parallel sessions
 coi shell --slot 2

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -13,8 +13,6 @@ import (
 
 var buildForce bool
 
-var buildCompression string
-
 var buildAll bool
 
 var buildCmd = &cobra.Command{
@@ -44,7 +42,6 @@ Examples:
 
 func init() {
 	buildCmd.Flags().BoolVarP(&buildForce, "force", "f", false, "Force rebuild even if image exists")
-	buildCmd.Flags().StringVar(&buildCompression, "compression", "", "Compression algorithm (e.g., none, gzip, xz; see Incus docs for all options)")
 	buildCmd.Flags().BoolVar(&buildAll, "all", false, "Build images for all profiles visible from the current directory (global ~/.coi/profiles + project .coi/profiles)")
 }
 
@@ -111,7 +108,7 @@ func (a *App) buildCommand(cmd *cobra.Command, args []string) error {
 			BaseImage:   coiBaseImage,
 			AliasName:   image.CoiAlias,
 			Description: "coi image (Docker + build tools + Claude CLI + GitHub CLI)",
-			Compression: buildCompression,
+			Compression: p.Container.Build.Compression,
 			StoragePool: buildPool,
 			Logger: func(msg string) {
 				fmt.Fprintf(os.Stderr, "%s\n", msg)
@@ -165,7 +162,7 @@ func (a *App) buildCommand(cmd *cobra.Command, args []string) error {
 		BaseImage:   baseImage,
 		BuildScript: scriptPath,
 		Force:       buildForce,
-		Compression: buildCompression,
+		Compression: p.Container.Build.Compression,
 		StoragePool: buildPool,
 		Logger: func(msg string) {
 			fmt.Fprintf(os.Stderr, "%s\n", msg)
@@ -250,7 +247,7 @@ func (a *App) buildAllProfiles() error {
 				BaseImage:   coiBaseImage,
 				AliasName:   image.CoiAlias,
 				Description: "coi image (Docker + build tools + Claude CLI + GitHub CLI)",
-				Compression: buildCompression,
+				Compression: p.Container.Build.Compression,
 				StoragePool: buildPool,
 				Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
 			}
@@ -289,7 +286,7 @@ func (a *App) buildAllProfiles() error {
 				BaseImage:   baseImage,
 				BuildScript: scriptPath,
 				Force:       buildForce,
-				Compression: buildCompression,
+				Compression: p.Container.Build.Compression,
 				StoragePool: buildPool,
 				Logger:      func(msg string) { fmt.Fprintf(os.Stderr, "%s\n", msg) },
 			}

--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -26,7 +26,7 @@ type shellState struct {
 	absWorkspace string
 
 	// After validate-env
-	useTmux bool // determined from config + explicit --tmux flag
+	useTmux bool // determined from [shell] use_tmux config (default true)
 
 	// After configure-session
 	sessionID    string
@@ -117,22 +117,17 @@ func (a *App) resolveWorkspacePhase(cmd *cobra.Command, s *shellState) session.P
 	}
 }
 
-// validateEnvPhase determines the effective tmux mode (config default vs
-// explicit flag) and verifies that Incus is available and at the minimum
+// validateEnvPhase determines the effective tmux mode ([shell] use_tmux,
+// default true) and verifies that Incus is available and at the minimum
 // required version.
 func (a *App) validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase {
 	return session.PhaseFunc{
 		PhaseName: "validate-env",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
-			// Config default, overridden by explicit --tmux flag.
-			useTmuxDefault := true
+			// Tmux mode is config-driven: [shell] use_tmux (default true).
+			s.useTmux = true
 			if a.cfg.Shell.UseTmux != nil {
-				useTmuxDefault = *a.cfg.Shell.UseTmux
-			}
-			if cmd.Flags().Changed("tmux") {
-				s.useTmux = useTmux // cobra already set the package-level var
-			} else {
-				s.useTmux = useTmuxDefault
+				s.useTmux = *a.cfg.Shell.UseTmux
 			}
 
 			if !container.Available() {
@@ -158,10 +153,6 @@ func (a *App) configureSessionPhase(cmd *cobra.Command, s *shellState) session.P
 	return session.PhaseFunc{
 		PhaseName: "configure-session",
 		RunFn: func(_ context.Context) (session.Teardown, error) {
-			// Override tool from --tool flag.
-			if toolFlag != "" {
-				a.cfg.Tool.Name = toolFlag
-			}
 			ti, err := getConfiguredTool(a.cfg)
 			if err != nil {
 				return nil, err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -99,31 +99,41 @@ Examples:
 	},
 }
 
-// removedFlagRe matches the removed --image/--persistent flags as EXACT
-// tokens inside a flag-error message ("unknown flag: --image",
-// "flag needs an argument: --image"). The boundary check prevents false
-// hints for flags that merely share the prefix (--images, --image-tag,
-// --persistent-home): the token must be followed by end-of-string,
-// whitespace, or '=' — never by more flag-name characters.
-var removedFlagRe = regexp.MustCompile(`(--image|--persistent)($|[\s=])`)
+// removedFlagConfig maps each removed, config-shaped CLI flag to the config
+// setting that replaces it. Everything config-shaped goes via config/profiles;
+// flags are only for per-invocation choices.
+var removedFlagConfig = map[string]string{
+	"--image":       `[container] image = "..."`,
+	"--persistent":  `[container] persistent = true`,
+	"--tmux":        `[shell] use_tmux = false`,
+	"--tool":        `[tool] name = "opencode"`,
+	"--compression": `[container.build] compression = "none"`,
+	"--timeout":     `[container] shutdown_timeout = 30`,
+}
 
-// removedFlagHint upgrades the bare "unknown flag" error for the removed
-// --image/--persistent flags into an actionable migration message. The flags
-// no longer exist anywhere — image selection and persistence are configured
-// via [container] image / persistent, settable globally, per project, or per
-// profile (edit the profile's config.toml).
+// removedFlagRe matches the removed flags as EXACT tokens inside a
+// flag-error message ("unknown flag: --image", "flag needs an argument:
+// --image"). The boundary check prevents false hints for flags that merely
+// share the prefix (--images, --image-tag, --persistent-home): the token must
+// be followed by end-of-string, whitespace, or '=' — never by more flag-name
+// characters. Commands that legitimately keep one of these names (e.g.
+// `coi image publish --compression`) never reach this path because their
+// flag exists and parses.
+var removedFlagRe = regexp.MustCompile(`(--image|--persistent|--tmux|--tool|--compression|--timeout)($|[\s=])`)
+
+// removedFlagHint upgrades the bare "unknown flag" error for a removed,
+// config-shaped flag into an actionable migration message pointing at the
+// replacement config setting (settable globally, per project, or per profile).
 func removedFlagHint(cmd *cobra.Command, err error) error {
 	if err == nil {
 		return nil
 	}
 	msg := err.Error()
 	if m := removedFlagRe.FindStringSubmatch(msg); m != nil {
-		return fmt.Errorf("%s\n\nThe %s flag was removed. Set it via config instead:\n"+
-			"  [container]\n"+
-			"  image = \"my-image\"      # was --image\n"+
-			"  persistent = true       # was --persistent\n"+
-			"in ~/.coi/config.toml, ./.coi/config.toml, or a profile (--profile <name>)",
-			msg, m[1])
+		return fmt.Errorf("%s\n\nThe %s flag was removed — config-shaped settings live in config, not flags.\n"+
+			"Set it in ~/.coi/config.toml, ./.coi/config.toml, or a profile (--profile <name>):\n"+
+			"  %s",
+			msg, m[1], removedFlagConfig[m[1]])
 	}
 	return err
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -95,7 +95,11 @@ func TestRemovedFlagHint_NoFalsePositiveOnPrefixCollision(t *testing.T) {
 	// Regression: substring matching told users "--image was removed" for
 	// flags that merely share the prefix. Exact-token matching must pass
 	// these through unchanged.
-	for _, flag := range []string{"--images", "--image-tag", "--imagestore", "--persistent-home", "--persistently"} {
+	for _, flag := range []string{
+		"--images", "--image-tag", "--imagestore",
+		"--persistent-home", "--persistently",
+		"--tmux-session", "--tooling", "--timeouts", "--compression-level",
+	} {
 		orig := errors.New("unknown flag: " + flag)
 		if err := removedFlagHint(nil, orig); err != orig {
 			t.Errorf("%s: must NOT trigger the migration hint, got: %v", flag, err)
@@ -105,10 +109,31 @@ func TestRemovedFlagHint_NoFalsePositiveOnPrefixCollision(t *testing.T) {
 	for _, msg := range []string{
 		"unknown flag: --image",
 		"unknown flag: --persistent",
+		"unknown flag: --tmux",
+		"unknown flag: --tool",
+		"unknown flag: --compression",
+		"unknown flag: --timeout",
 		"flag needs an argument: --image",
 	} {
 		if err := removedFlagHint(nil, errors.New(msg)); err.Error() == msg {
 			t.Errorf("%q: expected the migration hint to be appended", msg)
+		}
+	}
+}
+
+func TestRemovedFlagHint_PointsAtTheRightConfigKey(t *testing.T) {
+	cases := map[string]string{
+		"--tmux":        "[shell] use_tmux",
+		"--tool":        "[tool] name",
+		"--compression": "[container.build] compression",
+		"--timeout":     "[container] shutdown_timeout",
+		"--image":       "[container] image",
+		"--persistent":  "[container] persistent",
+	}
+	for flag, want := range cases {
+		err := removedFlagHint(nil, errors.New("unknown flag: "+flag))
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("%s: hint must point at %q, got: %v", flag, want, err)
 		}
 	}
 }

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -26,9 +26,7 @@ import (
 var (
 	debugShell    bool
 	background    bool
-	useTmux       bool
 	containerName string
-	toolFlag      string
 )
 
 var shellCmd = &cobra.Command{
@@ -39,8 +37,8 @@ var shellCmd = &cobra.Command{
 By default, runs Claude Code. Other tools can be configured via the tool.name config option.
 
 Sessions run in tmux by default for monitoring and detach/reattach support.
-Set [shell] use_tmux = false in .coi/config.toml to run without tmux (direct mode).
-The --tmux flag always overrides the config setting.
+Set [shell] use_tmux = false in config (or a profile) to run without tmux
+(direct mode) — like all config-shaped settings, this has no CLI flag.
 
 Tmux mode (default):
   - Interactive: Automatically attaches to tmux session
@@ -55,9 +53,8 @@ in .coi/config.toml.
 Examples:
   coi shell                         # Interactive session in tmux
   coi shell myproject               # Launch session using alias (from any directory)
-  coi shell --tool opencode         # Use opencode instead of configured tool
+  coi shell --profile opencode      # Tool/behavior via a profile ([tool] name = "opencode")
   coi shell --background            # Run in background (detached, tmux only)
-  coi shell --tmux=false            # Run in direct mode (no tmux)
   coi shell --resume                # Resume latest session (auto)
   coi shell --resume=<session-id>   # Resume specific session (note: = is required)
   coi shell --continue=<session-id> # Same as --resume (alias)
@@ -71,9 +68,7 @@ Examples:
 func init() {
 	shellCmd.Flags().BoolVar(&debugShell, "debug", false, "Launch interactive bash instead of AI tool (for debugging)")
 	shellCmd.Flags().BoolVar(&background, "background", false, "Run AI tool in background tmux session (detached)")
-	shellCmd.Flags().BoolVar(&useTmux, "tmux", true, "Use tmux for session management (default true)")
 	shellCmd.Flags().StringVar(&containerName, "container", "", "Use existing container (for testing)")
-	shellCmd.Flags().StringVar(&toolFlag, "tool", "", "Override AI tool (e.g. claude, opencode, aider)")
 }
 
 func (a *App) shellCommand(cmd *cobra.Command, args []string) error {

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -11,9 +11,8 @@ import (
 )
 
 var (
-	shutdownTimeout int
-	shutdownForce   bool
-	shutdownAll     bool
+	shutdownForce bool
+	shutdownAll   bool
 )
 
 var shutdownCmd = &cobra.Command{
@@ -36,7 +35,6 @@ Examples:
 }
 
 func init() {
-	shutdownCmd.Flags().IntVar(&shutdownTimeout, "timeout", 60, "Timeout in seconds to wait for graceful shutdown before force-killing")
 	shutdownCmd.Flags().BoolVarP(&shutdownForce, "force", "f", false, "Skip confirmation prompts")
 	shutdownCmd.Flags().BoolVarP(&shutdownAll, "all", "a", false, "Shutdown all containers")
 }
@@ -49,6 +47,10 @@ func shutdownCommand(cmd *cobra.Command, args []string) error {
 	if containerNames == nil {
 		return nil
 	}
+
+	// Graceful-shutdown window is config-driven: [container] shutdown_timeout
+	// (settable globally, per project, or per profile).
+	shutdownTimeout := app.cfg.Container.ShutdownTimeoutSeconds()
 
 	// Shutdown each container
 	shutdown := 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,9 +45,10 @@ type Config struct {
 
 // BuildConfig defines how to build the project's custom image
 type BuildConfig struct {
-	Base     string   `toml:"base"`     // Base image (default: "coi")
-	Script   string   `toml:"script"`   // Path to build script (relative to config file or absolute)
-	Commands []string `toml:"commands"` // Inline build commands (alternative to script)
+	Base        string   `toml:"base"`        // Base image (default: "coi")
+	Script      string   `toml:"script"`      // Path to build script (relative to config file or absolute)
+	Commands    []string `toml:"commands"`    // Inline build commands (alternative to script)
+	Compression string   `toml:"compression"` // Image compression algorithm (e.g. "none", "gzip", "xz"; empty = Incus default)
 }
 
 // HasBuildConfig returns true if a build configuration is defined (script or commands)
@@ -61,22 +62,33 @@ func (b *BuildConfig) HasBuildConfig() bool {
 // and top-level [build]. The same struct is embedded in both Config and
 // ProfileConfig so global and profile configs are symmetric.
 type ContainerConfig struct {
-	Image          string      `toml:"image"`
-	Persistent     *bool       `toml:"persistent"`
-	StoragePool    string      `toml:"storage_pool"`
-	Alias          string      `toml:"alias"`
-	Build          BuildConfig `toml:"build"`
-	StaleBaseCheck string      `toml:"stale_base_check"` // "error", "warn", "off"
+	Image           string      `toml:"image"`
+	Persistent      *bool       `toml:"persistent"`
+	ShutdownTimeout int         `toml:"shutdown_timeout"` // Seconds to wait for graceful shutdown before force-killing (default: 60)
+	StoragePool     string      `toml:"storage_pool"`
+	Alias           string      `toml:"alias"`
+	Build           BuildConfig `toml:"build"`
+	StaleBaseCheck  string      `toml:"stale_base_check"` // "error", "warn", "off"
 }
 
 // HasContainerConfig reports whether any field is set.
 func (c *ContainerConfig) HasContainerConfig() bool {
 	return c.Image != "" ||
 		c.Persistent != nil ||
+		c.ShutdownTimeout != 0 ||
 		c.StoragePool != "" ||
 		c.Alias != "" ||
 		c.StaleBaseCheck != "" ||
 		c.Build.HasBuildConfig()
+}
+
+// ShutdownTimeoutSeconds returns the graceful-shutdown window in seconds,
+// defaulting to 60 when unset.
+func (c *ContainerConfig) ShutdownTimeoutSeconds() int {
+	if c.ShutdownTimeout <= 0 {
+		return 60
+	}
+	return c.ShutdownTimeout
 }
 
 // TimezoneConfig contains timezone settings for containers
@@ -955,6 +967,9 @@ func mergeContainerInto(dst *ContainerConfig, src *ContainerConfig) {
 	if src.Persistent != nil {
 		dst.Persistent = src.Persistent
 	}
+	if src.ShutdownTimeout != 0 {
+		dst.ShutdownTimeout = src.ShutdownTimeout
+	}
 	if src.StoragePool != "" {
 		dst.StoragePool = src.StoragePool
 	}
@@ -1080,6 +1095,9 @@ func mergeBuildInto(dst *BuildConfig, src *BuildConfig) {
 	}
 	if src.Commands != nil {
 		dst.Commands = src.Commands
+	}
+	if src.Compression != "" {
+		dst.Compression = src.Compression
 	}
 }
 

--- a/schema/defs/BuildConfig.json
+++ b/schema/defs/BuildConfig.json
@@ -13,8 +13,14 @@
     },
     "commands": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Inline build commands as an alternative to a script file"
+    },
+    "compression": {
+      "type": "string",
+      "description": "Image compression algorithm (e.g. \"none\", \"gzip\", \"xz\"; empty = Incus default)"
     }
   }
 }

--- a/schema/defs/ContainerConfig.json
+++ b/schema/defs/ContainerConfig.json
@@ -21,6 +21,10 @@
     },
     "build": {
       "$ref": "#/$defs/BuildConfig"
+    },
+    "shutdown_timeout": {
+      "type": "integer",
+      "description": "Seconds to wait for graceful shutdown before force-killing (default: 60)"
     }
   }
 }

--- a/tests/build/compression_config.py
+++ b/tests/build/compression_config.py
@@ -1,23 +1,33 @@
 """
-Integration tests for the --compression flag in build commands.
+Integration tests for [container.build] compression (config-driven; the former
+--compression build flag was removed — config-shaped settings live in
+config/profiles, not flags).
 
 Currently covered:
-- coi build --compression none
-- coi build --profile <name> --compression none
+- coi build with [container.build] compression = "none" via $COI_CONFIG
+- coi build --profile <name> with compression in the profile's build section
+- the removed --compression flag fails with the config migration hint
 """
 
+import os
 import subprocess
+import tempfile
 import time
 
 
 def test_build_with_compression_none(coi_binary):
-    """Test building the coi image with --compression none flag."""
-    # Build coi image with --compression none --force
+    """Test building the coi image with [container.build] compression = none."""
+    fd, cfg_path = tempfile.mkstemp(suffix=".toml", prefix="coi-compression-")
+    with os.fdopen(fd, "w") as f:
+        f.write('[container.build]\ncompression = "none"\n')
+    env = {**os.environ, "COI_CONFIG": cfg_path}
+
     result = subprocess.run(
-        [coi_binary, "build", "--compression", "none", "--force"],
+        [coi_binary, "build", "--force"],
         capture_output=True,
         text=True,
         timeout=600,
+        env=env,
     )
     assert result.returncode == 0, f"Build failed: {result.stderr}"
     assert (
@@ -54,7 +64,8 @@ def test_build_custom_with_compression_none(coi_binary, tmp_path):
     profile_dir.mkdir(parents=True)
 
     (profile_dir / "config.toml").write_text(
-        f'[container]\nimage = "{image_name}"\n\n[container.build]\nscript = "build.sh"\n'
+        f'[container]\nimage = "{image_name}"\n\n'
+        '[container.build]\nscript = "build.sh"\ncompression = "none"\n'
     )
 
     (profile_dir / "build.sh").write_text("""#!/bin/bash
@@ -64,9 +75,9 @@ apt-get install -y curl
 echo "Custom build completed" > /tmp/build_marker.txt
 """)
 
-    # Build custom image with --compression none
+    # Build custom image; compression comes from the profile's build section
     result = subprocess.run(
-        [coi_binary, "build", "--profile", "test-compression", "--compression", "none"],
+        [coi_binary, "build", "--profile", "test-compression"],
         capture_output=True,
         text=True,
         timeout=300,
@@ -102,3 +113,18 @@ echo "Custom build completed" > /tmp/build_marker.txt
     # Cleanup
     subprocess.run([coi_binary, "container", "delete", container_name, "--force"], check=False)
     subprocess.run([coi_binary, "image", "delete", image_name], check=False)
+
+
+def test_build_compression_flag_removed(coi_binary):
+    """The removed --compression flag fails with the config migration hint."""
+    result = subprocess.run(
+        [coi_binary, "build", "--compression", "none"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "removed --compression flag must fail"
+    assert "flag was removed" in result.stderr, f"want migration hint, got:\n{result.stderr}"
+    assert "[container.build] compression" in result.stderr, (
+        f"hint must point at the build config key, got:\n{result.stderr}"
+    )

--- a/tests/cli/test_shell_use_tmux_config.py
+++ b/tests/cli/test_shell_use_tmux_config.py
@@ -3,8 +3,11 @@ Test for [shell] use_tmux config option in coi shell.
 
 Tests that:
 1. use_tmux = false in config causes shell to run in direct mode (no tmux)
-2. --tmux=true flag overrides use_tmux = false config
+2. the removed --tmux flag fails with the config migration hint
 3. use_tmux = true (default) causes shell to use tmux mode
+
+Tmux mode is config-driven only (0.10): the former --tmux flag was removed —
+config-shaped settings live in config/profiles, not flags.
 """
 
 import subprocess
@@ -42,39 +45,21 @@ use_tmux = false
     ), f"Expected no tmux mode with use_tmux=false config. Output:\n{combined}"
 
 
-def test_tmux_flag_overrides_config(coi_binary, workspace_dir, cleanup_containers):
+def test_tmux_flag_removed_with_hint(coi_binary, workspace_dir, cleanup_containers):
     """
-    --tmux=true flag should override use_tmux = false in config.
+    The removed --tmux flag must fail with the config migration hint.
     """
-    config_dir = Path(workspace_dir) / ".coi"
-    config_dir.mkdir(exist_ok=True)
-    (config_dir / "config.toml").write_text("""
-[shell]
-use_tmux = false
-""")
-
     result = subprocess.run(
-        [
-            coi_binary,
-            "shell",
-            "--workspace",
-            workspace_dir,
-            "--background",
-            "--tmux=true",
-            "--debug",
-        ],
+        [coi_binary, "shell", "--workspace", workspace_dir, "--tmux=false"],
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=30,
     )
 
-    combined = result.stdout + result.stderr
-    # --tmux=true explicitly overrides use_tmux=false; must show a tmux Mode line
-    assert "Mode: Background (tmux)" in combined or "Mode: Interactive (tmux)" in combined, (
-        f"Expected tmux Mode line when --tmux=true overrides use_tmux=false config. Output:\n{combined}"
-    )
-    assert "Mode: Direct" not in combined, (
-        f"Expected --tmux=true to override use_tmux=false config. Output:\n{combined}"
+    assert result.returncode != 0, "removed --tmux flag must fail"
+    assert "flag was removed" in result.stderr, f"want migration hint, got:\n{result.stderr}"
+    assert "[shell] use_tmux" in result.stderr, (
+        f"hint must point at [shell] use_tmux, got:\n{result.stderr}"
     )
 
 

--- a/tests/errors/removed_flags_hint.py
+++ b/tests/errors/removed_flags_hint.py
@@ -34,6 +34,23 @@ def test_removed_image_flag_hint(coi_binary):
     assert "[container]" in result.stderr, f"hint must point at config, got:\n{result.stderr}"
 
 
+def test_removed_tmux_tool_compression_timeout_hints(coi_binary):
+    """Each removed config-shaped flag points at its replacement config key."""
+    cases = [
+        (["shell", "--tmux=false"], "[shell] use_tmux"),
+        (["shell", "--tool", "opencode"], "[tool] name"),
+        (["build", "--compression", "none"], "[container.build] compression"),
+        (["shutdown", "--timeout=5", "x"], "[container] shutdown_timeout"),
+    ]
+    for args, want in cases:
+        result = _run(coi_binary, args)
+        assert result.returncode != 0, f"{args}: removed flag must fail"
+        assert "flag was removed" in result.stderr, (
+            f"{args}: want migration hint, got:\n{result.stderr}"
+        )
+        assert want in result.stderr, f"{args}: hint must point at {want}, got:\n{result.stderr}"
+
+
 def test_no_false_hint_for_prefix_collisions(coi_binary):
     """Flags that merely share the prefix (--images, --persistent-home) must
     get the plain unknown-flag error, NOT the migration hint."""

--- a/tests/help/shell_help.py
+++ b/tests/help/shell_help.py
@@ -39,12 +39,14 @@ def test_shell_help(coi_binary):
     # Should mention key flags
     assert "--slot" in output, f"Should document --slot flag. Got:\n{output}"
     assert "--resume" in output, f"Should document --resume flag. Got:\n{output}"
-    assert "--tool" in output, f"Should document --tool flag. Got:\n{output}"
+    assert "--debug" in output, f"Should document --debug flag. Got:\n{output}"
 
-    # Persistence and image selection are config-driven now
-    # ([container] persistent / image in .coi/config.toml); the CLI flags were removed.
+    # Config-shaped settings are config/profile-driven (0.10): the
+    # --persistent/--image/--tmux/--tool flags were all removed.
     assert "--persistent" not in output, f"--persistent flag was removed. Got:\n{output}"
     assert "--image" not in output, f"--image flag was removed. Got:\n{output}"
+    assert "--tmux" not in output, f"--tmux flag was removed. Got:\n{output}"
+    assert "--tool" not in output, f"--tool flag was removed. Got:\n{output}"
 
     # Should contain Flags section
     assert "Flags:" in output, f"Should contain Flags section. Got:\n{output}"

--- a/tests/shell/persistent/resume_running_container_bug.py
+++ b/tests/shell/persistent/resume_running_container_bug.py
@@ -181,11 +181,14 @@ def test_resume_running_container_succeeds(coi_binary, cleanup_containers, works
     # Phase 3: Resume — should reuse running container (currently fails)  #
     # ------------------------------------------------------------------ #
 
-    # Run with --tmux=false so it runs directly (no tmux detach).
+    # Run with [shell] use_tmux = false so it runs directly (no tmux detach;
+    # the --tmux flag was removed — tmux mode is config-driven).
     # The bug causes an immediate error exit; a successful resume would start
     # an interactive session that we'd then kill via timeout.
+    with (Path(workspace_dir) / ".coi" / "config.toml").open("a") as f:
+        f.write("\n[shell]\nuse_tmux = false\n")
     proc = subprocess.Popen(
-        [coi_binary, "shell", f"--resume={session_id}", "--tmux=false"],
+        [coi_binary, "shell", f"--resume={session_id}"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/shutdown/shutdown_no_spurious_errors.py
+++ b/tests/shutdown/shutdown_no_spurious_errors.py
@@ -15,7 +15,7 @@ force-kill attempt executes.
 import subprocess
 import time
 
-from support.helpers import calculate_container_name
+from support.helpers import calculate_container_name, write_trusted_coi_config
 
 
 def test_shutdown_no_spurious_errors(coi_binary, cleanup_containers, workspace_dir):
@@ -55,14 +55,17 @@ def test_shutdown_no_spurious_errors(coi_binary, cleanup_containers, workspace_d
 
     time.sleep(2)
 
-    # Now shutdown the already-stopped container with a timeout
+    # Now shutdown the already-stopped container with a short config-driven
+    # timeout ([container] shutdown_timeout — the --timeout flag was removed).
     # This simulates the race condition where graceful shutdown completes
     # during the timeout window, and the force-kill check runs on stopped container
+    env = write_trusted_coi_config("[container]\nshutdown_timeout = 5\n")
     result = subprocess.run(
-        [coi_binary, "shutdown", "--timeout=5", container_name],
+        [coi_binary, "shutdown", container_name],
         capture_output=True,
         text=True,
         timeout=120,
+        env=env,
     )
 
     # Shutdown should succeed

--- a/tests/shutdown/shutdown_with_timeout.py
+++ b/tests/shutdown/shutdown_with_timeout.py
@@ -1,16 +1,18 @@
 """
-Test for coi shutdown --timeout flag.
+Test for the [container] shutdown_timeout config option (the former
+--timeout flag was removed — config-shaped settings live in config/profiles).
 
 Tests that:
 1. Launch a container
-2. Shutdown with custom timeout
-3. Verify timeout value is shown in output
+2. Shutdown with a custom shutdown_timeout from config
+3. Verify the timeout value is shown in output
+4. The removed --timeout flag fails with the migration hint
 """
 
 import subprocess
 import time
 
-from support.helpers import calculate_container_name
+from support.helpers import calculate_container_name, write_trusted_coi_config
 
 
 def test_shutdown_with_timeout(coi_binary, cleanup_containers, workspace_dir):
@@ -19,9 +21,10 @@ def test_shutdown_with_timeout(coi_binary, cleanup_containers, workspace_dir):
 
     Flow:
     1. Launch a container
-    2. Run coi shutdown --timeout=5 <container>
+    2. Run coi shutdown <container> with [container] shutdown_timeout = 5
     3. Verify timeout is shown in output
     """
+    env = write_trusted_coi_config("[container]\nshutdown_timeout = 5\n")
     slot = 1
     container_name = calculate_container_name(workspace_dir, slot)
 
@@ -36,19 +39,37 @@ def test_shutdown_with_timeout(coi_binary, cleanup_containers, workspace_dir):
 
     time.sleep(3)
 
-    # Shutdown with custom timeout
+    # Shutdown with the config-driven timeout
     result = subprocess.run(
-        [coi_binary, "shutdown", "--timeout=5", container_name],
+        [coi_binary, "shutdown", container_name],
         capture_output=True,
         text=True,
         timeout=120,
+        env=env,
     )
 
     assert result.returncode == 0, f"Shutdown should succeed. stderr: {result.stderr}"
 
     combined_output = result.stdout + result.stderr
-    # Should show the timeout value (5s)
-    assert "5" in combined_output, f"Should show timeout value in output. Got:\n{combined_output}"
+    # Should show the config-driven timeout value (5s)
+    assert "timeout: 5s" in combined_output, (
+        f"Should show the configured timeout in output. Got:\n{combined_output}"
+    )
     assert "shutdown" in combined_output.lower(), (
         f"Should show shutdown message. Got:\n{combined_output}"
+    )
+
+
+def test_shutdown_timeout_flag_removed(coi_binary):
+    """The removed --timeout flag fails with the config migration hint."""
+    result = subprocess.run(
+        [coi_binary, "shutdown", "--timeout=5", "whatever"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "removed --timeout flag must fail"
+    assert "flag was removed" in result.stderr, f"want migration hint, got:\n{result.stderr}"
+    assert "[container] shutdown_timeout" in result.stderr, (
+        f"hint must point at the config key, got:\n{result.stderr}"
     )


### PR DESCRIPTION
Follow-up to the #532 flag-consistency audit: removes the four remaining config-shaped flags so the CLI is fully coherent with the config/profiles-first model. Flags now exist only for per-invocation choices (workspace, slot, resume, profile, force, format, ...).

## Removed → replacement (config, project config, or profile)

| Removed flag | Replacement |
|---|---|
| `coi shell --tmux` | `[shell] use_tmux` (was a flag+config duplicate with a documented override rule — the exact two-sources-of-truth pattern 0.10 eliminates) |
| `coi shell --tool` | `[tool] name`, or a per-tool profile (carries the tool's whole setup, not just the name) |
| `coi build --compression` | **NEW** `[container.build] compression` config key — a profile defining a build can now declare its compression; `coi image publish --compression` stays (raw plumbing) |
| `coi shutdown --timeout` | **NEW** `[container] shutdown_timeout` config key (default 60) — a graceful-shutdown window is policy, not a per-invocation whim |

## Details
- `removedFlagHint` generalized to a flag→config-key map: every removed flag errors with a hint naming its **exact** replacement key; exact-token matching keeps prefix collisions (`--tmux-session`, `--tooling`, `--timeouts`, `--compression-level`) hint-free. All verified live.
- New config keys wired through merge functions + JSON schema defs; `ShutdownTimeoutSeconds()` accessor defaults to 60.
- Tests migrated: use_tmux config test asserts the hint instead of flag override; compression tests config-driven (renamed `compression_config.py`); shutdown tests use trusted-config timeout; hint coverage for all four removals in Go + Python; shell help asserts the flags are gone.
- README tool-selection/build/usage sections rewritten config-first; CHANGELOG breaking entry expanded (still under 0.10.0).

Gates: go build/vet/test, golangci-lint v2.12.2 (0 issues), gofmt, ruff — all green locally.