### PR TITLE
test: A9 command-edge coverage + C3 safe dedup (#559 A9 + C3)

### DIFF
--- a/tests/cli/test_format_consistency.py
+++ b/tests/cli/test_format_consistency.py
@@ -167,3 +167,20 @@ def test_monitor_format_invalid_rejected(coi_binary):
     assert result.returncode == 2, f"Expected exit code 2 for --format xml, got {result.returncode}"
     combined = result.stdout + result.stderr
     assert "invalid format" in combined.lower(), f"Expected 'invalid format' error, got: {combined}"
+
+
+def test_monitor_watch_json_conflict(coi_binary):
+    """`coi monitor --watch N --json` is an unsupported combination and must be
+    rejected with exit 2 before any container work (JSON is a one-shot format)."""
+    result = subprocess.run(
+        [coi_binary, "monitor", "--watch", "1", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2, (
+        f"--json with --watch should exit 2. rc={result.returncode}\n{result.stdout}{result.stderr}"
+    )
+    assert "not supported with --watch" in (result.stdout + result.stderr).lower(), (
+        f"expected the watch/json conflict message.\n{result.stdout}{result.stderr}"
+    )

--- a/tests/cli/test_short_flags.py
+++ b/tests/cli/test_short_flags.py
@@ -173,3 +173,19 @@ def test_snapshot_delete_short_all(coi_binary):
     assert "-a, --all" in result.stdout, (
         f"Expected '-a, --all' in help output, got: {result.stdout}"
     )
+
+
+def test_build_short_all(coi_binary):
+    """coi build -a is the shorthand for --all; -a must appear in build's help
+    (a cheap proof the short flag is registered — a full build is not needed)."""
+    result = subprocess.run(
+        [coi_binary, "build", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout + result.stderr
+    assert "-a, --all" in out or ("-a" in out and "--all" in out), (
+        f"build should expose the -a shorthand for --all.\n{out}"
+    )

--- a/tests/cli/test_unfreeze_command.py
+++ b/tests/cli/test_unfreeze_command.py
@@ -1,0 +1,22 @@
+"""
+`coi unfreeze` had Go unit tests but no Python e2e (#559 A9). The full
+freeze→unfreeze cycle is covered by internal/cli/unfreeze_integration_test.go;
+this adds the cheap CLI error path (nonexistent container) so the command's
+user-facing error is regression-guarded end to end.
+"""
+
+import subprocess
+
+
+def test_unfreeze_nonexistent_errors(coi_binary):
+    """`coi unfreeze <nonexistent>` fails clearly with a not-found error."""
+    result = subprocess.run(
+        [coi_binary, "unfreeze", "coi-nonexistent-unfreeze-9f3a2b"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "unfreezing a nonexistent container must fail"
+    assert "not found" in (result.stdout + result.stderr).lower(), (
+        f"expected a not-found error.\n{result.stdout}{result.stderr}"
+    )

--- a/tests/cli/test_validate_command.py
+++ b/tests/cli/test_validate_command.py
@@ -1,0 +1,65 @@
+"""
+`coi validate profile <path>` — the schema-validation *logic* is covered by
+tests/schema/test_profile_schema.py (65 tests via the validator), but the CLI
+command that wraps it had no coverage (#559 A9).
+
+Host-only: validate's PersistentPreRunE skips config loading, so these need no
+Incus and run in the misc-cli lane.
+"""
+
+import json
+import subprocess
+
+
+def _validate(coi_binary, *args, timeout=30):
+    return subprocess.run(
+        [coi_binary, "validate", "profile", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_validate_profile_valid(coi_binary, tmp_path):
+    """A schema-valid profile exits 0 with 'Profile is valid.'"""
+    p = tmp_path / "config.toml"
+    p.write_text('[network]\nmode = "restricted"\n')
+    r = _validate(coi_binary, str(p))
+    assert r.returncode == 0, f"valid profile should exit 0.\n{r.stdout}{r.stderr}"
+    assert "is valid" in (r.stdout + r.stderr).lower()
+
+
+def test_validate_profile_invalid(coi_binary, tmp_path):
+    """A schema-invalid profile (unknown network mode) exits 1 with an error.
+    `mode = "blocked"` is rejected by the schema (see test_profile_schema)."""
+    p = tmp_path / "config.toml"
+    p.write_text('[network]\nmode = "blocked"\n')
+    r = _validate(coi_binary, str(p))
+    assert r.returncode == 1, f"invalid profile should exit 1.\n{r.stdout}{r.stderr}"
+    assert "validation failed" in (r.stdout + r.stderr).lower()
+
+
+def test_validate_profile_json_output(coi_binary, tmp_path):
+    """--format json emits a machine-readable result ({'valid': true, ...})."""
+    p = tmp_path / "config.toml"
+    p.write_text('[network]\nmode = "open"\n')
+    r = subprocess.run(
+        [coi_binary, "validate", "profile", str(p), "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode == 0, f"valid profile --format json should exit 0.\n{r.stdout}{r.stderr}"
+    obj = json.loads(r.stdout)  # raises if stdout is not valid JSON
+    assert obj.get("valid") is True, f"expected valid=true, got {obj}"
+
+
+def test_validate_profile_missing_arg(coi_binary):
+    """`coi validate profile` with no path is a usage error (ExactArgs(1))."""
+    r = subprocess.run(
+        [coi_binary, "validate", "profile"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode != 0, "missing path argument must fail"

--- a/tests/network/test_firewall_cleanup.py
+++ b/tests/network/test_firewall_cleanup.py
@@ -18,6 +18,8 @@ import subprocess
 import time
 from pathlib import Path
 
+from support.helpers import extract_container_name
+
 
 def get_container_ip(coi_binary, container_name):
     """Get container IP using coi container exec with --capture."""
@@ -176,11 +178,7 @@ mode = "open"
     assert result.returncode == 0, f"Shell should start. stderr: {result.stderr}"
 
     # Extract container name
-    container_name = None
-    for line in result.stderr.split("\n"):
-        if "Container name:" in line:
-            container_name = line.split("Container name:")[-1].strip()
-            break
+    container_name = extract_container_name(result)
 
     assert container_name, f"Should find container name. stderr: {result.stderr}"
 
@@ -257,11 +255,7 @@ mode = "restricted"
     assert result.returncode == 0, f"Shell should start. stderr: {result.stderr}"
 
     # Extract container name
-    container_name = None
-    for line in result.stderr.split("\n"):
-        if "Container name:" in line:
-            container_name = line.split("Container name:")[-1].strip()
-            break
+    container_name = extract_container_name(result)
 
     assert container_name, f"Should find container name. stderr: {result.stderr}"
 
@@ -339,11 +333,7 @@ mode = "open"
             continue
 
         # Extract container name
-        container_name = None
-        for line in result.stderr.split("\n"):
-            if "Container name:" in line:
-                container_name = line.split("Container name:")[-1].strip()
-                break
+        container_name = extract_container_name(result)
 
         if not container_name:
             continue
@@ -429,11 +419,7 @@ mode = "restricted"
     assert result.returncode == 0, f"Shell should start. stderr: {result.stderr}"
 
     # Extract container name
-    container_name = None
-    for line in result.stderr.split("\n"):
-        if "Container name:" in line:
-            container_name = line.split("Container name:")[-1].strip()
-            break
+    container_name = extract_container_name(result)
 
     assert container_name, "Should find container name"
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1270,3 +1270,22 @@ def calculate_container_name(workspace_dir, slot):
 
     # Format: {prefix}{hash}-{slot}
     return f"{prefix}{workspace_id}-{slot}"
+
+
+def extract_container_name(result):
+    """Extract the container name a `coi shell --background` launch reported.
+
+    Complements calculate_container_name (which derives the EXPECTED name from
+    workspace+slot); this reads the ACTUAL name from the launch output. Handles
+    both the `--debug` line ("Container name: <n>") and the plain "Container: <n>"
+    line, searching stderr then stdout. Returns the name, or None if not found.
+
+    result: a subprocess.CompletedProcess from `coi shell --background` (text mode).
+    """
+    for stream in (result.stderr or "", result.stdout or ""):
+        for line in stream.splitlines():
+            if "Container name:" in line:
+                return line.split("Container name:")[-1].strip()
+            if "Container: " in line:
+                return line.split("Container: ")[-1].strip()
+    return None


### PR DESCRIPTION
Final #559 cleanup tranche — A9 (minor command edges) + C3 (safe fixture dedup). Explored first; both scoped down from the audit.

## A9 — cheap edge coverage (all host-side, misc-cli lane)
- **`coi build -a`** — assert the `-a` shorthand for `--all` is in build's help (registered via `BoolVarP`; no full build needed).
- **`coi monitor --watch --json`** — assert the unsupported combo exits **2** with `--format json is not supported with --watch` (the check runs before container resolution, so it's container-free).
- **`coi validate profile`** (new file) — the schema *logic* has 65 tests but the **CLI command had none**. Covers valid (exit 0, "is valid"), invalid (`mode="blocked"` → exit 1, "validation failed"), `--format json` (`valid=true`), and missing-arg. Host-only (`validate` skips config loading).
- **`coi unfreeze`** (new file) — Go had unit tests, no Python e2e; adds the cheap not-found error path. (Full freeze→unfreeze cycle stays in `unfreeze_integration_test.go`.)
- **`coi schema`** — already covered (`test_profile_schema.py` exercises the command). Skipped.

## C3 — the one safe dedup
New `support.helpers.extract_container_name(result)` — reads the container name a `coi shell --background` launch reported (handles both `Container name:` and `Container:` lines). Replaced the **4 identical inline parse loops** in `test_firewall_cleanup.py`.

**Deferred (deliberately):** the monitoring-config-writer dedup (thresholds vary per test; existing `enable_monitoring*` fixtures cover the common cases — extraction would over-engineer), and the 3 `host_isolation` parse sites (different format string, separate file). Noted on #559.

Gates: ruff clean, coverage guard green (new `tests/cli/*` land in the existing misc-cli lane, no matrix churn). New tests are mostly host-side → fast + no container flake. Runs in CI.