### PR TITLE
test: de-mask xfail'd integration tests so failures turn CI red

### DIFF
--- a/tests/container/uid_mapping_shift_true.py
+++ b/tests/container/uid_mapping_shift_true.py
@@ -28,11 +28,10 @@ from support.helpers import (
 )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     os.getuid() != 1000,
     reason="shift=true fails when host UID != container code user UID (1000). "
     "This is a known Incus limitation — raw.idmap is the correct workaround.",
-    strict=True,
 )
 def test_workspace_write_access_shift_true(coi_binary, cleanup_containers, workspace_dir):
     """

--- a/tests/integration/test_security_monitoring.py
+++ b/tests/integration/test_security_monitoring.py
@@ -1001,10 +1001,11 @@ print("Task completed")
 class TestHighLevelThreats:
     """Test HIGH-level threats that trigger auto-pause."""
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
+        os.environ.get("GITHUB_ACTIONS") == "true",
         reason="cgroup io.stat does not track bind-mount I/O on GitHub Actions runners; "
         "reads from /workspace are served from the host page cache and not attributed "
-        "to the container's cgroup, so the monitoring daemon sees 0 bytes read."
+        "to the container's cgroup, so the monitoring daemon sees 0 bytes read.",
     )
     def test_large_file_read_triggers_auto_pause(
         self, test_workspace, enable_monitoring_low_thresholds, coi_binary
@@ -3063,10 +3064,11 @@ class TestThresholdBoundaries:
         proc.terminate()
         cleanup_container(container_name, coi_binary)
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
+        os.environ.get("GITHUB_ACTIONS") == "true",
         reason="cgroup io.stat does not track bind-mount I/O on GitHub Actions runners; "
         "reads from /workspace are served from the host page cache and not attributed "
-        "to the container's cgroup, so the monitoring daemon sees 0 bytes read."
+        "to the container's cgroup, so the monitoring daemon sees 0 bytes read.",
     )
     def test_file_read_at_threshold_triggers(
         self, test_workspace, enable_monitoring_low_thresholds, coi_binary
@@ -3164,10 +3166,11 @@ class TestThresholdBoundaries:
 
         cleanup_container(container_name, coi_binary)
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
+        os.environ.get("GITHUB_ACTIONS") == "true",
         reason="cgroup io.stat does not track bind-mount I/O on GitHub Actions runners; "
         "reads from /workspace are served from the host page cache and not attributed "
-        "to the container's cgroup, so the monitoring daemon sees 0 bytes read."
+        "to the container's cgroup, so the monitoring daemon sees 0 bytes read.",
     )
     def test_file_read_above_threshold_triggers(
         self, test_workspace, enable_monitoring_low_thresholds, coi_binary
@@ -3564,10 +3567,11 @@ class DisabledTestDiskSpaceMonitoring:
 class TestLargeWriteDetection:
     """Test large write detection for data exfiltration prevention."""
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
+        os.environ.get("GITHUB_ACTIONS") == "true",
         reason="cgroup io.stat does not track bind-mount I/O on GitHub Actions runners; "
         "writes to /workspace go through the host page cache and are not attributed "
-        "to the container's cgroup, so the monitoring daemon sees 0 bytes written."
+        "to the container's cgroup, so the monitoring daemon sees 0 bytes written.",
     )
     def test_large_write_triggers_high_threat(
         self, test_workspace, enable_monitoring_low_thresholds, coi_binary

--- a/tests/run/run_hostname_in_hosts.py
+++ b/tests/run/run_hostname_in_hosts.py
@@ -2,12 +2,10 @@
 Test that the container's hostname is present in /etc/hosts.
 
 Incus assigns the hostname at boot; /etc/hosts is baked into the image at build
-time with a different name.  Without /etc/rc.local adding the runtime hostname,
-sudo prints "unable to resolve host <name>" on every invocation.
-
-This test catches regressions. The fix lives in build.sh (the
-coi-fix-hostname.service oneshot), and the CI image cache key includes
-internal/image/**, so the built image carries the fix — the test runs for real.
+time with a different name. Without adding the runtime hostname, sudo prints
+"unable to resolve host <name>" on every invocation. The fix lives in build.sh
+(the coi-fix-hostname.service oneshot), and the CI image cache key includes
+internal/image/**, so the built image carries the fix — this test runs for real.
 """
 
 import subprocess
@@ -15,13 +13,14 @@ import subprocess
 
 def test_hostname_in_hosts(coi_binary, cleanup_containers, workspace_dir):
     """
-    Verify that the container hostname resolves via /etc/hosts.
+    Verify the container hostname resolves via /etc/hosts.
 
-    Flow:
-    1. Run `hostname` to get the container name.
-    2. Run `grep <hostname> /etc/hosts` to confirm the entry exists.
+    The container command's output arrives on stdout; coi's own progress/cleanup
+    logs ("Launching container ...", "Cleaning up container ...") go to stderr, so
+    stderr must NOT be parsed as command output — doing so previously made this
+    test read a log line as the "hostname".
     """
