### PR TITLE
fix(cleanup): detect close/poweroff from the outside container state (#616)

### DIFF
--- a/internal/session/cleanup.go
+++ b/internal/session/cleanup.go
@@ -99,34 +99,78 @@ func probeGuestState(mgr guestProber) string {
 	}
 }
 
-// guestShutdownInProgress reports whether the guest is mid shutdown.
-// "stopping" (or an answered-but-bus-down probe) means a poweroff/close is
-// in flight; any healthy manager state means the user simply left the shell.
-// "offline"/"unknown"/no answer are AMBIGUOUS — systemd can print those in
-// the sub-second tail of a poweroff (/run unmounted, SystemState query
-// failing) and a flaking exec transport looks identical — so those re-check
-// the container state and retry briefly instead of concluding either way.
+// Shutdown-detection timing. A `close`/poweroff transitions the container to
+// stopped within seconds; a normal `exit` never does. We OBSERVE that from
+// outside incus (Running()) rather than predict it from a racy in-guest probe.
+const (
+	shutdownProbeInterval = 500 * time.Millisecond
+	// shutdownDetectWindow bounds how long we observe the container before
+	// concluding a normal exit. It must outlast a `close`'s stop time (the guest
+	// exec transport can go dark mid-`--force poweroff` while incus still reports
+	// Running for a few seconds) without hanging teardown indefinitely.
+	shutdownDetectWindow = 10 * time.Second
+	// healthyConfirmChecks is how many consecutive healthy systemd answers rule
+	// out a normal exit. A `close` briefly passes through a healthy "running"
+	// answer in the window between the poweroff being enqueued and systemd
+	// flipping to "stopping", so a SINGLE healthy probe cannot be trusted — that
+	// single-probe trust was the issue #616 misdetection ("Container kept running"
+	// printed over a container that was actually powering off).
+	healthyConfirmChecks = 3
+)
+
+// guestShutdownInProgress reports whether the session ended because the container
+// is shutting down (`close`/poweroff) rather than the user leaving the shell
+// (`exit`). See shutdownInProgress; this is the production entry point.
 func guestShutdownInProgress(mgr guestProber) bool {
-	for i := 0; i < 6; i++ {
-		switch state := probeGuestState(mgr); state {
+	return shutdownInProgress(mgr, shutdownProbeInterval, shutdownDetectWindow, healthyConfirmChecks)
+}
+
+// shutdownInProgress decides shutdown-vs-exit from the OUTSIDE container state as
+// the reliable signal, using the in-guest systemd probe only as an accelerator
+// that can ADD a positive detection but never veto one. Each poll, in order:
+//
+//   - container observed stopped (incus) -> shutdown (definitive; wins)
+//   - guest systemd says stopping/bus-down -> shutdown (fast positive)
+//   - guest healthy N polls in a row -> normal exit (N in a row rules out the
+//     brief pre-"stopping" window a close passes through)
+//   - image has no systemd -> normal exit (a close needs systemctl to fire)
+//   - offline/unknown/no-answer -> ambiguous; keep observing
+//
+// If the container is still running with no positive signal when the window
+// elapses, it was a normal exit. The function never returns true without
+// positive evidence (an observed stop, or systemd itself saying it is tearing
+// down), so it can never force-stop a container the user meant to keep.
+func shutdownInProgress(mgr guestProber, interval, window time.Duration, healthyToExit int) bool {
+	deadline := time.Now().Add(window)
+	healthy := 0
+	for {
+		// Definitive, from outside incus: the container actually stopped. Checked
+		// first each poll so a stop observed at any point wins immediately.
+		if running, err := mgr.Running(); err == nil && !running {
+			return true
+		}
+
+		switch probeGuestState(mgr) {
 		case "stopping", guestStateBusDown:
 			return true
 		case "running", "degraded", "maintenance", "initializing", "starting":
-			return false
+			if healthy++; healthy >= healthyToExit {
+				return false
+			}
 		case guestStateNoSystemd:
-			// This image can never answer — don't burn the retry budget on
-			// every single exit there.
+			// This image can never answer, and a `close` needs systemctl to fire
+			// in the first place — treat as a normal exit (the outside-state check
+			// above still catches an externally-stopped container).
 			return false
 		default: // "offline", "unknown", coi:no-answer, anything unforeseen
-			if running, err := mgr.Running(); err == nil && !running {
-				return true
-			}
-			if i < 5 {
-				time.Sleep(500 * time.Millisecond)
-			}
+			healthy = 0 // ambiguous — a healthy streak must be consecutive
 		}
+
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(interval)
 	}
-	return false
 }
 
 // containerRunning reports the container's state and whether it could be

--- a/internal/session/cleanup_probe_test.go
+++ b/internal/session/cleanup_probe_test.go
@@ -59,14 +59,24 @@ func TestGuestShutdownInProgress_Stopping(t *testing.T) {
 	}
 }
 
+// fastShutdown runs the detector with tiny timing so tests never sleep the real
+// window, while exercising the same logic (and the same healthyConfirmChecks).
+func fastShutdown(f *fakeProber) bool {
+	return shutdownInProgress(f, time.Millisecond, 100*time.Millisecond, healthyConfirmChecks)
+}
+
 func TestGuestShutdownInProgress_HealthyStatesAreUserExit(t *testing.T) {
 	for _, state := range []string{"running", "degraded", "maintenance", "initializing", "starting"} {
-		f := &fakeProber{outs: []string{state}}
-		if guestShutdownInProgress(f) {
-			t.Errorf("%q must classify as a normal exit", state)
+		// A healthy state must classify as a normal exit — but only after it
+		// PERSISTS (healthyConfirmChecks in a row), so a close's brief pre-stopping
+		// "running" can't be mistaken for it (issue #616).
+		outs := make([]string, healthyConfirmChecks)
+		for i := range outs {
+			outs[i] = state
 		}
-		if f.execs != 1 {
-			t.Errorf("%q: one probe should suffice, got %d", state, f.execs)
+		f := &fakeProber{outs: outs}
+		if fastShutdown(f) {
+			t.Errorf("%q sustained must classify as a normal exit", state)
 		}
 	}
 }
@@ -98,12 +108,12 @@ func TestGuestShutdownInProgress_NoSystemdFastExit(t *testing.T) {
 
 func TestGuestShutdownInProgress_AmbiguousThenStopped(t *testing.T) {
 	// "unknown"/"offline" (late-poweroff tail) is ambiguous; the container
-	// stopping during the retry window resolves it as a shutdown.
+	// stopping during the observation window resolves it as a shutdown.
 	f := &fakeProber{
 		outs:    []string{"unknown", "offline"},
 		running: func(call int) (bool, error) { return call < 1, nil },
 	}
-	if !guestShutdownInProgress(f) {
+	if !fastShutdown(f) {
 		t.Error("ambiguous states with the container then stopping must classify as shutdown")
 	}
 }
@@ -111,8 +121,8 @@ func TestGuestShutdownInProgress_AmbiguousThenStopped(t *testing.T) {
 func TestGuestShutdownInProgress_TransportErrorOnLiveContainer(t *testing.T) {
 	// Exec yields nothing, container stays verifiably running: user exit
 	// (after the bounded retries) — a broken exec must not delete containers.
-	f := &fakeProber{errs: []error{errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x"), errors.New("x")}}
-	if guestShutdownInProgress(f) {
+	f := &fakeProber{errs: repeatErr(errors.New("x"), 200)}
+	if fastShutdown(f) {
 		t.Error("a persistently unanswerable probe on a running container must classify as a normal exit")
 	}
 }
@@ -121,10 +131,13 @@ func TestGuestShutdownInProgress_RunningErrorDoesNotCountAsStopped(t *testing.T)
 	// Incus daemon errors during the ambiguous branch must NOT be read as
 	// "container stopped" (the swallowed-error chain from the review).
 	f := &fakeProber{
-		outs:    []string{"unknown", "unknown", "unknown", "unknown", "unknown", "unknown"},
+		outs:    make([]string, 200), // all "" -> no-answer, ambiguous
 		running: func(int) (bool, error) { return false, errors.New("incus daemon restarting") },
 	}
-	if guestShutdownInProgress(f) {
+	for i := range f.outs {
+		f.outs[i] = "unknown"
+	}
+	if fastShutdown(f) {
 		t.Error("a Running() error must not be treated as evidence of a shutdown")
 	}
 }
@@ -161,5 +174,48 @@ func TestWaitForStopped(t *testing.T) {
 	stopped, _ = waitForStopped(f2, time.Second)
 	if stopped {
 		t.Error("Running() errors must not satisfy the stopped condition")
+	}
+}
+
+// ---- issue #616: `close` (systemctl --force poweroff) mislabeled "kept running" ----
+
+func repeatErr(err error, n int) []error {
+	out := make([]error, n)
+	for i := range out {
+		out[i] = err
+	}
+	return out
+}
+
+// Repro A — the pre-"stopping" race. `close` execs `systemctl --force poweroff`,
+// which ENQUEUES the poweroff and exits, ending the session before systemd flips
+// its manager state to "stopping". The first probe therefore catches a healthy
+// "running", and the container stops a moment later. Detection must not conclude
+// "normal exit" from that single hasty probe.
+func TestGuestShutdownInProgress_ClosePreStoppingRace_Regression(t *testing.T) {
+	f := &fakeProber{
+		outs:    []string{"running", "running", "running"},             // systemd not yet in "stopping"
+		running: func(call int) (bool, error) { return call < 2, nil }, // stops shortly after
+	}
+	if !fastShutdown(f) {
+		t.Error("issue #616: a close caught during systemd's pre-stopping window " +
+			"(probe says running, container then stops) must be detected as a shutdown, not 'kept running'")
+	}
+}
+
+// Repro B — the exec-goes-dark race. During `--force poweroff` the guest exec
+// transport is torn down before incus marks the container stopped, so the probe
+// returns no answer while Running() still reports true, and the container only
+// reaches "stopped" AFTER the old fixed 3s (6x500ms) retry budget. Detection must
+// observe the outside state long enough to see it stop.
+func TestGuestShutdownInProgress_CloseExecGoesDark_Regression(t *testing.T) {
+	const stopAfter = 10 // stops on the 11th Running() check — past the old 6-retry budget
+	f := &fakeProber{
+		errs:    repeatErr(errors.New("exec: connection reset by peer"), 60),
+		running: func(call int) (bool, error) { return call < stopAfter, nil },
+	}
+	if !fastShutdown(f) {
+		t.Error("issue #616: a close whose container reaches 'stopped' after the old retry budget " +
+			"must still be detected — observe the outside (incus) state until it stops")
 	}
 }


### PR DESCRIPTION
Fixes #616 — `close`/poweroff intermittently prints `Container kept running - use 'coi attach'…` even though the container is shutting down.

## Diagnosis
`close` is `sudo systemctl --force poweroff` (image build). Cleanup decided *shutdown vs. exit* by probing the guest's `systemctl is-system-running` with a 3s (6×500ms) budget — a **prediction** that races the shutdown. Two timings both misfire:

- **pre-"stopping" race:** `close` `exec`s systemctl, which *enqueues* the poweroff and exits, ending the tmux session **before** systemd flips to `stopping`. The first probe catches a healthy `running` → concludes "exit" immediately.
- **exec-goes-dark race:** during `--force poweroff` the guest exec transport is torn down before incus marks the container stopped, so the probe returns no answer while `Running()` still reports true, and the container only reaches `stopped` **after** the 3s budget.

Either way it falls through to "kept running." The container *does* power off (ends **stopped**; a persistent one is kept-stopped, which is why `coi shell --resume` works) — **the message is wrong, not the container.** For an **ephemeral** container the same false negative skips the delete + network teardown, leaking a stopped container (a residual of #597).

## Fix
Per the reporter's steer (*observe from outside incus, wait for the stop*): detection now polls the **outside container state** (`Running()`) over a bounded window, with the in-guest systemd probe as a **positive-only accelerator** — it can add a detection but never veto one. A single healthy probe no longer concludes "exit"; a healthy state must **persist** (`healthyConfirmChecks` in a row) to rule out the brief pre-"stopping" window. Timing is injectable so tests stay fast.

Safety preserved: the function still returns `true` only on **positive evidence** (an observed stop, or systemd itself saying it is tearing down), so it can never force-stop a container the user meant to keep.

## Repro-first
Two regression tests model the exact `close` timings and **fail against the old code** (pre-stopping fails instantly; exec-goes-dark after 2.5s); both pass now. Every existing safety test is preserved — unanswerable-probe-on-a-live-container = normal exit, `Running()`-error ≠ stopped, no-systemd fast exit.

`go build` / `go vet` / `golangci-lint` (0) / `gofmt` / full `internal/session` tests all green.

## Note on the tradeoff
A genuine `exit` now waits ~1.5s (3 healthy probes) before printing "kept running," instead of concluding on the first probe. That's the cost of de-racing the pre-"stopping" window; `stopping`/bus-down and an observed stop still short-circuit immediately.