### PR TITLE
test(build): registry↔build.sh agent drift guard + e2e agent-install coverage (#454)

### DIFF
--- a/internal/image/build_sh_agents_test.go
+++ b/internal/image/build_sh_agents_test.go
@@ -1,0 +1,86 @@
+package image
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/tool"
+)
+
+// extractShellFunc returns the body of a `name() { ... }` function from build.sh,
+// assuming the closing brace sits at column 0 (the style build.sh uses).
+func extractShellFunc(t *testing.T, script, name string) string {
+	t.Helper()
+	start := strings.Index(script, name+"() {")
+	if start < 0 {
+		t.Fatalf("build.sh: function %s() not found", name)
+	}
+	rest := script[start:]
+	end := strings.Index(rest, "\n}")
+	if end < 0 {
+		t.Fatalf("build.sh: could not find end of %s()", name)
+	}
+	return rest[:end]
+}
+
+// Finding 3 (registry <-> build.sh drift): the agent list is hardcoded in build.sh
+// twice — the install_selected_agents case arms and the ${COI_AGENTS:-...} default —
+// parallel to the Go tool registry. Nothing at compile time keeps them in sync, so a
+// newly-registered agent could pass host-side validateBuildAgents yet hit build.sh's
+// `*` arm and install nothing (silent exit-127 footgun). This test makes the registry
+// the enforced single source of truth: CI fails the moment the three diverge.
+func TestBuildScriptAgentsMatchRegistry(t *testing.T) {
+	script := string(embeddedCoiBuildScript)
+	fn := extractShellFunc(t, script, "install_selected_agents")
+
+	want := tool.ListSupported() // already sorted
+	if len(want) == 0 {
+		t.Fatal("tool.ListSupported() is empty")
+	}
+
+	// (a) case arms: `claude) install_claude_cli ;;` etc. Skip the "") and *) arms.
+	caseArm := regexp.MustCompile(`(?m)^\s*([a-z0-9_-]+)\)\s+install_`)
+	got := caseArm.FindAllStringSubmatch(fn, -1)
+	arms := make([]string, 0, len(got))
+	for _, m := range got {
+		arms = append(arms, m[1])
+	}
+	sort.Strings(arms)
+	if strings.Join(arms, ",") != strings.Join(want, ",") {
+		t.Errorf("install_selected_agents case arms %v do not match tool.ListSupported() %v; "+
+			"add/remove a case arm (and an install_<agent> function) to match the registry", arms, want)
+	}
+
+	// (b) default fallback literal: ${COI_AGENTS:-claude opencode pi}
+	def := regexp.MustCompile(`COI_AGENTS:-([^}]*)}`).FindStringSubmatch(fn)
+	if def == nil {
+		t.Fatal("install_selected_agents: could not find the ${COI_AGENTS:-...} default literal")
+	}
+	defAgents := strings.Fields(strings.TrimSpace(def[1]))
+	sort.Strings(defAgents)
+	if strings.Join(defAgents, ",") != strings.Join(want, ",") {
+		t.Errorf("COI_AGENTS default %v does not match tool.ListSupported() %v; "+
+			"the unset-installs-all default must list exactly the supported agents", defAgents, want)
+	}
+}
+
+// Finding 4 (call-site coverage): the hermetic bash test sources only
+// install_selected_agents, so a revert of main() to the old unconditional
+// install_claude_cli/install_opencode/install_pi calls would leave every test
+// green while the selector goes dead. Assert main() dispatches through
+// install_selected_agents and does NOT call the per-agent installers directly.
+func TestBuildScriptMainDispatchesThroughSelector(t *testing.T) {
+	main := extractShellFunc(t, string(embeddedCoiBuildScript), "main")
+
+	if !strings.Contains(main, "install_selected_agents") {
+		t.Error("main() must call install_selected_agents (agent selection is bypassed otherwise)")
+	}
+	for _, direct := range []string{"install_claude_cli", "install_opencode", "install_pi"} {
+		if strings.Contains(main, direct) {
+			t.Errorf("main() calls %s directly; per-agent installers must only be reached via "+
+				"install_selected_agents so COI_AGENTS is honored", direct)
+		}
+	}
+}

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -514,7 +514,7 @@ func (b *Builder) runBuildScriptResolved(resolvedScript string) error {
 	}
 
 	b.opts.Logger("Executing build script...")
