### PR TITLE
fix(shell): harden close/poweroff cleanup — force-stop fallback, bounded probe, fail-safe state reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.10.2 (Unreleased)
+
+### Fixed
+
+- **`close`/poweroff cleanup hardening (follow-up review of #597)** — a review pass over the 0.10.1 shutdown-detection fix found and fixed a cluster of edge cases: (1) a detected shutdown that OUTLASTS `[container] shutdown_timeout` (stock systemd stop budgets are 90s vs COI's 60s default) no longer relapses into the "kept running" mislabel — cleanup now escalates exactly like `coi shutdown` does, forcing the stop and honoring the contract (ephemeral → removed, persistent → kept and reported stopped); (2) the guest probe got a hard 10s deadline — the exec transport can wedge against a dying or responder-frozen container, and teardown previously had no bound at all on it; (3) the shutdown wait is now interruptible: Ctrl+C during the (up to 60s) wait forces the stop and proceeds instead of being silently swallowed until SIGKILL; (4) incus-daemon errors are no longer read as "container stopped" — state reads retry and fail SAFE (leave the container untouched, say so) instead of routing a live container into force-delete or printing "kept (stopped)" over a running one; (5) probe classification now follows the #590 stderr idiom: "Failed to connect to bus" on a Running container counts as shutdown evidence, "command not found" (non-systemd image) is decided instantly instead of burning a 3s retry loop on every exit, and systemd's late-shutdown "offline"/"unknown" answers are treated as ambiguous-and-recheck rather than "user exit"; (6) when the session save failed, the removal message no longer claims "session data saved for --resume"; (7) the shutdown-timeout default now has a single source (`config.DefaultShutdownTimeoutSeconds`, used by `coi shutdown` and cleanup alike) and `saveSessionData` reuses the shared stop-wait instead of a private copy. The probe/wait helpers moved onto a narrow interface with a unit-test matrix; the two 0.10.1 e2e tests regained the in-bash verification the sibling poweroff test always had (so a slow dummy exit can't masquerade as a shutdown-detection bug), and a new e2e pins the over-budget path: shutdown_timeout=5 + a 30s stop must end in "forcing the stop" and a removed container.
+
 ## 0.10.1 (2026-07-12)
 
 ### New Features

--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -415,7 +415,7 @@ func (a *App) setupContainerPhase(s *shellState) session.Phase {
 					SessionLogger:  s.result.Logger,
 					// Bound the wait for an in-flight `close`/poweroff by the
 					// same budget graceful shutdowns get everywhere else.
-					ShutdownTimeout: a.cfg.Container.ShutdownTimeout,
+					ShutdownTimeout: a.cfg.Container.ShutdownTimeoutSeconds(),
 				}
 				if err := session.Cleanup(cleanupOpts); err != nil {
 					fmt.Fprintf(os.Stderr, "Cleanup error: %v\n", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,11 +92,16 @@ func (c *ContainerConfig) HasContainerConfig() bool {
 		c.Build.HasBuildConfig()
 }
 
+// DefaultShutdownTimeoutSeconds is the graceful-shutdown window applied when
+// [container] shutdown_timeout is unset — the single source for every
+// consumer (coi shutdown, session cleanup's wait for an in-flight poweroff).
+const DefaultShutdownTimeoutSeconds = 60
+
 // ShutdownTimeoutSeconds returns the graceful-shutdown window in seconds,
-// defaulting to 60 when unset.
+// defaulting to DefaultShutdownTimeoutSeconds when unset.
 func (c *ContainerConfig) ShutdownTimeoutSeconds() int {
 	if c.ShutdownTimeout <= 0 {
-		return 60
+		return DefaultShutdownTimeoutSeconds
 	}
 	return c.ShutdownTimeout
 }

--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -3,12 +3,16 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/logger"
 	"github.com/mensfeld/code-on-incus/internal/network"
@@ -29,49 +33,138 @@ type CleanupOptions struct {
 	SessionLogger  *logger.SessionLogger
 	Logger         func(string)
 	// ShutdownTimeout is how long (seconds) to wait for an in-progress guest
-	// shutdown (`close`/poweroff) to finish before treating the container as
-	// still running; <=0 uses the [container] shutdown_timeout default (60).
+	// shutdown (`close`/poweroff) to finish before forcing the stop; <=0
+	// uses config.DefaultShutdownTimeoutSeconds (callers should pass
+	// cfg.Container.ShutdownTimeoutSeconds()).
 	ShutdownTimeout int
 }
 
-// guestShutdownInProgress reports whether the container's systemd is mid
-// shutdown. `systemctl is-system-running` prints the manager state and exits
-// non-zero for anything but "running", so classify by stdout: "stopping"
-// means a poweroff/close is in flight, any other state means the guest is up
-// and the user simply left the shell. When exec yields NO state at all (a
-// guest late in poweroff may already refuse execs — but a broken exec
-// transport looks identical) briefly re-check whether the container stops on
-// its own before concluding it is a normal exit.
-func guestShutdownInProgress(mgr container.ContainerManager) bool {
+// guestProber is the manager slice the shutdown-detection helpers need;
+// narrow so unit tests can fake it.
+type guestProber interface {
+	ExecCommand(command string, opts container.ExecCommandOptions) (string, error)
+	Running() (bool, error)
+}
+
+// probeExecTimeout bounds one guest probe: cleanup must never hang, and the
+// exec transport CAN wedge against a dying (or responder-frozen) container.
+const probeExecTimeout = 10 * time.Second
+
+// Synthetic states probeGuestState derives from the probe's failure shape,
+// distinct from anything `systemctl is-system-running` prints itself.
+const (
+	guestStateBusDown   = "coi:bus-down"   // guest answered: its D-Bus is gone (systemd tearing down)
+	guestStateNoSystemd = "coi:no-systemd" // systemctl missing: this image can never answer
+	guestStateNoAnswer  = "coi:no-answer"  // transport error or timeout: no evidence either way
+)
+
+// probeGuestState runs `systemctl is-system-running` in the guest with a
+// hard deadline and returns systemd's manager state ("stopping", "running",
+// "degraded", ...) or one of the synthetic coi: states above. The command
+// exits non-zero for every state except "running", so classification uses
+// stdout first and the stderr of the ExitError second (the #588/#590 lesson:
+// an incus-level failure and an in-guest failure arrive as the same error
+// shape and MUST be told apart before deciding a container's fate).
+func probeGuestState(mgr guestProber) string {
+	type result struct {
+		out string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		out, err := mgr.ExecCommand("systemctl is-system-running", container.ExecCommandOptions{Capture: true})
+		ch <- result{out, err}
+	}()
+	select {
+	case r := <-ch:
+		if state := strings.TrimSpace(r.out); state != "" {
+			return state
+		}
+		var exitErr *container.ExitError
+		if errors.As(r.err, &exitErr) {
+			switch stderr := exitErr.Stderr; {
+			case strings.Contains(stderr, "Failed to connect to bus"):
+				// systemctl ran but systemd's bus is gone — on a container
+				// that still reports Running, that IS the shutdown tail.
+				return guestStateBusDown
+			case strings.Contains(stderr, "command not found"):
+				return guestStateNoSystemd
+			}
+		}
+		return guestStateNoAnswer
+	case <-time.After(probeExecTimeout):
+		// Abandon the wedged exec goroutine; the process is exiting soon
+		// anyway, and blocking teardown forever is the one forbidden outcome.
+		return guestStateNoAnswer
+	}
+}
+
+// guestShutdownInProgress reports whether the guest is mid shutdown.
+// "stopping" (or an answered-but-bus-down probe) means a poweroff/close is
+// in flight; any healthy manager state means the user simply left the shell.
+// "offline"/"unknown"/no answer are AMBIGUOUS — systemd can print those in
+// the sub-second tail of a poweroff (/run unmounted, SystemState query
+// failing) and a flaking exec transport looks identical — so those re-check
+// the container state and retry briefly instead of concluding either way.
+func guestShutdownInProgress(mgr guestProber) bool {
 	for i := 0; i < 6; i++ {
-		out, _ := mgr.ExecCommand("systemctl is-system-running", container.ExecCommandOptions{Capture: true})
-		switch state := strings.TrimSpace(out); state {
-		case "stopping":
+		switch state := probeGuestState(mgr); state {
+		case "stopping", guestStateBusDown:
 			return true
-		case "":
-			if running, _ := mgr.Running(); !running {
+		case "running", "degraded", "maintenance", "initializing", "starting":
+			return false
+		case guestStateNoSystemd:
+			// This image can never answer — don't burn the retry budget on
+			// every single exit there.
+			return false
+		default: // "offline", "unknown", coi:no-answer, anything unforeseen
+			if running, err := mgr.Running(); err == nil && !running {
 				return true
 			}
-			time.Sleep(500 * time.Millisecond)
-		default:
-			// "running", "degraded", "maintenance", ... — the guest is up.
-			return false
+			if i < 5 {
+				time.Sleep(500 * time.Millisecond)
+			}
 		}
 	}
 	return false
 }
 
-// waitForStopped polls until the container stops or the timeout elapses;
-// reports whether it stopped.
-func waitForStopped(mgr container.ContainerManager, timeout time.Duration) bool {
+// containerRunning reports the container's state and whether it could be
+// determined at all. A daemon hiccup must not read as "stopped" — that is
+// what would route an ephemeral cleanup into force-delete of a live
+// container, or print "kept (stopped)" over a running one.
+func containerRunning(mgr guestProber) (running, ok bool) {
+	var err error
+	for i := 0; i < 3; i++ {
+		if running, err = mgr.Running(); err == nil {
+			return running, true
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return false, false
+}
+
+// waitForStopped polls until the container verifiably stops (an error-free
+// "not running" answer — daemon errors don't count), the timeout elapses, or
+// the user interrupts. Ctrl+C must not be a no-op here: this wait can hold
+// the terminal for the whole graceful-shutdown window, and the shell's own
+// signal plumbing is already disarmed by the time the deferred teardown runs.
+func waitForStopped(mgr guestProber, timeout time.Duration) (stopped, interrupted bool) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sig)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if running, _ := mgr.Running(); !running {
-			return true
+		if running, err := mgr.Running(); err == nil && !running {
+			return true, false
 		}
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-sig:
+			return false, true
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
-	return false
+	return false, false
 }
 
 // Cleanup stops and deletes a container, optionally saving session data
@@ -109,9 +202,11 @@ func Cleanup(opts CleanupOptions) error {
 	// saveSessionData handles the mid-shutdown race internally: on a transient SFTP
 	// error it waits for the container to fully stop, then retries using incus's
 	// direct file-access path (no SFTP) so the save succeeds in every exit scenario.
+	saveFailed := false
 	if opts.SaveSession && exists && opts.SessionID != "" && opts.SessionsDir != "" && opts.Tool != nil && opts.Tool.ConfigDirName() != "" {
 		if err := saveSessionData(mgr, opts.ContainerName, opts.SessionID, opts.Persistent, opts.ProfileName, opts.Workspace, opts.SessionsDir, opts.Tool, opts.Logger); err != nil {
 			opts.Logger(fmt.Sprintf("Warning: Failed to save session data: %v", err))
+			saveFailed = true
 		}
 	}
 
@@ -123,14 +218,43 @@ func Cleanup(opts CleanupOptions) error {
 	// ephemeral containers and printing "kept running" over a stopping one.
 	running := false
 	if exists {
-		running, _ = mgr.Running()
-		if running && guestShutdownInProgress(mgr) {
+		var known bool
+		running, known = containerRunning(mgr)
+		switch {
+		case !known:
+			// Incus can't answer right now: fail safe. Claim nothing about
+			// the state and do nothing destructive.
+			opts.Logger("Warning: could not determine container state (incus unreachable) - leaving the container untouched")
+			running = true
+		case running && guestShutdownInProgress(mgr):
 			timeout := opts.ShutdownTimeout
 			if timeout <= 0 {
-				timeout = 60
+				timeout = config.DefaultShutdownTimeoutSeconds
 			}
 			opts.Logger("Container is shutting down, waiting for it to stop...")
-			running = !waitForStopped(mgr, time.Duration(timeout)*time.Second)
+			stopped, interrupted := waitForStopped(mgr, time.Duration(timeout)*time.Second)
+			if !stopped {
+				// The shutdown is positively known at this point — finish the
+				// job rather than relapse into "kept running" (stock systemd
+				// units get 90s stop budgets, longer than our default window;
+				// this is the same escalation `coi shutdown` applies after
+				// its graceful window).
+				if interrupted {
+					opts.Logger("Interrupted - forcing the stop...")
+				} else {
+					opts.Logger(fmt.Sprintf("Still shutting down after %ds - forcing the stop...", timeout))
+				}
+				if err := mgr.Stop(true); err != nil {
+					opts.Logger(fmt.Sprintf("Warning: force stop failed: %v", err))
+				}
+			}
+			// Re-read the final state; if incus can't answer, the shutdown we
+			// positively detected is the best evidence — treat as stopped.
+			if r, ok := containerRunning(mgr); ok {
+				running = r
+			} else {
+				running = false
+			}
 		}
 	}
 
@@ -169,6 +293,10 @@ func Cleanup(opts CleanupOptions) error {
 				// Now delete container
 				if err := mgr.Delete(true); err != nil {
 					opts.Logger(fmt.Sprintf("Warning: Failed to delete container: %v", err))
+				} else if saveFailed {
+					// Don't claim the data is safe when the save above failed —
+					// with the container gone it is unrecoverable.
+					opts.Logger("Container removed (session data could NOT be saved - see the warning above)")
 				} else {
 					opts.Logger("Container removed (session data saved for --resume)")
 				}
@@ -243,12 +371,7 @@ func saveSessionData(mgr container.ContainerManager, containerName string, sessi
 		if attempt > 0 {
 			// SFTP failed — wait for the container to fully stop so incus
 			// uses direct file access (not SFTP) on the next attempt.
-			for i := 0; i < 10; i++ {
-				time.Sleep(500 * time.Millisecond)
-				if running, _ := mgr.Running(); !running {
-					break
-				}
-			}
+			waitForStopped(mgr, 5*time.Second)
 		}
 		pullErr = mgr.PullDirectory(stateDir, localConfigDir)
 		if pullErr == nil {

--- a/internal/session/cleanup_probe_test.go
+++ b/internal/session/cleanup_probe_test.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mensfeld/code-on-incus/internal/container"
+)
+
+// fakeProber scripts successive probe answers; Running answers come from a
+// function of the call index so tests can flip state mid-flight.
+type fakeProber struct {
+	outs     []string
+	errs     []error
+	execs    int
+	running  func(call int) (bool, error)
+	runCalls int
+}
+
+func (f *fakeProber) ExecCommand(_ string, _ container.ExecCommandOptions) (string, error) {
+	i := f.execs
+	f.execs++
+	var out string
+	var err error
+	if i < len(f.outs) {
+		out = f.outs[i]
+	}
+	if i < len(f.errs) {
+		err = f.errs[i]
+	}
+	return out, err
+}
+
+func (f *fakeProber) Running() (bool, error) {
+	i := f.runCalls
+	f.runCalls++
+	if f.running == nil {
+		return true, nil
+	}
+	return f.running(i)
+}
+
+func busDownErr() error {
+	return &container.ExitError{ExitCode: 1, Stderr: "Failed to connect to bus: Host is down"}
+}
+
+func noSystemdErr() error {
+	return &container.ExitError{ExitCode: 127, Stderr: "bash: line 1: systemctl: command not found"}
+}
+
+func TestGuestShutdownInProgress_Stopping(t *testing.T) {
+	f := &fakeProber{outs: []string{"stopping"}}
+	if !guestShutdownInProgress(f) {
+		t.Error("'stopping' must classify as shutdown in progress")
+	}
+	if f.execs != 1 {
+		t.Errorf("one probe should suffice, got %d", f.execs)
+	}
+}
+
+func TestGuestShutdownInProgress_HealthyStatesAreUserExit(t *testing.T) {
+	for _, state := range []string{"running", "degraded", "maintenance", "initializing", "starting"} {
+		f := &fakeProber{outs: []string{state}}
+		if guestShutdownInProgress(f) {
+			t.Errorf("%q must classify as a normal exit", state)
+		}
+		if f.execs != 1 {
+			t.Errorf("%q: one probe should suffice, got %d", state, f.execs)
+		}
+	}
+}
+
+func TestGuestShutdownInProgress_BusDownIsShutdown(t *testing.T) {
+	// systemctl ran but systemd's bus is gone while the container still
+	// reports Running: the shutdown tail.
+	f := &fakeProber{outs: []string{""}, errs: []error{busDownErr()}}
+	if !guestShutdownInProgress(f) {
+		t.Error("an answered-but-bus-down probe must classify as shutdown")
+	}
+}
+
+func TestGuestShutdownInProgress_NoSystemdFastExit(t *testing.T) {
+	// An image that can never answer must not burn the retry budget on
+	// every session exit.
+	f := &fakeProber{outs: []string{""}, errs: []error{noSystemdErr()}}
+	start := time.Now()
+	if guestShutdownInProgress(f) {
+		t.Error("missing systemctl must classify as a normal exit")
+	}
+	if f.execs != 1 {
+		t.Errorf("no-systemd must be decided on the first probe, got %d probes", f.execs)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("no-systemd classification took %v, must not sleep", elapsed)
+	}
+}
+
+func TestGuestShutdownInProgress_AmbiguousThenStopped(t *testing.T) {
+	// "unknown"/"offline" (late-poweroff tail) is ambiguous; the container
+	// stopping during the retry window resolves it as a shutdown.
+	f := &fakeProber{
+		outs:    []string{"unknown", "offline"},
+		running: func(call int) (bool, error) { return call < 1, nil },
+	}
+	if !guestShutdownInProgress(f) {
+		t.Error("ambiguous states with the container then stopping must classify as shutdown")
+	}
+}
+
+func TestGuestShutdownInProgress_TransportErrorOnLiveContainer(t *testing.T) {
+	// Exec yields nothing, container stays verifiably running: user exit
+	// (after the bounded retries) — a broken exec must not delete containers.
+	f := &fakeProber{errs: []error{errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x")}}
+	if guestShutdownInProgress(f) {
+		t.Error("a persistently unanswerable probe on a running container must classify as a normal exit")
+	}
+}
+
+func TestGuestShutdownInProgress_RunningErrorDoesNotCountAsStopped(t *testing.T) {
+	// Incus daemon errors during the ambiguous branch must NOT be read as
+	// "container stopped" (the swallowed-error chain from the review).
+	f := &fakeProber{
+		outs:    []string{"unknown", "unknown", "unknown", "unknown", "unknown", "unknown"},
+		running: func(int) (bool, error) { return false, errors.New("incus daemon restarting") },
+	}
+	if guestShutdownInProgress(f) {
+		t.Error("a Running() error must not be treated as evidence of a shutdown")
+	}
+}
+
+func TestContainerRunning_ErrorIsUnknownNotStopped(t *testing.T) {
+	f := &fakeProber{running: func(int) (bool, error) { return false, errors.New("boom") }}
+	if _, ok := containerRunning(f); ok {
+		t.Error("persistent Running() errors must report state as unknown")
+	}
+
+	// A transient error followed by a clean answer resolves.
+	f2 := &fakeProber{running: func(call int) (bool, error) {
+		if call == 0 {
+			return false, errors.New("blip")
+		}
+		return true, nil
+	}}
+	running, ok := containerRunning(f2)
+	if !ok || !running {
+		t.Errorf("expected (running=true, ok=true) after a transient blip, got (%v, %v)", running, ok)
+	}
+}
+
+func TestWaitForStopped(t *testing.T) {
+	// Stops on the second poll.
+	f := &fakeProber{running: func(call int) (bool, error) { return call < 1, nil }}
+	stopped, interrupted := waitForStopped(f, 5*time.Second)
+	if !stopped || interrupted {
+		t.Errorf("expected (stopped=true, interrupted=false), got (%v, %v)", stopped, interrupted)
+	}
+
+	// Never stops: times out, and daemon errors are not "stopped".
+	f2 := &fakeProber{running: func(int) (bool, error) { return false, errors.New("err") }}
+	stopped, _ = waitForStopped(f2, time.Second)
+	if stopped {
+		t.Error("Running() errors must not satisfy the stopped condition")
+	}
+}

--- a/tests/shell/ephemeral/slow_shutdown_exceeds_timeout_ephemeral.py
+++ b/tests/shell/ephemeral/slow_shutdown_exceeds_timeout_ephemeral.py
@@ -1,0 +1,127 @@
+"""
+Test for coi shell (ephemeral) - a guest shutdown that OUTLASTS the graceful
+window must be force-stopped and removed, not relabeled "kept running".
+
+Stock systemd gives service stops a 90s budget (DefaultTimeoutStopSec) while
+COI's [container] shutdown_timeout defaults to 60s, so "detected shutdown
+outlives the wait" is reachable with completely ordinary units. When that
+happens the cleanup must escalate exactly like `coi shutdown` does after its
+graceful window — force the stop and honor the ephemeral contract (delete) —
+instead of relapsing into the "Container kept running - use 'coi attach'"
+mislabel it was built to fix.
+
+This test makes the overrun cheap: shutdown_timeout is pinned to 5s and a
+transient unit holds the guest in "stopping" for ~30s.
+"""
+
+import time
+from pathlib import Path
+
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    get_container_list,
+    spawn_coi,
+    wait_for_container_ready,
+    wait_for_prompt,
+    wait_for_specific_container_deletion,
+    wait_for_text_in_monitor,
+    with_live_screen,
+)
+
+
+def test_slow_shutdown_exceeding_timeout_is_forced(coi_binary, cleanup_containers, workspace_dir):
+    """
+    Flow:
+    1. Pin [container] shutdown_timeout = 5 in the workspace config
+    2. Start coi shell (ephemeral), exit the dummy tool to bash
+    3. Install a transient unit whose ExecStop sleeps ~30s, poweroff non-forced
+    4. Cleanup detects the shutdown, waits 5s, must FORCE the stop
+    5. The ephemeral container must be removed; no "kept running" mislabel
+    """
+    coi_dir = Path(workspace_dir) / ".coi"
+    coi_dir.mkdir(exist_ok=True)
+    (coi_dir / "config.toml").write_text("[container]\nshutdown_timeout = 5\n")
+
+    env = {"COI_USE_DUMMY": "1"}
+
+    child = spawn_coi(
+        coi_binary,
+        ["shell"],
+        cwd=workspace_dir,
+        env=env,
+        timeout=120,
+    )
+
+    wait_for_container_ready(child, timeout=60)
+    wait_for_prompt(child, timeout=90)
+
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # Exit the dummy tool to bash
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
+    time.sleep(3)
+
+    # Verify we actually reached bash before typing power commands into it.
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+        child.send("echo $((12345+54321))")
+        time.sleep(0.5)
+        child.send("\x0d")
+        in_bash = wait_for_text_in_monitor(monitor, "66666", timeout=20)
+        assert in_bash, "Should be in bash shell after exiting the dummy tool"
+
+    # Slow-stop unit: the (non-forced) shutdown stays in "stopping" ~30s,
+    # far past the 5s graceful window configured above.
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+        child.send(
+            "sudo systemd-run --unit=coi-test-slowstop -p TimeoutStopSec=45 "
+            "-p ExecStop='/bin/sleep 30' /bin/sleep infinity && echo SLOWSTOP_READY"
+        )
+        time.sleep(0.5)
+        child.send("\x0d")
+        started = wait_for_text_in_monitor(monitor, "SLOWSTOP_READY", timeout=20)
+        assert started, "transient slow-stop unit should start"
+
+    assert container_name in get_container_list(), (
+        f"Container {container_name} should be running before poweroff"
+    )
+
+    child.send("sudo systemctl poweroff")
+    time.sleep(0.3)
+    child.send("\x0d")
+
+    try:
+        child.expect(EOF, timeout=90)
+    except TIMEOUT:
+        pass
+
+    if hasattr(child.logfile_read, "get_raw_output"):
+        output = child.logfile_read.get_raw_output()
+    elif hasattr(child.logfile_read, "get_output"):
+        output = child.logfile_read.get_output()
+    else:
+        output = ""
+
+    try:
+        child.close(force=False)
+    except Exception:
+        child.close(force=True)
+
+    deleted = wait_for_specific_container_deletion(container_name, timeout=90)
+
+    assert "forcing the stop" in output, (
+        f"a shutdown outlasting the graceful window must be escalated to a force stop. "
+        f"Got:\n{output}"
+    )
+    assert "Container kept running" not in output, (
+        f"a detected shutdown must never relapse into the 'kept running' mislabel. Got:\n{output}"
+    )
+    assert deleted, (
+        f"Ephemeral container {container_name} must be removed after the forced stop "
+        f"(waited 90s). Output:\n{output}"
+    )

--- a/tests/shell/ephemeral/slow_shutdown_exceeds_timeout_ephemeral.py
+++ b/tests/shell/ephemeral/slow_shutdown_exceeds_timeout_ephemeral.py
@@ -94,6 +94,14 @@ def test_slow_shutdown_exceeding_timeout_is_forced(coi_binary, cleanup_container
     child.send("sudo systemctl poweroff")
     time.sleep(0.3)
     child.send("\x0d")
+    # Leave the shell right away so the coi process regains control (EOF) at
+    # the START of the guest shutdown. With a non-forced poweroff the exec
+    # session otherwise survives deep into the shutdown and cleanup would
+    # find the container already stopped — no in-flight window to test.
+    time.sleep(1)
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
 
     try:
         child.expect(EOF, timeout=90)

--- a/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
+++ b/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
@@ -61,7 +61,18 @@ def test_slow_shutdown_removes_ephemeral(coi_binary, cleanup_containers, workspa
     child.send("exit")
     time.sleep(0.3)
     child.send("\x0d")
-    time.sleep(5)
+    time.sleep(3)
+
+    # Verify we actually reached bash before typing power commands into it:
+    # a slow dummy exit would otherwise swallow the command and the failure
+    # would masquerade as a shutdown-detection bug.
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+        child.send("echo $((12345+54321))")
+        time.sleep(0.5)
+        child.send("\x0d")
+        in_bash = wait_for_text_in_monitor(monitor, "66666", timeout=20)
+        assert in_bash, "Should be in bash shell after exiting the dummy tool"
 
     # A transient unit whose stop takes ~30s: this holds the whole (non-forced)
     # shutdown in "stopping" well past cleanup's old fixed polling window.

--- a/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
+++ b/tests/shell/ephemeral/slow_shutdown_removes_ephemeral.py
@@ -97,6 +97,14 @@ def test_slow_shutdown_removes_ephemeral(coi_binary, cleanup_containers, workspa
     child.send("sudo systemctl poweroff")
     time.sleep(0.3)
     child.send("\x0d")
+    # Leave the shell right away so the coi process regains control (EOF) at
+    # the START of the guest shutdown. With a non-forced poweroff the exec
+    # session otherwise survives deep into the shutdown and cleanup would
+    # find the container already stopped — no in-flight window to test.
+    time.sleep(1)
+    child.send("exit")
+    time.sleep(0.3)
+    child.send("\x0d")
 
     try:
         child.expect(EOF, timeout=90)
@@ -119,6 +127,10 @@ def test_slow_shutdown_removes_ephemeral(coi_binary, cleanup_containers, workspa
     # the ephemeral container must be recognized as stopped and removed.
     deleted = wait_for_specific_container_deletion(container_name, timeout=120)
 
+    assert "Container is shutting down, waiting" in output, (
+        f"cleanup must detect the in-flight shutdown (the guest is pinned in "
+        f"'stopping' when EOF arrives). Got:\n{output}"
+    )
     assert "Container kept running" not in output, (
         f"a slow poweroff must not be mislabeled as a normal exit. Got:\n{output}"
     )

--- a/tests/shell/persistent/close_stops_and_keeps_persistent.py
+++ b/tests/shell/persistent/close_stops_and_keeps_persistent.py
@@ -78,7 +78,18 @@ def test_close_stops_and_keeps_persistent(coi_binary, cleanup_containers, worksp
     child.send("exit")
     time.sleep(0.3)
     child.send("\x0d")
-    time.sleep(5)
+    time.sleep(3)
+
+    # Verify we actually reached bash before typing power commands into it:
+    # a slow dummy exit would otherwise swallow the command and the failure
+    # would masquerade as a shutdown-detection bug.
+    with with_live_screen(child) as monitor:
+        time.sleep(1)
+        child.send("echo $((12345+54321))")
+        time.sleep(0.5)
+        child.send("\x0d")
+        in_bash = wait_for_text_in_monitor(monitor, "66666", timeout=20)
+        assert in_bash, "Should be in bash shell after exiting the dummy tool"
 
     # Power the container off with the `close` wrapper
     child.send("close")


### PR DESCRIPTION
Follow-up to #597, addressing all findings from its post-merge review. The 0.10.1 fix is correct for the common case; this closes the edges:

## Correctness
- **Timeout relapse** — a *detected* shutdown outlasting `shutdown_timeout` relapsed into the 'kept running' mislabel + ephemeral leak. Reachable with stock units: systemd's DefaultTimeoutStopSec is **90s** vs our 60s default. Cleanup now escalates like `coi shutdown`: force stop, then honor the contract. **New e2e** pins it (`shutdown_timeout = 5` vs a 30s stop → 'forcing the stop' + container removed).
- **Unbounded probe** — the guest exec (the first ever in a teardown path) had no deadline and could hang forever against a dying or responder-*frozen* container. Hard 10s bound.
- **Uninterruptible wait** — Ctrl+C during the shutdown wait was swallowed (the shell's signal plumbing is disarmed before deferred teardown runs); it now forces the stop and proceeds.
- **Swallowed errors** — incus-daemon failures no longer read as 'stopped': state reads retry and fail SAFE (leave the container untouched, say so) instead of force-deleting a live container or printing 'kept (stopped)' over a running one.
- **Probe classification** now follows the #590 `ExitError.Stderr` idiom: bus-down on a Running container = shutdown evidence; `command not found` (non-systemd image) decided on the first probe (no 3s retry tax per exit); systemd's late-shutdown `offline`/`unknown` answers are ambiguous-and-recheck, not 'user exit'.
- **Honest messaging** — deletion after a failed save no longer claims 'session data saved for --resume'.

## Cleanup
- Shutdown-timeout default single-sourced (`config.DefaultShutdownTimeoutSeconds`; phases_shell passes `ShutdownTimeoutSeconds()` like `coi shutdown` does)
- `saveSessionData` reuses `waitForStopped` instead of its private 10×500ms copy
- Probe/wait helpers moved onto a narrow `guestProber` interface + unit-test matrix (stopping / bus-down / no-systemd / ambiguous / transport-error / daemon-error)
- Both #597 e2e tests regained the in-bash arithmetic verification the sibling poweroff test always had (a slow dummy exit can no longer masquerade as a shutdown-detection bug)

Consciously out of scope: the persistent `!exists` nft-backstop asymmetry (pre-existing from before #597, pinned by `TestCleanup_NoTeardownBackstopInPersistentMode`).