### PR TITLE
chore(release): date CHANGELOG for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.10.0 (Unreleased)
+## 0.10.0 (2026-07-10)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Release prep, same shape as #500 for 0.9.0: stamp the 0.10.0 CHANGELOG section with today's date. Tag `v0.10.0` follows once this merges.

Pre-release checklist already completed:
- release.yml hardened against all zizmor high-severity findings (#585)
- issue tracker triaged (#185 closed as superseded, #531 fixed on the wiki, #332 progressed)
- wiki: current-feature docs published; the 0.10 removed-flags sweep + 0.9→0.10 migration section is parked on the wiki's `release-0.10-docs` branch, to be fast-forwarded to master at tag time