### PR TITLE
ci(release): fix zizmor high-severity findings in release workflow (#332)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,17 @@ on:
         description: 'Release version (e.g., v0.1.0)'
         required: true
 
-permissions:
-  contents: write
+# Least privilege per job: only the release job publishes, so only it gets
+# write. A workflow-level `contents: write` would also hand write access to
+# the build job, which merely compiles.
+permissions: {}
 
 jobs:
   build:
     name: Build binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -28,19 +32,33 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # The build job never pushes; don't leave the token in .git/config
+          # where the uploaded artifact tooling could see it (zizmor: artipacked).
+          # The release job's checkout keeps credentials — it pushes the
+          # `latest` tag.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.25'
+          # No cache in the workflow that builds RELEASE binaries: a poisoned
+          # Go module/build cache written by any other workflow would be baked
+          # into published artifacts (zizmor: cache-poisoning).
+          cache: false
 
       - name: Get version
         id: version
+        # Dispatch input reaches the shell via env, not template expansion, so
+        # its value can never be interpreted as code (zizmor: template-injection).
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=$VERSION_INPUT" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install build dependencies for CGo journal access
@@ -75,10 +93,11 @@ jobs:
       - name: Verify version
         # Only verify amd64 builds since ARM64 cannot run on amd64 runners
         if: matrix.arch == 'amd64'
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           chmod +x coi-${{ matrix.os }}-${{ matrix.arch }}
           BUILT_VERSION=$(./coi-${{ matrix.os }}-${{ matrix.arch }} version | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-          EXPECTED_VERSION=${{ steps.version.outputs.version }}
           # Strip leading 'v' from expected version if present
           EXPECTED_VERSION=${EXPECTED_VERSION#v}
           echo "Built version: $BUILT_VERSION"
@@ -99,6 +118,8 @@ jobs:
     name: Create release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -111,11 +132,14 @@ jobs:
 
       - name: Get version
         id: version
+        # Same env indirection as the build job (zizmor: template-injection).
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=$VERSION_INPUT" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Prepare release files
@@ -132,6 +156,11 @@ jobs:
           cat checksums.txt
 
       - name: Create release notes
+        # The heredoc stays quoted ('EOF') so the markdown backticks are never
+        # shell-substituted; the version lands via a placeholder + sed from
+        # env instead of template expansion (zizmor: template-injection).
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           cat > release-notes.md << 'EOF'
           ## Installation
@@ -148,14 +177,14 @@ jobs:
 
           #### Linux AMD64 (x86_64)
           ```bash
-          wget https://github.com/mensfeld/code-on-incus/releases/download/${{ steps.version.outputs.version }}/coi-linux-amd64
+          wget https://github.com/mensfeld/code-on-incus/releases/download/__VERSION__/coi-linux-amd64
           chmod +x coi-linux-amd64
           sudo mv coi-linux-amd64 /usr/local/bin/coi
           ```
 
           #### Linux ARM64 (aarch64)
           ```bash
-          wget https://github.com/mensfeld/code-on-incus/releases/download/${{ steps.version.outputs.version }}/coi-linux-arm64
+          wget https://github.com/mensfeld/code-on-incus/releases/download/__VERSION__/coi-linux-arm64
           chmod +x coi-linux-arm64
           sudo mv coi-linux-arm64 /usr/local/bin/coi
           ```
@@ -183,6 +212,7 @@ jobs:
           - [Wiki](https://github.com/mensfeld/code-on-incus/wiki)
           - [CHANGELOG](https://github.com/mensfeld/code-on-incus/blob/master/CHANGELOG.md)
           EOF
+          sed -i "s|__VERSION__|$VERSION|g" release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3


### PR DESCRIPTION
Pre-release hardening pass for `release.yml` (the workflow 0.10.0 is about to exercise), addressing the actionable subset of #332 **without enrolling any third-party tooling** — zizmor 1.26.1 was run locally as a one-off linter; nothing is added to CI.

## Fixed (all 4 high-severity findings)

1. **excessive-permissions** — `contents: write` was declared workflow-level, so the build job (which only compiles) also held write. Now: `permissions: {}` at workflow level, `contents: read` on `build`, `contents: write` only on `release`.
2. **template-injection ×2** — the `workflow_dispatch` version input was expanded directly into `run` scripts. All `steps.version.outputs.version` / `inputs.version` uses now reach the shell via `env` indirection. The release-notes heredoc deliberately **stays quoted** (unquoting it would expose the markdown backtick fences to shell command substitution) and gets the version via a `__VERSION__` placeholder + `sed` from env.
3. **cache-poisoning** — `setup-go`'s default cache fed the job that builds the **published release binaries**; a poisoned module/build cache written by any other workflow could be baked into artifacts. `cache: false` in this workflow only (CI keeps its caches).

Plus one low: `persist-credentials: false` on the build job's checkout (artipacked). The release job's checkout intentionally keeps credentials — its last step pushes the `latest` tag.

## Deliberately not changed

- `softprops/action-gh-release` (zizmor info: "use `gh release`") — swapping the release-creation mechanism right before a release is the wrong moment; can be a follow-up.
- Findings in the other workflows (all low/informational after suppression) — out of scope for the pre-release pass.
- No StepSecurity/scorecard/zizmor-as-required-check enrollment, per the #332 discussion state.

Verification: zizmor on `release.yml` now reports 0 high / 0 medium (1 info + 1 low, both the deliberate keeps above); the file parses clean. Behavior of the workflow is unchanged for the tag-push path — the version string flows identically, just via env.