### PR TITLE
chore(release): date CHANGELOG for 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.10.2 (Unreleased)
+## 0.11.0 (2026-07-29)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Release prep for **0.11.0** — dates the CHANGELOG header and bumps the version.

**Why 0.11.0 (minor), not 0.10.2 (patch):** this release contains a breaking change (`model` moved from the config root / `[defaults]` to `[tool.claude]`), so under semver it's a minor bump.

Mirrors the prior release-prep PRs (#595, #586): the version string in `internal/cli/root.go` is `"dev"` and set at build time via ldflags, so no source bump is needed.

## Release contents (0.11.0)

**Breaking:**
- `model` moved from the config root / `[defaults]` to `[tool.claude]`, and is now actually wired — delivered to Claude Code as `ANTHROPIC_MODEL` (#657).

**New features:**
- `[[network.hosts]]` + `coi hosts` — static `/etc/hosts` entries with mode-aware firewall reachability (#605).
- `[defaults] profile` — selects the profile a bare `coi` uses (#607).
- `coi close` — alias for `coi shutdown` (#593).
- `COI_TIMING_DEBUG` — wall-clock startup profiler (#660).

Plus a large batch of fixes (installer ZFS/btrfs storage safety #666/#661/#662, `raw.idmap` UID-mapping #667, allowlist DNS-resolution hardening #603, `coi run` HOME/USER #623, shutdown/close cleanup, and monitoring/network test stabilization) and security fixes — see the full CHANGELOG section.

## Pre-release checks done
- **CHANGELOG ↔ PRs:** verified complete — every user-facing feat/fix merged since v0.10.1 has an entry.
- **Wiki:** aligned to 0.11.0 in the same sweep (pushed to the GitHub wiki) — new Migration-Guide 0.10.1→0.11.0 section, Network-Isolation "Static Host Entries", Profiles `[defaults] profile`, Troubleshooting "Profiling Slow Startup", `coi close` note, and the `model`→`[tool.claude]` doc move.
- **README:** already current (`coi close` documented; no stale `model` examples).

After merge: tag `v0.11.0` to cut the release.