### PR TITLE
feat(config)!: remove legacy CLAUDE_ON_INCUS_* env-var config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+- **The legacy `CLAUDE_ON_INCUS_*` env-var config overrides were removed entirely** — `CLAUDE_ON_INCUS_IMAGE`, `CLAUDE_ON_INCUS_PERSISTENT`, `CLAUDE_ON_INCUS_SESSIONS_DIR`, and `CLAUDE_ON_INCUS_STORAGE_DIR` were first-commit relics from the pre-rename claude-on-incus era that silently overrode config (`CLAUDE_ON_INCUS_PERSISTENT=true` in a shell profile could defeat explicit config). They are now simply ignored, with no shim: set `[container] image` / `persistent` and `[paths] sessions_dir` / `storage_dir` instead. (The `COI_LIMIT_*` env family remains for now; the `claude-on-incus` binary symlink compatibility is untouched.)
+
 - **All config-shaped CLI flags were removed: `--image`, `--persistent`, `--tmux`, `--tool`, `coi build --compression`, and `coi shutdown --timeout`** — everything config-shaped goes via config/profiles, not flags; flags are only for per-invocation choices (workspace, slot, resume, profile, force, format, ...). The replacements, settable in `~/.coi/config.toml`, a project `./.coi/config.toml`, or a profile (then `coi shell|run --profile <name>`):
   - `[container] image = "..."` (was `--image`) and `[container] persistent = true` (was `--persistent`)
   - `[shell] use_tmux = false` (was `coi shell --tmux=false`; previously duplicated as flag + config with a documented override rule — the two-sources-of-truth pattern this release eliminates)

--- a/README.md
+++ b/README.md
@@ -433,11 +433,14 @@ permission_mode = "bypass"
 
 **Configuration hierarchy** (highest precedence last):
 1. Built-in defaults
-2. User config (`~/.coi/config.toml`)
+2. User config (`~/.coi/config.toml`, or the file `$COI_CONFIG` points at)
 3. Project config (`./.coi/config.toml`)
-4. `COI_CONFIG` environment variable
-5. Environment variables (`CLAUDE_ON_INCUS_*`, `COI_*`)
-6. Operational CLI flags (`--workspace`, `--slot`, `--persistent`, `--resume`, `--profile`, `--image`)
+4. Profile (`--profile <name>`)
+
+Config-shaped settings have no CLI flags or env-var overrides — config and
+profiles are the single source of truth (`COI_LIMIT_*` env vars are the one
+remaining legacy exception). The remaining CLI flags are per-invocation
+choices only: `--workspace`, `--slot`, `--resume`, `--profile`.
 
 Place a `.coi/config.toml` in any repository root to auto-configure COI for that project — useful for teams to share container image, environment, and resource limits.
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -15,7 +15,7 @@ import (
 // 1. Built-in defaults
 // 2. User config (~/.coi/config.toml)
 // 3. Project config (./.coi/config.toml)
-// 4. Environment variables (CLAUDE_ON_INCUS_* or COI_*)
+// 4. Environment variables (COI_LIMIT_* only)
 //
 // Profile directories are scanned independently from config files.
 // See GetProfileParentDirs() for the full list of scanned locations.
@@ -431,28 +431,9 @@ func loadProfileDirectories(cfg *Config, configDir string, trusted bool) error {
 	return nil
 }
 
-// loadFromEnv loads configuration from environment variables
+// loadFromEnv loads configuration from environment variables (COI_LIMIT_*
+// only; config-shaped settings live in config/profiles, not env vars).
 func loadFromEnv(cfg *Config) {
-	// CLAUDE_ON_INCUS_IMAGE
-	if env := os.Getenv("CLAUDE_ON_INCUS_IMAGE"); env != "" {
-		cfg.Container.Image = env
-	}
-
-	// CLAUDE_ON_INCUS_SESSIONS_DIR
-	if env := os.Getenv("CLAUDE_ON_INCUS_SESSIONS_DIR"); env != "" {
-		cfg.Paths.SessionsDir = ExpandPath(env)
-	}
-
-	// CLAUDE_ON_INCUS_STORAGE_DIR
-	if env := os.Getenv("CLAUDE_ON_INCUS_STORAGE_DIR"); env != "" {
-		cfg.Paths.StorageDir = ExpandPath(env)
-	}
-
-	// CLAUDE_ON_INCUS_PERSISTENT
-	if env := os.Getenv("CLAUDE_ON_INCUS_PERSISTENT"); env == "true" || env == "1" {
-		cfg.Container.Persistent = ptrBool(true)
-	}
-
 	// Limit environment variables (using COI_ prefix for brevity)
 	// CPU limits
 	if env := os.Getenv("COI_LIMIT_CPU"); env != "" {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -9,13 +9,6 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	// Clean environment
-	cleanEnv := func() {
-		os.Unsetenv("CLAUDE_ON_INCUS_IMAGE")
-		os.Unsetenv("CLAUDE_ON_INCUS_PERSISTENT")
-	}
-	defer cleanEnv()
-
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
@@ -32,23 +25,15 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadFromEnv(t *testing.T) {
-	// Set environment variables
-	os.Setenv("CLAUDE_ON_INCUS_IMAGE", "env-image")
-	os.Setenv("CLAUDE_ON_INCUS_PERSISTENT", "1")
-	defer func() {
-		os.Unsetenv("CLAUDE_ON_INCUS_IMAGE")
-		os.Unsetenv("CLAUDE_ON_INCUS_PERSISTENT")
-	}()
+	// COI_LIMIT_* is the only env layer; config-shaped settings (image,
+	// persistence, paths) are config/profile-only.
+	t.Setenv("COI_LIMIT_CPU", "3")
 
 	cfg := GetDefaultConfig()
 	loadFromEnv(cfg)
 
-	if cfg.Container.Image != "env-image" {
-		t.Errorf("Expected image 'env-image', got '%s'", cfg.Container.Image)
-	}
-
-	if cfg.Container.Persistent == nil || !*cfg.Container.Persistent {
-		t.Error("Expected persistent to be true from env")
+	if cfg.Limits.CPU.Count != "3" {
+		t.Errorf("Expected COI_LIMIT_CPU to apply, got %q", cfg.Limits.CPU.Count)
 	}
 }
 


### PR DESCRIPTION
Removes the last pre-rename relics: the `CLAUDE_ON_INCUS_IMAGE`, `CLAUDE_ON_INCUS_PERSISTENT`, `CLAUDE_ON_INCUS_SESSIONS_DIR`, and `CLAUDE_ON_INCUS_STORAGE_DIR` env vars, which dated to the initial claude-on-incus commit and silently overrode config (a stray `CLAUDE_ON_INCUS_PERSISTENT=true` in a shell profile could defeat explicit config — including the 0.10 persistence semantics).

Per the config-first model, they're removed **entirely, no shim**: the replacements are the config keys that already exist (`[container] image` / `persistent`, `[paths] sessions_dir` / `storage_dir`), settable globally, per project, or per profile.

- `loadFromEnv` now handles only `COI_LIMIT_*` (the one remaining, deliberately kept env layer).
- `TestLoadFromEnv` rewritten to cover the COI_LIMIT layer; no test references the legacy vars anymore.
- README config-precedence section rewritten: defaults → user config (`$COI_CONFIG`) → project config → profile; config-shaped settings have no flags or env overrides.
- `claude-on-incus` binary/symlink compatibility untouched (real users have old installs).

Gates: go build/vet/test, golangci-lint v2.12.2 (0 issues), gofmt — green. Rides the unreleased 0.10.0 breaking umbrella.