-	execOpts := container.ExecCommandOptions{Capture: false, Env: agentEnv(b.opts.Agents)}
+	execOpts := b.buildScriptExecOpts()
 	if _, err := b.mgr.ExecCommand("/tmp/build.sh", execOpts); err != nil {
 		return fmt.Errorf("build script failed: %w", err)
 	}
@@ -683,4 +683,11 @@ func agentEnv(agents []string) map[string]string {
 		return nil
 	}
 	return map[string]string{"COI_AGENTS": strings.Join(agents, ",")}
+}
+
+// buildScriptExecOpts builds the exec options used to run build.sh in the build
+// container. It threads the agent selection through COI_AGENTS (#454); kept as a
+// method so the wiring is unit-testable without launching a container.
+func (b *Builder) buildScriptExecOpts() container.ExecCommandOptions {
+	return container.ExecCommandOptions{Capture: false, Env: agentEnv(b.opts.Agents)}
 }

--- a/internal/image/builder_agents_test.go
+++ b/internal/image/builder_agents_test.go
@@ -14,3 +14,24 @@ func TestAgentEnv(t *testing.T) {
 		t.Errorf("COI_AGENTS = %q, want %q", env["COI_AGENTS"], "claude,pi")
 	}
 }
+
+// Finding 4 (Env wiring): prove the builder actually threads the agent selection
+// into the exec options used to run build.sh — i.e. runBuildScriptResolved does not
+// silently drop the Env. Testable without launching a container.
+func TestBuildScriptExecOpts(t *testing.T) {
+	// Selection present -> COI_AGENTS delivered to the script.
+	b := NewBuilder(BuildOptions{Agents: []string{"claude", "pi"}})
+	opts := b.buildScriptExecOpts()
+	if opts.Env["COI_AGENTS"] != "claude,pi" {
+		t.Errorf("exec opts COI_AGENTS = %q, want %q", opts.Env["COI_AGENTS"], "claude,pi")
+	}
+	if opts.Capture {
+		t.Error("build script exec should stream (Capture=false), not capture")
+	}
+
+	// No selection -> no COI_AGENTS, so build.sh keeps its install-all default.
+	b = NewBuilder(BuildOptions{})
+	if opts := b.buildScriptExecOpts(); opts.Env != nil {
+		t.Errorf("empty agents should leave Env nil (COI_AGENTS unset), got %v", opts.Env)
+	}
+}