-    # Step 1: get the hostname assigned by Incus
+    # Step 1: read the Incus-assigned hostname from the command's stdout only.
     result = subprocess.run(
         [coi_binary, "run", "--workspace", workspace_dir, "hostname"],
         capture_output=True,
@@ -30,19 +29,29 @@ def test_hostname_in_hosts(coi_binary, cleanup_containers, workspace_dir):
     )
     assert result.returncode == 0, f"coi run hostname failed: {result.stderr}"
 
-    hostname = (result.stdout + result.stderr).strip().splitlines()[-1].strip()
-    assert hostname, "Could not determine container hostname"
+    stdout_lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert stdout_lines, (
+        f"coi run hostname produced no stdout.\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    hostname = stdout_lines[-1]
+    # The container hostname is its Incus instance name (coi-<hash>-<slot>). This
+    # guard also fails loudly if extraction ever regresses to a coi log line
+    # (e.g. "Cleaning up container ...", which does not start with "coi-").
+    assert hostname.startswith("coi-"), (
+        f"expected a coi-* container hostname, got {hostname!r}\nstdout: {result.stdout!r}"
+    )
 
-    # Step 2: confirm it appears in /etc/hosts
+    # Step 2: confirm it resolves via /etc/hosts inside the container. grep's
+    # matched line is on stdout; require both a zero exit (a match) and the
+    # hostname in stdout (not stderr, whose cleanup log also contains the name).
     result2 = subprocess.run(
         [coi_binary, "run", "--workspace", workspace_dir, "grep", hostname, "/etc/hosts"],
         capture_output=True,
         text=True,
         timeout=120,
     )
-    combined = result2.stdout + result2.stderr
-    assert result2.returncode == 0 and hostname in combined, (
-        f"Hostname '{hostname}' not found in /etc/hosts.\n"
-        f"grep output: {combined}\n"
-        "The /etc/rc.local hostname fix may not have run correctly."
+    assert result2.returncode == 0 and hostname in result2.stdout, (
+        f"Hostname '{hostname}' not found in /etc/hosts (grep exit {result2.returncode}).\n"
+        f"grep stdout: {result2.stdout!r}\n"
+        "The coi-fix-hostname.service (build.sh) may not have run correctly."
     )

--- a/tests/run/run_hostname_in_hosts.py
+++ b/tests/run/run_hostname_in_hosts.py
@@ -5,21 +5,14 @@ Incus assigns the hostname at boot; /etc/hosts is baked into the image at build
 time with a different name.  Without /etc/rc.local adding the runtime hostname,
 sudo prints "unable to resolve host <name>" on every invocation.
 
-This test catches regressions.  It is marked xfail because CI uses a cached
-pre-built coi-default image; the fix only lands after the next fresh rebuild.
+This test catches regressions. The fix lives in build.sh (the
+coi-fix-hostname.service oneshot), and the CI image cache key includes
+internal/image/**, so the built image carries the fix — the test runs for real.
 """
 
 import subprocess
 
-import pytest
 
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="CI uses a cached coi-default image that predates the hostname fix; "
-    "the test will become xpass once the cache is invalidated and the image is "
-    "rebuilt — at that point remove this marker so regressions are caught.",
-)
 def test_hostname_in_hosts(coi_binary, cleanup_containers, workspace_dir):
     """
     Verify that the container hostname resolves via /etc/hosts.


### PR DESCRIPTION
**Audit + fix** for "do we have integration tests that would NOT fail CI?" — answer: yes, 6, all via `xfail`.

## Audit result
- **`xfail` markers (6)** — a failing `xfail` test reports as **XFAIL = a pass**, so the failure shows **green**. These were the only failure-maskers.
- **No orphaned tests** — every `tests/*` dir and every `tests/integration/*.py` file is referenced by a matrix `path:`; nothing runs-nowhere.
- **CI wiring is sound** — the integration pytest step has no `continue-on-error` (the one `continue-on-error: true` is on a preflight bind-mount diagnostic, not a test step), so a failing test in a covered path already fails the lane.
- **No skip-list** masking (`pytest_skip_list.txt` doesn't exist). The many `pytest.skip(...)` calls are legitimate environment guards (`nft not available`, `container not ready`, …), not failure-masking.

## The fix (per the "failures must be red" policy)
Replace all 6 `xfail`s with honest signals. A `skipif` **declares a test inapplicable** in an environment that can't support it — it does not turn a *failure* into a *pass*:

| Test(s) | Was | Now |
|---|---|---|
| `test_security_monitoring.py` ×4 (cgroup `io.stat` can't attribute bind-mount I/O on GHA) | `xfail` | `skipif(GITHUB_ACTIONS)` — skipped in CI, runs+passes locally |
| `uid_mapping_shift_true.py` (needs host UID == 1000) | conditional strict `xfail` | `skipif(os.getuid() != 1000)` |
| `run_hostname_in_hosts.py` | strict `xfail` ("stale cached image") | **marker removed** — runs for real |

The hostname marker's premise is obsolete: the fix is in `build.sh` (`coi-fix-hostname.service`) and the image cache key includes `internal/image/**`, so the built image carries the fix. This PR's CI is the check — **green** means the fix works and the marker was stale; **red** means a genuine failure to fix (which is exactly the behavior you want).

After this, `grep -rn xfail tests/` returns nothing.