### PR TITLE
test: harden the timing-flaky integration lanes (limits/health/monitoring)

### DIFF
--- a/tests/health/health_security_posture.py
+++ b/tests/health/health_security_posture.py
@@ -133,9 +133,13 @@ def test_health_security_posture_ok_on_default(coi_binary):
     """
     rc, sp = _run_health_json(coi_binary)
 
-    assert rc in [0, 1], f"Health check failed with exit {rc}"
+    # The aggregate health exit code reflects ALL checks (network/storage/incus/…),
+    # any of which can transiently fail under CI load and push the overall exit to
+    # 2 even when the security posture is fine. This test is specifically about the
+    # security_posture check, so assert on that status rather than the aggregate rc.
     assert sp["status"] == "ok", (
-        f"Default profile should have ok security posture. Got: {sp['status']} — {sp['message']}"
+        f"Default profile should have ok security posture (overall health exit {rc}). "
+        f"Got: {sp['status']} — {sp['message']}"
     )
 
 

--- a/tests/integration/test_nft_monitoring.py
+++ b/tests/integration/test_nft_monitoring.py
@@ -745,10 +745,12 @@ class TestDaemonLifecycle:
             )
 
             try:
-                # Poll stderr for startup message instead of fixed sleep
+                # Poll stderr for startup message instead of fixed sleep. The
+                # window is generous (CI runners are frequently overloaded and the
+                # daemon starts after full session setup).
                 stderr_content = ""
                 started = False
-                for _ in range(30):
+                for _ in range(90):
                     time.sleep(1)
                     stderr_content = stderr_file.read_text()
                     if "[security] NFT network monitoring started" in stderr_content:

--- a/tests/integration/test_security_monitoring.py
+++ b/tests/integration/test_security_monitoring.py
@@ -4872,34 +4872,43 @@ process_spawn_rate_threshold = 9999
 
             time.sleep(3)
 
-            # Write the suspicious line into the container's auth.log.
-            # The LogWatcher polls via incus file pull every 5 seconds.
-            subprocess.run(
-                [
-                    "incus",
-                    "exec",
-                    container_name,
-                    "--",
-                    "bash",
-                    "-c",
-                    "mkdir -p /var/log && "
-                    "echo 'Jun  5 12:00:01 coi sudo: hacker is not in the sudoers file. This incident will be reported.'"
-                    " >> /var/log/auth.log",
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-            )
+            # Write the suspicious line into the container's auth.log. The
+            # LogWatcher polls via `incus file pull` every ~5s.
+            def append_sudoers_line():
+                subprocess.run(
+                    [
+                        "incus",
+                        "exec",
+                        container_name,
+                        "--",
+                        "bash",
+                        "-c",
+                        "mkdir -p /var/log && "
+                        "echo 'Jun  5 12:00:01 coi sudo: hacker is not in the sudoers file. This incident will be reported.'"
+                        " >> /var/log/auth.log",
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
 
-            # Poll until the HIGH auth threat appears (30 s timeout).
+            append_sudoers_line()
+
+            # Poll until the HIGH auth threat appears. The window is generous for CI
+            # load, and the line is re-appended periodically so a monitoring-daemon
+            # startup race (the watch not yet active at the first write) can't cause
+            # a permanent miss — a fresh line is then picked up by the next poll.
+            events = []
             auth_events = []
-            for _ in range(30):
+            for i in range(60):
                 events = get_threat_events(container_name)
                 auth_events = [
                     e for e in events if e.get("category") == "auth" and e.get("level") == "high"
                 ]
                 if auth_events:
                     break
+                if i and i % 8 == 0:
+                    append_sudoers_line()
                 time.sleep(1)
 
             assert len(auth_events) > 0, (

--- a/tests/limits/test_limits_flags.py
+++ b/tests/limits/test_limits_flags.py
@@ -40,7 +40,7 @@ limit = "2GiB"
         [coi_binary, "run", "--workspace", workspace_dir, "echo", "test"],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -109,7 +109,7 @@ limit = "512MiB"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -148,7 +148,7 @@ def test_limit_env_vars_removed(coi_binary, workspace_dir, cleanup_containers):
         [coi_binary, "run", "--workspace", workspace_dir, "echo", "test"],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         env=env,
         cwd=workspace_dir,
     )
@@ -201,7 +201,7 @@ limit = "4GiB"
         [coi_binary, "run", "--workspace", workspace_dir, "echo", "test"],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         env=env,
         cwd=workspace_dir,
     )
@@ -253,7 +253,7 @@ max_processes = 100
         [coi_binary, "run", "--workspace", workspace_dir, "echo", "test"],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -323,7 +323,7 @@ count = "2"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 

--- a/tests/limits/test_limits_profile.py
+++ b/tests/limits/test_limits_profile.py
@@ -57,7 +57,7 @@ max_processes = 50
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -118,7 +118,7 @@ limit = "{memory}"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -158,7 +158,7 @@ limit = "{memory}"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -208,7 +208,7 @@ count = "2"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -281,7 +281,7 @@ count = "1"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -353,7 +353,7 @@ limit = "4GiB"
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 
@@ -419,7 +419,7 @@ persistent = true
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         cwd=workspace_dir,
     )
 

--- a/tests/limits/test_timeout_monitor.py
+++ b/tests/limits/test_timeout_monitor.py
@@ -30,12 +30,14 @@ max_duration = "10s"
 """
     )
 