--- a/tests/build/test_agent_selection.py
+++ b/tests/build/test_agent_selection.py
@@ -140,7 +140,7 @@ def test_coi_build_warns_when_configured_tool_not_built(coi_binary, workspace_di
     assert result.returncode == 0, f"warn is non-fatal; build should skip/succeed:\n{combined}"
 
 
-def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp_path):
+def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir):
     """End-to-end proof (#454, review finding 4): a real `coi build` with
     agents=["claude"] produces a coi-default image that HAS claude but NOT opencode/pi.
 
@@ -154,10 +154,10 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
     if shutil.which("incus") is None:
         pytest.skip("incus CLI not available")
 
-    # Capture the original image so it can be restored afterwards. `coi build --force`
-    # only re-points the coi-default alias at the new (slim) image; the original full
-    # image stays in the store, so restoring is normally just re-aliasing its
-    # fingerprint. Keep an export as a fallback in case the original is ever removed.
+    # Capture the original image fingerprint so it can be restored afterwards. `coi
+    # build --force` re-points the coi-default alias at the freshly built (slim) image
+    # and leaves the original in the store, so restoring is just deleting the slim image
+    # and re-aliasing this fingerprint — no multi-hundred-MB export needed.
     info = subprocess.run(
         ["incus", "image", "info", "coi-default"], capture_output=True, text=True, timeout=60
     )
@@ -165,15 +165,6 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
     if info.returncode != 0 or not m:
         pytest.skip("could not read coi-default fingerprint to back it up")
     orig_fp = m.group(1)
-
-    exp = subprocess.run(
-        ["incus", "image", "export", "coi-default", str(tmp_path / "coi-default-backup")],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    backups = list(tmp_path.glob("coi-default-backup*"))
-    backup_tar = str(backups[0]) if (exp.returncode == 0 and backups) else None
 
     coi_dir = Path(workspace_dir) / ".coi"
     coi_dir.mkdir(exist_ok=True)
@@ -216,50 +207,56 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
         assert "MISS:opencode" in out, f"opencode must be ABSENT with agents=[claude]:\n{out}"
         assert "MISS:pi" in out, f"pi must be ABSENT with agents=[claude]:\n{out}"
     finally:
-        # Restore the shared coi-default for sibling tests in this lane. `coi build
-        # --force` moved the alias to the slim image but left the original in the store,
-        # so re-pointing the alias is enough (and avoids a fingerprint collision on
-        # re-import). Fall back to importing the export only if the original is gone.
+        # Restore the shared coi-default for sibling tests in this lane (which run in
+        # randomized order, so a slip here cascades). `coi build --force` re-pointed
+        # coi-default at the slim image and left the original in the store. Delete the
+        # slim image — which drops its coi-default alias AND reclaims disk in one step —
+        # then re-alias the original fingerprint. Deleting the image first means the
+        # subsequent alias create cannot fail with "already exists", and the alias is
+        # re-created immediately, so coi-default is never left unaliased on this path.
         cur = subprocess.run(
             ["incus", "image", "info", "coi-default"], capture_output=True, text=True, timeout=60
         )
         mcur = re.search(r"Fingerprint:\s*([0-9a-f]+)", cur.stdout)
         slim_fp = mcur.group(1) if mcur else None
 
-        subprocess.run(
-            ["incus", "image", "alias", "delete", "coi-default"],
-            capture_output=True,
-            text=True,
-            timeout=60,
+        orig_present = (
+            subprocess.run(
+                ["incus", "image", "info", orig_fp], capture_output=True, text=True, timeout=60
+            ).returncode
+            == 0
         )
-        still = subprocess.run(
-            ["incus", "image", "info", orig_fp], capture_output=True, text=True, timeout=60
-        )
-        if still.returncode == 0:
+
+        # Only act when the build actually produced a distinct slim image and the
+        # original survives. Otherwise (build skipped/failed -> still original, or the
+        # original is somehow gone) coi-default already resolves to a working image, so
+        # leave it as-is rather than risk unaliasing the shared image.
+        if orig_present and slim_fp and slim_fp != orig_fp:
+            subprocess.run(
+                ["incus", "image", "delete", slim_fp], capture_output=True, text=True, timeout=120
+            )
             restore = subprocess.run(
                 ["incus", "image", "alias", "create", "coi-default", orig_fp],
                 capture_output=True,
                 text=True,
                 timeout=60,
             )
-        elif backup_tar:
-            restore = subprocess.run(
-                ["incus", "image", "import", backup_tar, "--alias", "coi-default"],
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-        else:
-            restore = still
-        assert restore.returncode == 0, (
-            f"failed to restore shared coi-default: {restore.stdout}{restore.stderr}"
-        )
-
-        # Reclaim disk: drop the now-orphaned slim image (core-build is image-intensive).
-        if slim_fp and slim_fp != orig_fp:
-            subprocess.run(
-                ["incus", "image", "delete", slim_fp],
-                capture_output=True,
-                text=True,
-                timeout=120,
+            if restore.returncode != 0:
+                # The slim delete didn't drop the alias (e.g. image was locked); force
+                # it off and recreate so coi-default ends up on the original image.
+                subprocess.run(
+                    ["incus", "image", "alias", "delete", "coi-default"],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                restore = subprocess.run(
+                    ["incus", "image", "alias", "create", "coi-default", orig_fp],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            assert restore.returncode == 0, (
+                f"failed to re-alias coi-default to the original image: "
+                f"{restore.stdout}{restore.stderr}"
             )

--- a/tests/build/test_agent_selection.py
+++ b/tests/build/test_agent_selection.py
@@ -161,7 +161,9 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
     else:
         exp = subprocess.run(
             ["incus", "image", "export", "coi-default", str(tmp_path / "coi-default-backup")],
-            capture_output=True, text=True, timeout=300,
+            capture_output=True,
+            text=True,
+            timeout=300,
         )
         if exp.returncode != 0:
             pytest.skip(f"could not back up coi-default: {exp.stderr}")
@@ -179,7 +181,10 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
     try:
         build = subprocess.run(
             [coi_binary, "build", "--force"],
-            capture_output=True, text=True, timeout=1500, cwd=workspace_dir,
+            capture_output=True,
+            text=True,
+            timeout=1500,
+            cwd=workspace_dir,
         )
         assert build.returncode == 0, f"slim build failed:\n{build.stdout}{build.stderr}"
 
@@ -187,10 +192,20 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
         # unselected agents absent. `command -v` failing is exactly the runtime footgun
         # the selector must avoid for the configured tool, so it is the right probe.
         probe = subprocess.run(
-            [coi_binary, "run", "--workspace", workspace_dir, "--", "bash", "-lc",
-             "for a in claude opencode pi; do "
-             "command -v \"$a\" >/dev/null 2>&1 && echo HAVE:$a || echo MISS:$a; done"],
-            capture_output=True, text=True, timeout=300,
+            [
+                coi_binary,
+                "run",
+                "--workspace",
+                workspace_dir,
+                "--",
+                "bash",
+                "-lc",
+                "for a in claude opencode pi; do "
+                'command -v "$a" >/dev/null 2>&1 && echo HAVE:$a || echo MISS:$a; done',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
         )
         out = probe.stdout + probe.stderr
         assert probe.returncode == 0, f"probe run failed:\n{out}"
@@ -199,11 +214,14 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
         assert "MISS:pi" in out, f"pi must be ABSENT with agents=[claude]:\n{out}"
     finally:
         # Restore the shared coi-default (full agents) for sibling tests in this lane.
-        subprocess.run(["incus", "image", "delete", "coi-default"],
-                       capture_output=True, text=True, timeout=120)
+        subprocess.run(
+            ["incus", "image", "delete", "coi-default"], capture_output=True, text=True, timeout=120
+        )
         restore = subprocess.run(
             ["incus", "image", "import", backup_tar, "--alias", "coi-default"],
-            capture_output=True, text=True, timeout=300,
+            capture_output=True,
+            text=True,
+            timeout=300,
         )
         assert restore.returncode == 0, (
             f"failed to restore shared coi-default from {backup_tar}: {restore.stderr}"

--- a/tests/build/test_agent_selection.py
+++ b/tests/build/test_agent_selection.py
@@ -13,6 +13,7 @@ install functions as markers, and assert the dispatch. Hermetic: no network, no 
 """
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -153,24 +154,26 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
     if shutil.which("incus") is None:
         pytest.skip("incus CLI not available")
 
