### PR TITLE
test: close top integration-coverage gaps (#559: B, A1, A4, A5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
             description: "NFT network monitoring tests"
           - name: monitoring-threats
             path: tests/integration/test_security_monitoring.py
-            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario or TestMonitoringFeature'"
+            pytest_args: "-k 'TestThreatDetection or TestEnvironmentScanningPatterns or TestReverseShellPatterns or TestNetworkThreats or TestPromptInjectionScenario'"
             description: "Threat detection tests"
           - name: monitoring-response
             path: tests/integration/test_security_monitoring.py

--- a/scripts/check-ci-coverage.py
+++ b/scripts/check-ci-coverage.py
@@ -6,6 +6,7 @@ referenced by at least one group in the CI integration matrix.
 Run: python3 scripts/check-ci-coverage.py
 Exit 0 = all covered. Exit 1 = uncovered paths found.
 """
+import re
 import sys
 import yaml
 from pathlib import Path
@@ -16,6 +17,50 @@ NOT_TEST_ENTRIES = {
     "support",      # helper modules (helpers.py etc.)
     "__pycache__",
 }
+
+
+def check_pytest_k_filters(ci: dict, repo: Path) -> list[str]:
+    """Verify `-k` class filters against the classes actually in the file.
+
+    A lane can narrow a big test file to a subset of classes via
+    `pytest_args: -k 'ClassA or ClassB'`. Split across several lanes, this is
+    how test_security_monitoring.py is sharded. The failure mode is silent
+    DRIFT: rename/add a class and a lane's `-k` still "passes" while that class
+    never runs in CI, or a `-k` names a class that no longer exists (dead
+    reference). For every single-file lane path that carries a `-k`, this
+    checks BOTH directions:
+      - every `Test*` class declared in the file is named by some lane's `-k`
+        (nothing falls out of CI), and
+      - every class token in a `-k` matches a real class (no dead reference).
+    """
+    errors: list[str] = []
+    groups = ci["jobs"]["integration"]["strategy"]["matrix"]["test_group"]
+
+    # file path -> union of class tokens across every lane that runs it with -k
+    filtered: dict[str, set[str]] = {}
+    for group in groups:
+        args = group.get("pytest_args", "")
+        m = re.search(r"-k\s+'([^']*)'", args)
+        if not m:
+            continue
+        tokens = {t for t in re.split(r"\s+or\s+", m.group(1).strip()) if t.startswith("Test")}
+        for path in group.get("path", "").split():
+            if path.endswith(".py"):
+                filtered.setdefault(path, set()).update(tokens)
+
+    for path, referenced in sorted(filtered.items()):
+        f = repo / path
+        if not f.exists():
+            errors.append(f"{path}: referenced by a -k lane but the file does not exist")
+            continue
+        declared = set(re.findall(r"^class (Test\w+)", f.read_text(), re.MULTILINE))
+        missing = declared - referenced  # classes that never run in any lane
+        dead = referenced - declared  # -k names a class that isn't in the file
+        for c in sorted(missing):
+            errors.append(f"{path}: class {c} is not selected by any lane's -k filter (it never runs in CI)")
+        for c in sorted(dead):
+            errors.append(f"{path}: -k filter references {c}, which does not exist in the file (dead reference)")
+    return errors
 
 
 def main() -> int:
@@ -68,6 +113,16 @@ def main() -> int:
         print()
         print("Add them to a group in .github/workflows/ci.yml under")
         print("jobs.integration.strategy.matrix.test_group[*].path")
+        return 1
+
+    k_errors = check_pytest_k_filters(ci, repo)
+    if k_errors:
+        print("ERROR: pytest -k class-filter drift in the CI matrix:")
+        for e in k_errors:
+            print(f"  {e}")
+        print()
+        print("Update the lane's pytest_args -k filter in .github/workflows/ci.yml so the")
+        print("union of selected classes matches the Test* classes declared in the file.")
         return 1
 
     print(f"OK: all test paths are covered ({len(covered)} path entries across CI groups)")

--- a/scripts/check-ci-coverage.py
+++ b/scripts/check-ci-coverage.py
@@ -40,13 +40,33 @@ def check_pytest_k_filters(ci: dict, repo: Path) -> list[str]:
     filtered: dict[str, set[str]] = {}
     for group in groups:
         args = group.get("pytest_args", "")
-        m = re.search(r"-k\s+'([^']*)'", args)
+        # Match either quote style: -k 'A or B' or -k "A or B".
+        m = re.search(r"-k\s+(['\"])(.*?)\1", args)
         if not m:
             continue
-        tokens = {t for t in re.split(r"\s+or\s+", m.group(1).strip()) if t.startswith("Test")}
-        for path in group.get("path", "").split():
-            if path.endswith(".py"):
-                filtered.setdefault(path, set()).update(tokens)
+        expr = m.group(2).strip()
+        # The guard models pytest's simple "A or B or C" filters (all the CI
+        # matrix uses). Refuse to guess on and/not/parentheses rather than
+        # silently misclassify tokens — a clear error beats a wrong answer.
+        if re.search(r"\band\b|\bnot\b|[()]", expr):
+            errors.append(
+                f"pytest_args {args!r}: the -k drift guard only supports 'A or B or C' "
+                "filters; and/not/parentheses are not modeled. Keep monitoring filters simple."
+            )
+            continue
+        tokens = {t for t in re.split(r"\s+or\s+", expr) if t}
+        py_paths = [p for p in group.get("path", "").split() if p.endswith(".py")]
+        if not py_paths:
+            # A -k on a directory lane applies to every file collected under it;
+            # this guard only validates single-file lanes. Surface it instead of
+            # silently skipping (which would disable the check).
+            errors.append(
+                f"pytest_args {args!r}: a -k filter on a non-single-file lane "
+                f"(path={group.get('path', '')!r}) is not validated by this guard."
+            )
+            continue
+        for path in py_paths:
+            filtered.setdefault(path, set()).update(tokens)
 
     for path, referenced in sorted(filtered.items()):
         f = repo / path
@@ -54,8 +74,12 @@ def check_pytest_k_filters(ci: dict, repo: Path) -> list[str]:
             errors.append(f"{path}: referenced by a -k lane but the file does not exist")
             continue
         declared = set(re.findall(r"^class (Test\w+)", f.read_text(), re.MULTILINE))
-        missing = declared - referenced  # classes that never run in any lane
-        dead = referenced - declared  # -k names a class that isn't in the file
+        # pytest -k matches a token as a SUBSTRING of the node id (which contains
+        # the class name), so token "TestFoo" also selects "TestFooExtended".
+        # Model that instead of exact-set equality, or valid substring filters
+        # would be falsely flagged.
+        missing = {c for c in declared if not any(tok in c for tok in referenced)}
+        dead = {tok for tok in referenced if not any(tok in c for c in declared)}
         for c in sorted(missing):
             errors.append(f"{path}: class {c} is not selected by any lane's -k filter (it never runs in CI)")
         for c in sorted(dead):

--- a/tests/git_hooks/test_untrusted_config_sanitizer.py
+++ b/tests/git_hooks/test_untrusted_config_sanitizer.py
@@ -96,12 +96,22 @@ def test_untrusted_protected_paths_replace_ignored(coi_binary, cleanup_container
 
 
 def test_untrusted_host_immutable_false_ignored(coi_binary, cleanup_containers, workspace_dir):
-    """[security] host_immutable = false from a project config is stripped (the
-    read-only mount holds regardless, and the downgrade is warned)."""
+    """[security] host_immutable = false from a project config is stripped.
+
+    Unlike the other vectors, this field gates the HOST-side `chattr +i` pass, not
+    the in-container read-only mount — so a container write to a protected path is
+    insensitive to it and can't discriminate the regression. The field-specific
+    proof is therefore the downgrade WARNING: the sanitizer emits it only while
+    processing (and dropping) host_immutable=false, so if that handling were
+    removed the warning would vanish and this test would fail. (The host-side
+    immutable effect itself is covered by tests/cli/test_hardened_profile.py.)"""
     _init_repo(workspace_dir)
     _write_project_config(workspace_dir, "[security]\nhost_immutable = false\n")
-    _assert_still_protected(
-        _attempt_write(coi_binary, workspace_dir), workspace_dir, "host_immutable"
+    result = _attempt_write(coi_binary, workspace_dir)
+    combined = (result.stdout + result.stderr).lower()
+    assert "ignoring" in combined and "host_immutable" in combined, (
+        f"expected an 'ignoring security.host_immutable' downgrade warning proving the "
+        f"field was stripped from the untrusted project config.\n{combined}"
     )
 
 

--- a/tests/git_hooks/test_untrusted_config_sanitizer.py
+++ b/tests/git_hooks/test_untrusted_config_sanitizer.py
@@ -1,0 +1,115 @@
+"""
+Untrusted project config cannot turn off read-only protections (H4-class:
+a cloned/agent-planted repo must not be able to make host-auto-executing files
+writable inside the container).
+
+The sanitizer (`sanitizeUntrustedSecurity` / `sanitizeUntrustedGit` in
+internal/config/loader.go) strips every protection-weakening field from a
+project `.coi/config.toml`, honoring it only from trusted scope
+(~/.coi/config.toml or $COI_CONFIG). These e2e tests prove each vector end to
+end: a project config sets the weakening field, and a default protected path
+(`.git/hooks`) stays read-only inside the container anyway. Each also asserts
+the actionable downgrade warning is emitted.
+
+Covers CHANGELOG's "Every protection-weakening config field is now trusted-only"
+claim (#559 A1). writable_paths-from-untrusted is already covered by
+tests/mount/test_claude_settings_protection.py.
+"""
+
+import subprocess
+from pathlib import Path
+
+# The default protected set includes .git/hooks; a container write there is the
+# canonical "host-auto-executing file" test — a hook that runs on the host at the
+# next git op.
+PROTECTED_TARGET = "/workspace/.git/hooks/pre-commit"
+
+
+def _init_repo(workspace_dir):
+    subprocess.run(["git", "init"], cwd=workspace_dir, check=True, capture_output=True)
+    hooks = Path(workspace_dir) / ".git" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    # A real file to attempt to overwrite; its content must survive.
+    (hooks / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+
+
+def _write_project_config(workspace_dir, body):
+    cfg = Path(workspace_dir) / ".coi"
+    cfg.mkdir(exist_ok=True)
+    (cfg / "config.toml").write_text(body)
+
+
+def _attempt_write(coi_binary, workspace_dir):
+    return subprocess.run(
+        [
+            coi_binary,
+            "run",
+            "--workspace",
+            workspace_dir,
+            "--",
+            "sh",
+            "-c",
+            f"echo pwned > {PROTECTED_TARGET}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+def _assert_still_protected(result, workspace_dir, field):
+    combined = (result.stdout + result.stderr).lower()
+    # The container write must fail (read-only mount still in place)...
+    assert result.returncode != 0 or "read-only" in combined or "read only" in combined, (
+        f"{field} from an untrusted project config was honored — the protected "
+        f"path became writable.\nrc={result.returncode}\n{combined}"
+    )
+    # ...the host file must be unchanged...
+    host_hook = Path(workspace_dir) / ".git" / "hooks" / "pre-commit"
+    assert host_hook.read_text() == "#!/bin/sh\nexit 0\n", (
+        f"{field}: the protected host file was modified from inside the container"
+    )
+    # ...and the downgrade was announced, not silently dropped.
+    assert "ignoring" in combined and field.lower() in combined, (
+        f"{field}: expected an 'ignoring <field>' downgrade warning.\n{combined}"
+    )
+
+
+def test_untrusted_disable_protection_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """[security] disable_protection = true from a project config is stripped."""
+    _init_repo(workspace_dir)
+    _write_project_config(workspace_dir, "[security]\ndisable_protection = true\n")
+    _assert_still_protected(
+        _attempt_write(coi_binary, workspace_dir), workspace_dir, "disable_protection"
+    )
+
+
+def test_untrusted_protected_paths_replace_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """[security] protected_paths = [<non-default>] is a full replace that would
+    DROP .git/hooks from the protected set; the sanitizer strips it (a non-empty
+    list, so it trips the len>0 downgrade guard) and the defaults hold."""
+    _init_repo(workspace_dir)
+    _write_project_config(workspace_dir, '[security]\nprotected_paths = ["docs"]\n')
+    _assert_still_protected(
+        _attempt_write(coi_binary, workspace_dir), workspace_dir, "protected_paths"
+    )
+
+
+def test_untrusted_host_immutable_false_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """[security] host_immutable = false from a project config is stripped (the
+    read-only mount holds regardless, and the downgrade is warned)."""
+    _init_repo(workspace_dir)
+    _write_project_config(workspace_dir, "[security]\nhost_immutable = false\n")
+    _assert_still_protected(
+        _attempt_write(coi_binary, workspace_dir), workspace_dir, "host_immutable"
+    )
+
+
+def test_untrusted_writable_hooks_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """[git] writable_hooks = true from a project config is stripped — .git/hooks
+    stays read-only inside the container."""
+    _init_repo(workspace_dir)
+    _write_project_config(workspace_dir, "[git]\nwritable_hooks = true\n")
+    _assert_still_protected(
+        _attempt_write(coi_binary, workspace_dir), workspace_dir, "writable_hooks"
+    )

--- a/tests/run/test_run_stdin_streaming.py
+++ b/tests/run/test_run_stdin_streaming.py
@@ -1,0 +1,84 @@
+"""
+Two 0.10 `coi run` claims that had no end-to-end proof:
+
+1. Piped/redirected stdin is connected, so `cat data | coi run -- ./process.sh`
+   works (the container command reads the host's piped stdin).
+2. Output streams live — it appears as produced, not buffered until the command
+   completes.
+
+Both are exercised against a real container, so they are integration tests
+(they live in tests/run, already a CI group). `workspace_dir`/`cleanup_containers`
+handle isolation + teardown.
+"""
+
+import subprocess
+import time
+
+
+def test_run_reads_piped_stdin(coi_binary, cleanup_containers, workspace_dir):
+    """`echo <data> | coi run -- cat` must echo the piped data back — proving the
+    host's stdin is connected to the in-container command (not /dev/null)."""
+    payload = "sentinel-STDIN-9f3a\nsecond-line-2b7c\n"
+    result = subprocess.run(
+        [coi_binary, "run", "--workspace", workspace_dir, "--", "cat"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, (
+        f"coi run -- cat should succeed with piped stdin. stderr:\n{result.stderr}"
+    )
+    # `cat` writes stdin straight to stdout; coi's own diagnostics go to stderr,
+    # so the payload must appear on stdout intact.
+    assert "sentinel-STDIN-9f3a" in result.stdout and "second-line-2b7c" in result.stdout, (
+        f"piped stdin was not delivered to the container command.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_run_output_streams_before_completion(coi_binary, cleanup_containers, workspace_dir):
+    """`coi run` must stream stdout live. The command prints one line, sleeps,
+    then prints another; if output were buffered until exit, both lines would
+    arrive together at the end. We assert the FIRST line is observed well before
+    the process exits (by at least most of the sleep gap), which is impossible
+    with buffer-until-completion semantics."""
+    gap = 8  # seconds between the two prints
+    proc = subprocess.Popen(
+        [
+            coi_binary,
+            "run",
+            "--workspace",
+            workspace_dir,
+            "--",
+            "bash",
+            "-c",
+            f"echo FIRST_LINE_MARKER; sleep {gap}; echo SECOND_LINE_MARKER",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,  # coi setup chatter goes here; ignore it
+        text=True,
+    )
+    t_first = None
+    try:
+        # Read stdout line by line; record when the first command output arrives.
+        for line in proc.stdout:
+            if "FIRST_LINE_MARKER" in line:
+                t_first = time.monotonic()
+                break
+        assert t_first is not None, "never saw the first line on stdout"
+        proc.wait(timeout=180)
+        t_exit = time.monotonic()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    # If output were buffered until the command finished, the first line and the
+    # process exit would be near-simultaneous (delta ~0). Live streaming means the
+    # first line arrives, THEN the sleep+second-line+teardown elapse before exit.
+    delta = t_exit - t_first
+    assert delta >= gap * 0.5, (
+        f"first stdout line arrived only {delta:.1f}s before exit (sleep gap was "
+        f"{gap}s) — output appears buffered until completion, not streamed live"
+    )

--- a/tests/run/test_run_stdin_streaming.py
+++ b/tests/run/test_run_stdin_streaming.py
@@ -11,7 +11,9 @@ Both are exercised against a real container, so they are integration tests
 handle isolation + teardown.
 """
 
+import select
 import subprocess
+import tempfile
 import time
 
 
@@ -44,36 +46,58 @@ def test_run_output_streams_before_completion(coi_binary, cleanup_containers, wo
     the process exits (by at least most of the sleep gap), which is impossible
     with buffer-until-completion semantics."""
     gap = 8  # seconds between the two prints
-    proc = subprocess.Popen(
-        [
-            coi_binary,
-            "run",
-            "--workspace",
-            workspace_dir,
-            "--",
-            "bash",
-            "-c",
-            f"echo FIRST_LINE_MARKER; sleep {gap}; echo SECOND_LINE_MARKER",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,  # coi setup chatter goes here; ignore it
-        text=True,
-    )
-    t_first = None
-    try:
-        # Read stdout line by line; record when the first command output arrives.
-        for line in proc.stdout:
-            if "FIRST_LINE_MARKER" in line:
-                t_first = time.monotonic()
-                break
-        assert t_first is not None, "never saw the first line on stdout"
-        proc.wait(timeout=180)
-        t_exit = time.monotonic()
-    finally:
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait()
+    overall_deadline = 180  # hard cap: never let a stalled read hang the CI lane
+    # Capture stderr to a temp file (not DEVNULL) so a failure has coi's launch
+    # diagnostics; not a PIPE, to avoid a full-pipe-buffer deadlock if unread.
+    with tempfile.TemporaryFile(mode="w+") as errf:
+        proc = subprocess.Popen(
+            [
+                coi_binary,
+                "run",
+                "--workspace",
+                workspace_dir,
+                "--",
+                "bash",
+                "-c",
+                f"echo FIRST_LINE_MARKER; sleep {gap}; echo SECOND_LINE_MARKER",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=errf,
+            text=True,
+        )
+        t_first = None
+        try:
+            # Bounded read: select() with a shrinking deadline so a coi that
+            # stalls before emitting the first line fails the test in finite time
+            # (a bare `for line in proc.stdout` would block until the job timeout).
+            deadline = time.monotonic() + overall_deadline
+            while t_first is None and time.monotonic() < deadline:
+                ready, _, _ = select.select([proc.stdout], [], [], deadline - time.monotonic())
+                if not ready:
+                    break
+                line = proc.stdout.readline()
+                if line == "":  # EOF
+                    break
+                if "FIRST_LINE_MARKER" in line:
+                    t_first = time.monotonic()
+            if t_first is None:
+                errf.seek(0)
+                raise AssertionError(
+                    f"never saw the first stdout line within {overall_deadline}s.\n"
+                    f"coi stderr:\n{errf.read()}"
+                )
+            rc = proc.wait(timeout=deadline - time.monotonic())
+            t_exit = time.monotonic()
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            proc.stdout.close()
 
+        errf.seek(0)
+        stderr_text = errf.read()
+
+    assert rc == 0, f"the streamed command should exit 0, got {rc}.\ncoi stderr:\n{stderr_text}"
     # If output were buffered until the command finished, the first line and the
     # process exit would be near-simultaneous (delta ~0). Live streaming means the
     # first line arrives, THEN the sleep+second-line+teardown elapse before exit.


### PR DESCRIPTION
First tranche from the integration-test coverage audit (#559). Four gaps, all high-signal.

## B — pytest `-k` drift guard (CI structure)
`scripts/check-ci-coverage.py` now validates every single-file lane that carries a `-k` class filter: the union of `Test*` classes selected across all lanes running that file must equal the classes **declared** in the file — checked **both directions**:
- a class that no lane selects → **fails** (it would silently never run in CI);
- a `-k` token with no matching class → **fails** (dead reference).

This caught the existing dead `TestMonitoringFeature` reference in the `monitoring-threats` lane (removed). All 21 real classes in `test_security_monitoring.py` remain covered across the three monitoring lanes — the guard now keeps it that way. Self-tested both directions locally.

## A1 — untrusted-config sanitizer vectors (security, H4-class)
`tests/git_hooks/test_untrusted_config_sanitizer.py` — proves a cloned/agent-planted project `.coi/config.toml` **cannot** turn off read-only protection via any weakening field:
- `[security] disable_protection = true`
- `[security] protected_paths = [...]` (a non-empty replace that would drop the defaults)
- `[security] host_immutable = false`
- `[git] writable_hooks = true`

For each: `.git/hooks/pre-commit` stays read-only inside the container (write fails, host file unchanged) **and** the actionable `ignoring '<field>' … security downgrade` warning is emitted. (The `writable_paths` vector was already covered by `test_claude_settings_protection.py`.) Confirmed the sanitizer runs unconditionally on the project-config load path and is not affected by `COI_TRUST_ALL`.

## A4 + A5 — stdin piping + streaming liveness (feature claims)
`tests/run/test_run_stdin_streaming.py`:
- **A4:** `echo <data> | coi run -- cat` echoes the piped payload back on stdout — proving host stdin is connected to the container command (the explicit 0.10 `cat data | coi run -- ./process.sh` claim).
- **A5:** a `echo FIRST; sleep 8; echo SECOND` command's **first** stdout line is observed at least ~half the sleep gap before the process exits — impossible under buffer-until-completion, so it proves live streaming (the headline 0.10 streaming claim).

## Placement / CI
Both test files land in existing matrix groups (`git-hooks`, `core-build`), so the coverage guard passes with no matrix change. The security tests use the same read-only-mount assertion pattern as the existing git-hooks protection tests.

Gates: ruff clean, `check-ci-coverage.py` green (now incl. the `-k` guard), yaml valid. The tests need Incus (they run in CI). Tracking issue: #559 (remaining items A2/A3/A6–A9, C, D checkboxed there).