### PR TITLE
[red proof — do not merge] close/poweroff cleanup reproduction tests only

### DIFF
--- a/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
+++ b/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
@@ -1,0 +1,117 @@
+"""
+Test for coi shell (ephemeral) - a SLOW guest shutdown must still end with
+the container removed.
+
+Cleanup distinguishes "user powered the container off" (delete it) from
+"user typed exit" (keep it for re-attach) by polling the container state for
+a fixed ~5s after the shell ends. Any shutdown slower than that window was
+mislabeled as a normal exit: cleanup printed "Container kept running - use
+'coi attach' to reconnect..." and the ephemeral container was never removed
+(it finished stopping moments later and lingered as a stopped leftover).
+
+The stock power wrappers (`close`/`poweroff`/...) use `systemctl --force
+poweroff`, which skips unit stop jobs and usually finishes inside the old
+window — which is exactly why the plain poweroff tests never caught this.
+This test pins the guest in "stopping" deterministically: a transient unit
+with a slow ExecStop plus a NON-forced `systemctl poweroff` (which honors
+unit stops) keeps the container shutting down for ~30s.
+"""
+
+import time
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    get_container_list,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_specific_container_deletion,
+    wait_for_text_in_monitor,
+    with_live_screen,
+)
+
+
+def test_slow_shutdown_removes_ephemeral(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Flow:
+    1. Start coi shell (ephemeral), exit the dummy tool to bash
+    2. Install a transient unit whose ExecStop sleeps 30s
+    3. Power off WITHOUT --force so the slow unit stop is honored
+    4. The shell dies early in the shutdown; the guest keeps stopping ~30s
+    5. Cleanup must still recognize the poweroff and DELETE the container
+    """
+    env = {"COI_USE_DUMMY": "1"}
+
+    child = spawn_coi(
+        coi_binary,
+        ["shell"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # Exit the dummy tool to bash
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
+    time.sleep(5)
+
+    # A transient unit whose stop takes ~30s: this holds the whole (non-forced)
+    # shutdown in "stopping" well past cleanup's old fixed polling window.
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+        child.send(
+            "sudo systemd-run --unit=coi-test-slowstop -p TimeoutStopSec=45 "
+            "-p ExecStop='/bin/sleep 30' /bin/sleep infinity && echo SLOWSTOP_READY"
+        )
+        time.sleep(0.5)
+        child.send("\x0d")
+        started = wait_for_text_in_monitor(monitor, "SLOWSTOP_READY", timeout=20)
+        assert started, "transient slow-stop unit should start"
+
+    # Verify container is running before shutdown
+    assert container_name in get_container_list(), (
+        f"Container {container_name} should be running before poweroff"
+    )
+
+    # Non-forced poweroff honors the slow unit stop (the wrappers' --force
+    # would skip it and stop too fast to reproduce the race)
+    child.send("sudo systemctl poweroff")
+    time.sleep(0.3)
+    child.send("\x0d")
+
+    try:
+        child.expect(EOF, timeout=90)
+    except TIMEOUT:
+        pass
+
+    if hasattr(child.logfile_read, "get_raw_output"):
+        output = child.logfile_read.get_raw_output()
+    elif hasattr(child.logfile_read, "get_output"):
+        output = child.logfile_read.get_output()
+    else:
+        output = ""
+
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+
+    # The user powered the container off: however slow the guest shutdown is,
+    # the ephemeral container must be recognized as stopped and removed.
+    deleted = wait_for_specific_container_deletion(container_name, timeout=120)
+
+    assert "Container kept running" not in output, (
+        f"a slow poweroff must not be mislabeled as a normal exit. Got:\n{output}"
+    )
+    assert deleted, (
+        f"Ephemeral container {container_name} must be removed after a slow poweroff "
+        f"(waited 120s). Output:\n{output}"
+    )

--- a/tests/shell/persistent/close_stops_and_keeps_persistent.py
+++ b/tests/shell/persistent/close_stops_and_keeps_persistent.py
@@ -1,0 +1,128 @@
+"""
+Test for coi shell in persistent mode - `close` stops the container and
+cleanup reports it truthfully.
+
+`close` is the in-container wrapper for `systemctl --force poweroff`: it
+shuts the guest DOWN. In persistent mode the container must be KEPT but end
+up STOPPED — and the cleanup message must say so. The persistent cleanup
+branch used to print "Container kept running - use 'coi attach' to
+reconnect..." unconditionally whenever the container existed, i.e. also
+while `close` was powering it off, telling the user their instance was still
+up when it was going (or already) down.
+"""
+
+import subprocess
+import time
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    send_prompt,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_text_in_monitor,
+    with_live_screen,
+    write_workspace_container_config,
+)
+
+
+def container_status(name):
+    """Return the container's status string ("" if it does not exist)."""
+    result = subprocess.run(
+        ["incus", "list", name, "--format=csv", "-c", "ns"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    for line in result.stdout.strip().split("\n"):
+        parts = line.split(",")
+        if len(parts) >= 2 and parts[0] == name:
+            return parts[1].strip()
+    return ""
+
+
+def test_close_stops_and_keeps_persistent(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Flow:
+    1. Start coi shell in persistent mode (via workspace config)
+    2. Exit the dummy tool to bash
+    3. Run `close` (the poweroff wrapper users are told about)
+    4. Verify the container is KEPT but reaches STOPPED
+    5. Verify cleanup does NOT claim the container was kept running
+    """
+    env = {"COI_USE_DUMMY": "1"}
+    write_workspace_container_config(workspace_dir, persistent=True)
+
+    child = spawn_coi(
+        coi_binary,
+        ["shell"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    with with_live_screen(child) as monitor:
+        time.sleep(2)
+        send_prompt(child, "hello from close test")
+        responded = wait_for_text_in_monitor(monitor, "hello from close test-BACK", timeout=30)
+        assert responded, "Dummy CLI should respond with echo"
+
+    # Exit the dummy tool to bash
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
+    time.sleep(5)
+
+    # Power the container off with the `close` wrapper
+    child.send("close")
+    time.sleep(0.3)
+    child.send("\x0d")
+
+    try:
+        child.expect(EOF, timeout=90)
+    except TIMEOUT:
+        pass
+
+    if hasattr(child.logfile_read, "get_raw_output"):
+        output = child.logfile_read.get_raw_output()
+    elif hasattr(child.logfile_read, "get_output"):
+        output = child.logfile_read.get_output()
+    else:
+        output = ""
+
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+
+    # The container must be KEPT (persistent) and reach STOPPED: close
+    # invokes a poweroff, so "still running" is never the end state.
+    status = ""
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        status = container_status(container_name)
+        if status.lower() == "stopped":
+            break
+        time.sleep(1)
+
+    assert status != "", f"Persistent container {container_name} must be kept after close"
+    assert status.lower() == "stopped", (
+        f"close powers the container off; expected STOPPED, got {status}"
+    )
+
+    # The cleanup message must reflect that: claiming the container was
+    # "kept running" (and suggesting `coi attach`) after a poweroff is the
+    # bug this test pins down.
+    assert "Container kept running" not in output, (
+        f"cleanup must not claim a powering-off container was kept running. Got:\n{output}"
+    )
+    assert "kept" in output.lower(), (
+        f"cleanup should still say the persistent container was kept. Got:\n{output}"
+    )


### PR DESCRIPTION
CI-proof companion to #597: this branch carries ONLY the phase-1 reproduction tests (a537aa3), so the shell-ephemeral and shell-persistent lanes are **expected to fail** here, proving the tests reproduce the bug on master without the fix. Will be closed once the red run is recorded. Do not merge.