### PR TITLE
test(health): stop gating specific-check tests on the aggregate coi health exit

### DIFF
--- a/tests/health/health_json_output.py
+++ b/tests/health/health_json_output.py
@@ -31,7 +31,7 @@ def test_health_json_output(coi_binary):
     # Exit 2 means a check FAILED. Show the report, not just stderr: without it the
     # failure says only "exit 2" and gives no way to tell which of the ~34 checks
     # broke.
-    assert result.returncode in [0, 1], (
+    assert result.returncode in (0, 1, 2), (
         f"Health check failed with exit {result.returncode}.\n"
         f"--- report ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )

--- a/tests/health/health_json_output.py
+++ b/tests/health/health_json_output.py
@@ -27,12 +27,14 @@ def test_health_json_output(coi_binary):
         timeout=120,
     )
 
-    # Should succeed (exit 0 for healthy, 1 for degraded)
-    # Exit 2 means a check FAILED. Show the report, not just stderr: without it the
-    # failure says only "exit 2" and gives no way to tell which of the ~34 checks
-    # broke.
+    # This test is about the JSON output STRUCTURE, not the aggregate health.
+    # Any valid classification (0 healthy, 1 degraded, 2 unhealthy) still emits the
+    # full report, and an unrelated check can push the aggregate to 2 under CI
+    # load — so accept all three and let the structure assertions below decide.
+    # Only a crash (exit outside 0/1/2) fails here; show the report then, since
+    # otherwise the failure says only "exit N" with no way to tell what broke.
     assert result.returncode in (0, 1, 2), (
-        f"Health check failed with exit {result.returncode}.\n"
+        f"coi health did not run (exit {result.returncode}).\n"
         f"--- report ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )
 

--- a/tests/health/health_kernel_version.py
+++ b/tests/health/health_kernel_version.py
@@ -22,8 +22,9 @@ def test_health_kernel_version_text(coi_binary):
         timeout=120,
     )
 
-    assert result.returncode in [0, 1], (
-        f"Health check failed with exit {result.returncode}. stderr: {result.stderr}"
+    assert result.returncode in (0, 1, 2), (
+        f"coi health did not run cleanly (exit {result.returncode}); an unrelated "
+        f"check failing is fine, the specific check is asserted below. stderr: {result.stderr}"
     )
 
     output = result.stdout
@@ -44,8 +45,9 @@ def test_health_kernel_version_json(coi_binary):
         timeout=120,
     )
 
-    assert result.returncode in [0, 1], (
-        f"Health check failed with exit {result.returncode}. stderr: {result.stderr}"
+    assert result.returncode in (0, 1, 2), (
+        f"coi health did not run cleanly (exit {result.returncode}); an unrelated "
+        f"check failing is fine, the specific check is asserted below. stderr: {result.stderr}"
     )
 
     data = json.loads(result.stdout)

--- a/tests/health/health_privileged_profile.py
+++ b/tests/health/health_privileged_profile.py
@@ -66,8 +66,9 @@ def test_health_privileged_profile_ok(coi_binary):
             timeout=120,
         )
 
-        assert result.returncode in [0, 1], (
-            f"Health check failed with exit {result.returncode}. stderr: {result.stderr}"
+        assert result.returncode in (0, 1, 2), (
+            f"coi health did not run cleanly (exit {result.returncode}); an unrelated "
+            f"check failing is fine, the specific check is asserted below. stderr: {result.stderr}"
         )
 
         data = json.loads(result.stdout)

--- a/tests/health/health_storage_pool.py
+++ b/tests/health/health_storage_pool.py
@@ -23,7 +23,7 @@ def test_health_storage_pools_present_in_json(coi_binary):
         timeout=60,
     )
 
-    assert result.returncode in [0, 1], (
+    assert result.returncode in (0, 1, 2), (
         f"Health check exited {result.returncode}. stderr: {result.stderr}"
     )
 
@@ -80,7 +80,7 @@ def test_health_storage_pools_in_text_output(coi_binary):
         timeout=60,
     )
 
-    assert result.returncode in [0, 1], (
+    assert result.returncode in (0, 1, 2), (
         f"Health check exited {result.returncode}. stderr: {result.stderr}"
     )
 

--- a/tests/health/health_text_output.py
+++ b/tests/health/health_text_output.py
@@ -26,12 +26,14 @@ def test_health_text_output(coi_binary):
         timeout=120,
     )
 
-    # Should succeed (exit 0 for healthy, 1 for degraded)
-    # Exit 2 means a check FAILED. Show the report, not just stderr: without it the
-    # failure says only "exit 2" and gives no way to tell which of the ~34 checks
-    # broke.
+    # This test is about the text output, not the aggregate health. Any valid
+    # classification (0 healthy, 1 degraded, 2 unhealthy) still prints the report,
+    # and an unrelated check can push the aggregate to 2 under CI load — so accept
+    # all three and let the content assertions below decide. Only a crash (exit
+    # outside 0/1/2) fails here; show the report then, since otherwise the failure
+    # says only "exit N" with no way to tell what broke.
     assert result.returncode in (0, 1, 2), (
-        f"Health check failed with exit {result.returncode}.\n"
+        f"coi health did not run (exit {result.returncode}).\n"
         f"--- report ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )
 

--- a/tests/health/health_text_output.py
+++ b/tests/health/health_text_output.py
@@ -30,7 +30,7 @@ def test_health_text_output(coi_binary):
     # Exit 2 means a check FAILED. Show the report, not just stderr: without it the
     # failure says only "exit 2" and gives no way to tell which of the ~34 checks
     # broke.
-    assert result.returncode in [0, 1], (
+    assert result.returncode in (0, 1, 2), (
         f"Health check failed with exit {result.returncode}.\n"
         f"--- report ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )

--- a/tests/health/health_verbose_output.py
+++ b/tests/health/health_verbose_output.py
@@ -27,8 +27,9 @@ def test_health_verbose_output(coi_binary):
     )
 
     # Should succeed (exit 0 for healthy, 1 for degraded)
-    assert result.returncode in [0, 1], (
-        f"Health check failed with exit {result.returncode}. stderr: {result.stderr}"
+    assert result.returncode in (0, 1, 2), (
+        f"coi health did not run cleanly (exit {result.returncode}); an unrelated "
+        f"check failing is fine, the specific check is asserted below. stderr: {result.stderr}"
     )
 
     output = result.stdout

--- a/tests/health/health_verbose_output.py
+++ b/tests/health/health_verbose_output.py
@@ -26,7 +26,9 @@ def test_health_verbose_output(coi_binary):
         timeout=120,
     )
 
-    # Should succeed (exit 0 for healthy, 1 for degraded)
+    # Accept any valid classification (0 healthy, 1 degraded, 2 unhealthy): an
+    # unrelated check can push the aggregate to 2 under CI load, and this test is
+    # about the verbose output below, not the aggregate health.
     assert result.returncode in (0, 1, 2), (
         f"coi health did not run cleanly (exit {result.returncode}); an unrelated "
         f"check failing is fine, the specific check is asserted below. stderr: {result.stderr}"


### PR DESCRIPTION
Test-only stability. Extends #629's fix to the sibling health tests — the recurring `Health check failed with exit 2` flake that's been taxing PRs (it blocked #632 three times, on a *different* health test each run).

## The flake
Several health tests do:
```python
assert result.returncode in [0, 1], "Health check failed with exit ..."
# ... then assert a SPECIFIC check's status/output
```
`coi health` runs many checks and its **aggregate** exit reflects all of them. Under CI load an unrelated check (network/storage) can push the aggregate to 2, so the gate fails spuriously even though the check under test is `ok`. #629 fixed exactly this for `health_security_posture::..._ok_on_default`; the siblings had the same unfixed pattern.

## Fix
Widen the gate to `(0, 1, 2)` — "coi health ran and classified" — and let the specific-check assertion below decide. A genuine crash (exit not in 0/1/2) still fails.

Applied to the 8 gates across 6 files (`health_kernel_version`, `health_privileged_profile`, `health_json_output`, `health_text_output`, `health_verbose_output`, `health_storage_pool`).

**Deliberately untouched:**
- `health_exit_codes` — the exit code *is* its subject.
- The expect-failure assertions (`rc in [1, 2]` after setting a bad profile) — those legitimately require an unhealthy exit.

No product change; `grep -rn xfail tests/` still empty (no failure-masking — a real check failure still turns the specific assertion red).