### PR TITLE
test(monitoring): xfail triage (D) + de-flake 'Container did not start' (#559 D)

### DIFF
--- a/tests/integration/test_security_monitoring.py
+++ b/tests/integration/test_security_monitoring.py
@@ -129,11 +129,16 @@ def get_container_state(name):
     return containers[0].get("status", "Unknown") if containers else "Unknown"
 
 
-def wait_for_container_running(name, timeout=30):
+def wait_for_container_running(name, timeout=60):
     """Wait for container to reach Running state with retries.
 
     Returns True if container is Running, False if it never reached Running
     within the timeout period.
+
+    Timeout is 60s (was 30s): on the heavily-parallel monitoring lanes a
+    `coi shell` first-boot occasionally needs >30s, which surfaced as an
+    intermittent "Container ... did not start" failure that passed on re-run.
+    60s matches the sibling helper in test_log_watcher_inotify.py.
     """
     for _ in range(timeout):
         state = get_container_state(name)


### PR DESCRIPTION
#559 D — xfail triage. **Reading each xfail showed the audit's "fixable flakes" framing was wrong**: all 6 are legitimate and correctly documented, so the code change here is a single central de-flake of the *hard* flake the audit conflated with them.

## Triage verdicts (no change — verified legitimate)
| xfail | verdict |
|---|---|
| 4× `test_large_file_read_*` / `test_large_write_*` (io.stat) | **Real GHA limitation** — cgroup `io.stat` doesn't attribute bind-mount `/workspace` I/O (host page cache) to the container cgroup. Detection works; CI can't produce the accounting. Keep. |
| `uid_mapping_shift_true` | Conditional xfail documenting the exact `shift=true` limitation that motivated #530's `raw.idmap`. Keep. |
| `run_hostname_in_hosts` (`strict=True`) | Correctly-designed **self-correcting** xfail — the fix *is* in `internal/image/build.sh` (a `coi-fix-hostname.service`); it flips to xpass→red once the image cache rebuilds, forcing marker removal. Touching it blind is pure downside. Keep. |

## The one actionable item — the HARD flake
`TestForkBombDetection::test_fork_bomb_kills_container` → **"Container did not start"** (cost CI reruns twice today). It is *not* an xfail — it's a hard test whose shared gate `wait_for_container_running` polled **30×1s**. On the heavily-parallel monitoring lanes, `coi shell` first-boot occasionally needs >30s (it passed on re-run → timing, not a hard failure). Raised the timeout **30→60s** (matching the sibling helper in `test_log_watcher_inotify.py`) — one change covering **all 8** "did not start" call sites in the file.

## Net
D is effectively "verify the xfails are honest (they are) and fix the real flake hiding among them." No xfail removed (removing a legitimate one just turns CI red). Follow-up noted on #559: the "did not start" sites `stderr=DEVNULL` their launch, so a genuine (non-timing) failure has no diagnostics — worth capturing later.

ruff/guard clean. Runs in CI (monitoring lanes).