### PR TITLE
test: coverage-gap tranche 2 (#559: A6 audit, A7 coi-run symlink, A8 legacy env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
             path: tests/meta tests/snapshot tests/image
             description: "Snapshot, image, and meta command tests"
           - name: misc-commands
-            path: tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
+            path: tests/audit tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: audit/clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
           - name: misc-config
             path: tests/config tests/health tests/limits tests/schema
             description: "Config, health, limits, and schema tests"

--- a/tests/audit/test_audit_command.py
+++ b/tests/audit/test_audit_command.py
@@ -1,0 +1,60 @@
+"""
+`coi audit` had zero integration coverage (#559 A6).
+
+The command streams threat-event audit records as JSON lines. `--file <path>`
+reads an arbitrary JSONL file and re-emits each parsed event — a host-only path
+(no container, no monitoring), which makes it the cheapest honest way to exercise
+the command's real render pipeline (audit.HostAuditTail -> StreamEvents/ParseLine).
+"""
+
+import json
+import subprocess
+
+# A valid audit event line (ParseLine requires a known `type`).
+EVENT = '{"ts":"2026-01-01T00:00:00Z","type":"audit","msg":"AUDIT-SENTINEL-7f3a"}'
+
+
+def _audit(coi_binary, *args):
+    return subprocess.run(
+        [coi_binary, "audit", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_audit_file_streams_events_as_valid_jsonl(coi_binary, tmp_path):
+    """`coi audit --file <jsonl>` re-emits each event; output is valid JSON lines."""
+    log = tmp_path / "session.jsonl"
+    log.write_text(EVENT + "\n")
+
+    r = _audit(coi_binary, "--file", str(log))
+    assert r.returncode == 0, f"coi audit --file should succeed. stderr:\n{r.stderr}"
+    assert "AUDIT-SENTINEL-7f3a" in r.stdout, (
+        f"the event must be echoed on stdout.\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+    # Every non-empty stdout line must be a valid JSON object carrying `type`.
+    lines = [ln for ln in r.stdout.splitlines() if ln.strip()]
+    assert lines, "expected at least one JSON line on stdout"
+    for ln in lines:
+        obj = json.loads(ln)  # raises if the output is not valid JSONL
+        assert "type" in obj, f"event missing 'type': {ln}"
+
+
+def test_audit_file_empty_is_clean(coi_binary, tmp_path):
+    """An empty audit file streams nothing and exits 0 (not an error)."""
+    log = tmp_path / "empty.jsonl"
+    log.write_text("")
+
+    r = _audit(coi_binary, "--file", str(log))
+    assert r.returncode == 0, f"empty --file should exit 0. stderr:\n{r.stderr}"
+    assert r.stdout.strip() == "", f"empty file should produce no events, got:\n{r.stdout}"
+
+
+def test_audit_file_nonexistent_errors(coi_binary, tmp_path):
+    """A missing --file path fails with a clear error, not a silent success."""
+    r = _audit(coi_binary, "--file", str(tmp_path / "does-not-exist.jsonl"))
+    assert r.returncode != 0, "a nonexistent --file must fail"
+    assert "audit log" in (r.stdout + r.stderr).lower(), (
+        f"expected an 'open audit log' error.\n{r.stdout}\n{r.stderr}"
+    )

--- a/tests/config/test_legacy_env_vars_ignored.py
+++ b/tests/config/test_legacy_env_vars_ignored.py
@@ -1,0 +1,64 @@
+"""
+0.10 removed the env-var config layer entirely (#559 A8). `COI_LIMIT_*` is
+already covered (tests/limits/test_limits_flags.py); the legacy
+`CLAUDE_ON_INCUS_*` overrides were not. These prove they are now IGNORED, not
+honored as a hidden config source.
+"""
+
+import os
+import subprocess
+
+from support.helpers import calculate_container_name, get_container_list
+
+
+def _run(coi_binary, workspace_dir, extra_env, argv, timeout=180):
+    env = os.environ.copy()
+    env.update(extra_env)
+    return subprocess.run(
+        [coi_binary, "run", "--workspace", workspace_dir, *argv],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def test_claude_on_incus_image_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """CLAUDE_ON_INCUS_IMAGE must be ignored: the run uses the default image and
+    succeeds. If the env var were still honored the run would try a nonexistent
+    image and fail."""
+    r = _run(
+        coi_binary,
+        workspace_dir,
+        {"CLAUDE_ON_INCUS_IMAGE": "coi-legacy-env-nonexistent-xyz"},
+        ["--", "echo", "IMG-ENV-IGNORED"],
+    )
+    combined = r.stdout + r.stderr
+    assert r.returncode == 0, (
+        f"CLAUDE_ON_INCUS_IMAGE must be ignored (default image used), but the run "
+        f"failed — the legacy env override may still be honored.\n{combined}"
+    )
+    assert "IMG-ENV-IGNORED" in combined, combined
+
+
+def test_claude_on_incus_persistent_ignored(coi_binary, cleanup_containers, workspace_dir):
+    """CLAUDE_ON_INCUS_PERSISTENT=true must be ignored: the run stays ephemeral,
+    so no container for this workspace survives afterwards. If the env var were
+    honored the container would be kept (stopped) and show up in `incus list`."""
+    r = _run(
+        coi_binary,
+        workspace_dir,
+        {"CLAUDE_ON_INCUS_PERSISTENT": "true"},
+        ["--", "echo", "PERSIST-ENV-IGNORED"],
+    )
+    combined = r.stdout + r.stderr
+    assert r.returncode == 0, combined
+    assert "PERSIST-ENV-IGNORED" in combined, combined
+
+    live = get_container_list()  # all containers (running + stopped)
+    survivors = [calculate_container_name(workspace_dir, slot) for slot in range(1, 11)]
+    leaked = [name for name in survivors if name in live]
+    assert not leaked, (
+        f"CLAUDE_ON_INCUS_PERSISTENT=true must be ignored (run stays ephemeral), "
+        f"but a container survived: {leaked}\nlive containers:\n{live}"
+    )

--- a/tests/run/test_run_script_symlink.py
+++ b/tests/run/test_run_script_symlink.py
@@ -1,0 +1,67 @@
+"""
+`coi run` (no args) executes a workspace-root `coi-run` script. The 0.10 claim
+(#559 A7): a `coi-run` *symlink* is followed only if it resolves INSIDE the
+workspace — a target outside it passes the host stat but would not exist in the
+container, so COI fails fast host-side with an explanation. Unit-tested
+(run_test.go); these are the missing end-to-end checks.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_noargs(coi_binary, workspace_dir, timeout=120):
+    # No `--` command => run-script mode: COI looks for workspace/coi-run.
+    return subprocess.run(
+        [coi_binary, "run", "--workspace", workspace_dir],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_coi_run_symlink_escaping_workspace_fails_fast(
+    coi_binary, cleanup_containers, workspace_dir, tmp_path
+):
+    """A coi-run symlink whose target is OUTSIDE the workspace must abort host-side,
+    before any container launch, and must never execute the target."""
+    outside = tmp_path / "evil.sh"
+    outside.write_text("#!/bin/sh\necho ESCAPED-SHOULD-NOT-RUN\n")
+    outside.chmod(0o755)
+    (Path(workspace_dir) / "coi-run").symlink_to(outside)  # absolute target outside ws
+
+    r = _run_noargs(coi_binary, workspace_dir, timeout=45)
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, f"escaping symlink must fail fast.\n{combined}"
+    assert "outside the workspace" in combined, f"expected the escape explanation.\n{combined}"
+    assert "ESCAPED-SHOULD-NOT-RUN" not in combined, "the escaping target must not execute"
+
+
+def test_coi_run_dangling_symlink_fails_fast(
+    coi_binary, cleanup_containers, workspace_dir, tmp_path
+):
+    """A coi-run symlink to a nonexistent target fails fast with a clear message."""
+    (Path(workspace_dir) / "coi-run").symlink_to(tmp_path / "nope-does-not-exist")
+
+    r = _run_noargs(coi_binary, workspace_dir, timeout=45)
+    combined = (r.stdout + r.stderr).lower()
+    assert r.returncode != 0, f"dangling symlink must fail.\n{combined}"
+    assert "dangling" in combined or "resolve" in combined, (
+        f"expected a dangling/resolve error.\n{combined}"
+    )
+
+
+def test_coi_run_symlink_inside_workspace_runs(coi_binary, cleanup_containers, workspace_dir):
+    """A coi-run symlink to a target INSIDE the workspace is followed and executed.
+    Must be a RELATIVE symlink so it also resolves inside the container's mount."""
+    real = Path(workspace_dir) / "real-script.sh"
+    real.write_text("#!/bin/sh\necho SYMLINK-INSIDE-OK\n")
+    real.chmod(0o755)
+    # Relative target: /workspace/coi-run -> real-script.sh resolves in-container too.
+    os.symlink("real-script.sh", Path(workspace_dir) / "coi-run")
+
+    r = _run_noargs(coi_binary, workspace_dir, timeout=180)
+    combined = r.stdout + r.stderr
+    assert r.returncode == 0, f"in-workspace symlink script should run.\n{combined}"
+    assert "SYMLINK-INSIDE-OK" in combined, f"the linked script must execute.\n{combined}"


### PR DESCRIPTION
Second tranche from the coverage audit (#559). **Exploration first trimmed the list** — three of the candidates turned out already-covered, which is exactly what the audit is for:

- **A2** (DHCP stale-rule purge) — already covered: `tests/network/test_nft_stale_rule_purge.py` + Go `nft_stale_purge_integration_test.go`.
- **A3** (boot-block on persistent restart) — already covered: Go `boot_block_integration_test.go` (3 tests, real containers).
- **A8 `COI_LIMIT_*`** — already covered: `tests/limits/test_limits_flags.py`.

(My earlier CHANGELOG-claims audit under-counted these because it only searched for Python "e2e" and missed the Go integration tests. Checked #559's boxes accordingly.)

## Implemented — the genuine remainders

**A6 — `coi audit` (was ZERO coverage)** · `tests/audit/test_audit_command.py`
Exercises the host-only `--file` path (no container, fast): a valid JSONL file streams back as valid JSON lines with the event echoed; an empty file is a clean exit-0 no-op; a missing file errors clearly (`open audit log`). New `tests/audit` dir assigned to the `misc-commands` lane (coverage guard passes, 48 entries).

**A7 — coi-run symlink-escape rule (was unit-only)** · `tests/run/test_run_script_symlink.py`
- symlink escaping the workspace → **fails fast host-side** with `outside the workspace`, and the target is **never executed**;
- dangling symlink → clear failure;
- **relative** in-workspace symlink → runs (resolves inside the container mount too — an absolute-path symlink wouldn't, which is why the test uses a relative one).

**A8 — legacy `CLAUDE_ON_INCUS_*` ignored** · `tests/config/test_legacy_env_vars_ignored.py`
- `CLAUDE_ON_INCUS_IMAGE=<bogus>` → **ignored**: run uses the default image and succeeds (if honored it'd try the bogus image and fail);
- `CLAUDE_ON_INCUS_PERSISTENT=true` → **ignored**: run stays ephemeral, no container survives in `incus list`.

## Gates
ruff clean, yaml valid, `check-ci-coverage.py` green (incl. the `-k` guard and the new `tests/audit` assignment). Tests need Incus → they run in CI (first execution is on this PR). Remaining #559 items: A9 (minor), C1–C3 (quality), D (xfail triage).