-    # Restore source for the shared image: prefer the pristine CI cache tarball
-    # (always the full, all-agents image); fall back to a local export otherwise.
-    ci_cache = "/tmp/coi-image.tar.gz"
-    if os.path.exists(ci_cache):
-        backup_tar = ci_cache
-    else:
-        exp = subprocess.run(
-            ["incus", "image", "export", "coi-default", str(tmp_path / "coi-default-backup")],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-        if exp.returncode != 0:
-            pytest.skip(f"could not back up coi-default: {exp.stderr}")
-        backups = list(tmp_path.glob("coi-default-backup*"))
-        if not backups:
-            pytest.skip("image export produced no tarball to restore from")
-        backup_tar = str(backups[0])
+    # Capture the original image so it can be restored afterwards. `coi build --force`
+    # only re-points the coi-default alias at the new (slim) image; the original full
+    # image stays in the store, so restoring is normally just re-aliasing its
+    # fingerprint. Keep an export as a fallback in case the original is ever removed.
+    info = subprocess.run(
+        ["incus", "image", "info", "coi-default"], capture_output=True, text=True, timeout=60
+    )
+    m = re.search(r"Fingerprint:\s*([0-9a-f]+)", info.stdout)
+    if info.returncode != 0 or not m:
+        pytest.skip("could not read coi-default fingerprint to back it up")
+    orig_fp = m.group(1)
+
+    exp = subprocess.run(
+        ["incus", "image", "export", "coi-default", str(tmp_path / "coi-default-backup")],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    backups = list(tmp_path.glob("coi-default-backup*"))
+    backup_tar = str(backups[0]) if (exp.returncode == 0 and backups) else None
 
     coi_dir = Path(workspace_dir) / ".coi"
     coi_dir.mkdir(exist_ok=True)
@@ -213,16 +216,50 @@ def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp
         assert "MISS:opencode" in out, f"opencode must be ABSENT with agents=[claude]:\n{out}"
         assert "MISS:pi" in out, f"pi must be ABSENT with agents=[claude]:\n{out}"
     finally:
-        # Restore the shared coi-default (full agents) for sibling tests in this lane.
-        subprocess.run(
-            ["incus", "image", "delete", "coi-default"], capture_output=True, text=True, timeout=120
+        # Restore the shared coi-default for sibling tests in this lane. `coi build
+        # --force` moved the alias to the slim image but left the original in the store,
+        # so re-pointing the alias is enough (and avoids a fingerprint collision on
+        # re-import). Fall back to importing the export only if the original is gone.
+        cur = subprocess.run(
+            ["incus", "image", "info", "coi-default"], capture_output=True, text=True, timeout=60
         )
-        restore = subprocess.run(
-            ["incus", "image", "import", backup_tar, "--alias", "coi-default"],
+        mcur = re.search(r"Fingerprint:\s*([0-9a-f]+)", cur.stdout)
+        slim_fp = mcur.group(1) if mcur else None
+
+        subprocess.run(
+            ["incus", "image", "alias", "delete", "coi-default"],
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=60,
         )
+        still = subprocess.run(
+            ["incus", "image", "info", orig_fp], capture_output=True, text=True, timeout=60
+        )
+        if still.returncode == 0:
+            restore = subprocess.run(
+                ["incus", "image", "alias", "create", "coi-default", orig_fp],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        elif backup_tar:
+            restore = subprocess.run(
+                ["incus", "image", "import", backup_tar, "--alias", "coi-default"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        else:
+            restore = still
         assert restore.returncode == 0, (
-            f"failed to restore shared coi-default from {backup_tar}: {restore.stderr}"
+            f"failed to restore shared coi-default: {restore.stdout}{restore.stderr}"
         )
+
+        # Reclaim disk: drop the now-orphaned slim image (core-build is image-intensive).
+        if slim_fp and slim_fp != orig_fp:
+            subprocess.run(
+                ["incus", "image", "delete", slim_fp],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )

--- a/tests/build/test_agent_selection.py
+++ b/tests/build/test_agent_selection.py
@@ -13,6 +13,7 @@ install functions as markers, and assert the dispatch. Hermetic: no network, no 
 """
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -136,3 +137,74 @@ def test_coi_build_warns_when_configured_tool_not_built(coi_binary, workspace_di
     # Warn fired (tool 'claude' not in agents) and the build did not error out.
     assert "claude" in combined.lower() and "warning" in combined.lower(), combined
     assert result.returncode == 0, f"warn is non-fatal; build should skip/succeed:\n{combined}"
+
+
+def test_slim_build_installs_only_selected_agents(coi_binary, workspace_dir, tmp_path):
+    """End-to-end proof (#454, review finding 4): a real `coi build` with
+    agents=["claude"] produces a coi-default image that HAS claude but NOT opencode/pi.
+
+    This is the one link the unit + hermetic tests cannot cover on their own — it
+    exercises the whole chain for real: project config -> BuildOptions.Agents ->
+    agentEnv -> COI_AGENTS env -> ExecCommand -> build.sh's install_selected_agents ->
+    the actual installed binary set. The shared coi-default image is backed up and
+    restored so sibling tests in this lane are unaffected. Slow (a real image build);
+    only runs where coi-default + incus already exist (the core-build CI lane)."""
+    _skip_without_incus(coi_binary)
+    if shutil.which("incus") is None:
+        pytest.skip("incus CLI not available")
+
+    # Restore source for the shared image: prefer the pristine CI cache tarball
+    # (always the full, all-agents image); fall back to a local export otherwise.
+    ci_cache = "/tmp/coi-image.tar.gz"
+    if os.path.exists(ci_cache):
+        backup_tar = ci_cache
+    else:
+        exp = subprocess.run(
+            ["incus", "image", "export", "coi-default", str(tmp_path / "coi-default-backup")],
+            capture_output=True, text=True, timeout=300,
+        )
+        if exp.returncode != 0:
+            pytest.skip(f"could not back up coi-default: {exp.stderr}")
+        backups = list(tmp_path.glob("coi-default-backup*"))
+        if not backups:
+            pytest.skip("image export produced no tarball to restore from")
+        backup_tar = str(backups[0])
+
+    coi_dir = Path(workspace_dir) / ".coi"
+    coi_dir.mkdir(exist_ok=True)
+    (coi_dir / "config.toml").write_text(
+        '[container]\nimage = "coi-default"\n\n[container.build]\nagents = ["claude"]\n'
+    )
+
+    try:
+        build = subprocess.run(
+            [coi_binary, "build", "--force"],
+            capture_output=True, text=True, timeout=1500, cwd=workspace_dir,
+        )
+        assert build.returncode == 0, f"slim build failed:\n{build.stdout}{build.stderr}"
+
+        # Inspect the built image via a throwaway container: claude present, the two
+        # unselected agents absent. `command -v` failing is exactly the runtime footgun
+        # the selector must avoid for the configured tool, so it is the right probe.
+        probe = subprocess.run(
+            [coi_binary, "run", "--workspace", workspace_dir, "--", "bash", "-lc",
+             "for a in claude opencode pi; do "
+             "command -v \"$a\" >/dev/null 2>&1 && echo HAVE:$a || echo MISS:$a; done"],
+            capture_output=True, text=True, timeout=300,
+        )
+        out = probe.stdout + probe.stderr
+        assert probe.returncode == 0, f"probe run failed:\n{out}"
+        assert "HAVE:claude" in out, f"claude must be installed with agents=[claude]:\n{out}"
+        assert "MISS:opencode" in out, f"opencode must be ABSENT with agents=[claude]:\n{out}"
+        assert "MISS:pi" in out, f"pi must be ABSENT with agents=[claude]:\n{out}"
+    finally:
+        # Restore the shared coi-default (full agents) for sibling tests in this lane.
+        subprocess.run(["incus", "image", "delete", "coi-default"],
+                       capture_output=True, text=True, timeout=120)
+        restore = subprocess.run(
+            ["incus", "image", "import", backup_tar, "--alias", "coi-default"],
+            capture_output=True, text=True, timeout=300,
+        )
+        assert restore.returncode == 0, (
+            f"failed to restore shared coi-default from {backup_tar}: {restore.stderr}"
+        )


### PR DESCRIPTION
Follow-up to the #574 code review — fixes review **findings 3 and 4** (the two I flagged as out of scope at merge time).

## Finding 3 — registry ↔ build.sh drift guard
The agent set was hardcoded in `build.sh` **twice** (the `install_selected_agents` case arms and the `${COI_AGENTS:-claude opencode pi}` default), parallel to `tool.ListSupported()` with nothing enforcing agreement. A newly-registered agent could pass host-side `validateBuildAgents` yet hit build.sh's `*` arm and install **nothing** — a silent exit-127 footgun.

- `TestBuildScriptAgentsMatchRegistry` parses the embedded `build.sh` and asserts **both** the case arms and the default literal equal `tool.ListSupported()`. CI now fails the moment the registry and build.sh diverge.

## Finding 4 — end-to-end agent-install coverage
The chain `config → BuildOptions.Agents → agentEnv → COI_AGENTS → ExecCommand → build.sh → installed set` was only tested in disjoint pieces (a revert of `main()` or a dropped `Env:` stayed green).

- Extracted `buildScriptExecOpts()` from `runBuildScriptResolved` + unit test proving the builder threads `COI_AGENTS` into the exec (Env not dropped).
- `TestBuildScriptMainDispatchesThroughSelector` — asserts `main()` dispatches via `install_selected_agents` and never calls the per-agent installers directly (the revert-main regression the hermetic test can't see).
- `test_slim_build_installs_only_selected_agents` — a **real** `coi build` with `agents=["claude"]` proves the produced image **has claude and lacks opencode/pi**. Backs up and restores the shared `coi-default` (prefers the pristine CI cache tarball) so sibling tests in the lane are unaffected. Runs in the `core-build` lane; skips where incus/coi-default are absent.

Local: `go build`, `go vet`, `gofmt`, `go test ./internal/...`, `ruff`, `bash -n build.sh`, and the CI coverage guard all pass.