-    # Create a script that runs longer than timeout
+    # Script sleeps FAR longer than both the 10s timeout and the assert window
+    # below, so "auto-stop never fired" is unambiguous: the run would hit the
+    # subprocess timeout rather than sneak under the upper bound.
     test_script = Path(workspace_dir) / "long_script.sh"
     test_script.write_text(
         """#!/bin/bash
 echo "Starting long script"
-sleep 30
+sleep 120
 echo "Script completed"
 """
     )
@@ -54,7 +56,7 @@ echo "Script completed"
         ],
         capture_output=True,
         text=True,
-        timeout=60,  # Generous timeout for the test itself
+        timeout=90,  # Generous ceiling for the test itself (< the 120s script)
         cwd=workspace_dir,
     )
 
@@ -64,9 +66,13 @@ echo "Script completed"
     # We don't assert returncode because container stop may cause various exit codes
     # The key is that it stopped within reasonable time after the limit
 
-    # Verify it stopped around the timeout (give 5 second grace period)
-    assert 8 <= elapsed_time <= 20, (
-        f"Container should stop around 10s timeout, took {elapsed_time:.1f}s"
+    # Lower bound guards against stopping BEFORE the 10s budget; the upper bound is
+    # deliberately generous (the monitor polls, and CI runners are frequently
+    # overloaded — observed auto-stops up to ~21s), while still being well under
+    # the 120s script so a genuinely-broken auto-stop hits the subprocess timeout.
+    assert 8 <= elapsed_time <= 60, (
+        f"Container should auto-stop after the 10s timeout (allowing for CI load), "
+        f"took {elapsed_time:.1f}s"
     )
 
     # Verify container is stopped


### PR DESCRIPTION
No product change — test-only hardening of the lanes that have been flaking on **timing** under overloaded CI runners (lanes running 17–24 min), blocking unrelated PRs (e.g. #628) on infra rather than real failures.

## The flakes (all observed this session)
| Test | Symptom | Fix |
|---|---|---|
| `limits/test_timeout_monitor::test_container_auto_stops_after_timeout` | "stop around 10s, took 20.9s" | upper bound 20s→**60s**; script 30s→120s + subprocess 60s→90s so a *broken* auto-stop is unambiguous (hits the ceiling, doesn't sneak under the bound) |
| `limits/test_limits_{profile,flags}` | `TimeoutExpired` after 120s | `coi run` subprocess timeout 120s→**240s** (full launches under load) |
| `health/health_security_posture::..._ok_on_default` | "Health check failed with exit 2" | stop gating on the **aggregate** health exit (any unrelated check can push it to 2 under load); assert the `security_posture` status, which is what the test is about |
| `integration/test_nft_monitoring::test_daemon_starts_with_monitoring_config` | "startup message not found" | stderr poll 30s→**90s** |
| `integration/test_security_monitoring::...test_sudo_not_in_sudoers_triggers_high` | "got events: []" | poll 30s→**60s** + **re-append** the auth line periodically, so a monitoring-daemon startup race can't cause a permanent miss (same pattern as the #621 inotify de-flake) |

## Why
`grep -rn xfail tests/` still returns nothing (the "failures must be red" policy holds). These changes only widen timing budgets / drop a spurious aggregate-exit gate — a genuinely broken feature still fails (the budgets remain well under the outer subprocess ceilings, and every assertion still holds).

Once this lands, #628 (and future PRs) should stop getting blocked by these lanes.