### PR TITLE
fix(version): stop double-'v' prefix that broke release builds and `coi update`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
           CC: ${{ matrix.arch == 'arm64' && 'aarch64-linux-gnu-gcc' || 'gcc' }}
           PKG_CONFIG_PATH: ${{ matrix.arch == 'arm64' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
         run: |
+          # The Makefile's VERSION uses `?=`, so an env value wins and its own
+          # `sed 's/^v//'` never runs. Strip the leading 'v' here to honor the
+          # Makefile's bare-version contract; otherwise the binary reports
+          # "vv0.10.1" and version comparison breaks (#672 follow-up).
+          export VERSION="${VERSION#v}"
           make build
           mv coi coi-${{ matrix.os }}-${{ matrix.arch }}
 
@@ -97,13 +102,17 @@ jobs:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           chmod +x coi-${{ matrix.os }}-${{ matrix.arch }}
-          BUILT_VERSION=$(./coi-${{ matrix.os }}-${{ matrix.arch }} version | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-          # Strip leading 'v' from expected version if present
+          # Compare the FULL first line against the exact expected string. The
+          # old `grep -oP 'v\K…'` matched the digits even inside "vv0.10.1",
+          # so a doubled-prefix build slipped through. Anchoring the whole line
+          # makes any stray 'v' (or missing one) fail the release.
           EXPECTED_VERSION=${EXPECTED_VERSION#v}
-          echo "Built version: $BUILT_VERSION"
-          echo "Expected version: $EXPECTED_VERSION"
-          if [ "$BUILT_VERSION" != "$EXPECTED_VERSION" ]; then
-            echo "ERROR: Version mismatch! Built: $BUILT_VERSION, Expected: $EXPECTED_VERSION"
+          BUILT_LINE=$(./coi-${{ matrix.os }}-${{ matrix.arch }} version | head -n1)
+          EXPECTED_LINE="code-on-incus (coi) v${EXPECTED_VERSION}"
+          echo "Built version line:    $BUILT_LINE"
+          echo "Expected version line: $EXPECTED_LINE"
+          if [ "$BUILT_LINE" != "$EXPECTED_LINE" ]; then
+            echo "ERROR: Version mismatch! Built: '$BUILT_LINE', Expected: '$EXPECTED_LINE'"
             exit 1
           fi
           echo "Version verification passed!"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,6 +15,11 @@ import (
 // Version is the current version of coi (injected via ldflags at build time)
 var Version = "dev"
 
+// rootVersionTemplate is the text/template cobra renders for `coi --version`.
+// It mirrors the first line the `coi version` subcommand prints so both surfaces
+// agree; {{.Version}} is rootCmd.Version, which is normalizeVersion(Version).
+const rootVersionTemplate = "code-on-incus (coi) v{{.Version}}\n"
+
 // App holds the shared CLI state that is populated from persistent flags and
 // config loading in PersistentPreRunE. Grouping this in a struct rather than
 // package-level vars makes it easier to construct an isolated instance in
@@ -53,7 +58,7 @@ Examples:
   coi image list               # List available images
   coi list                     # List active sessions
 `,
-	Version: Version,
+	Version: normalizeVersion(Version),
 	// When called without subcommand, run shell command
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Execute shell command with the same args
@@ -204,6 +209,12 @@ func Execute() error {
 }
 
 func init() {
+	// Keep `coi --version` (cobra's version flag) consistent with the `coi
+	// version` subcommand: same "code-on-incus (coi) v<semver>" line, and the
+	// version already normalized (rootCmd.Version above) so a stray/doubled 'v'
+	// from a mis-tagged build can't leak here either.
+	rootCmd.SetVersionTemplate(rootVersionTemplate)
+
 	// Global flags available to all commands.
 	// NOTE: --image and --persistent were removed on purpose — anything
 	// config-shaped goes via config/profiles ([container] image / persistent).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -259,10 +259,10 @@ var versionCmd = &cobra.Command{
 			return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid format %q: must be 'text' or 'json'", format)}
 		}
 		if format == "json" {
-			fmt.Printf(`{"version":%q,"url":"https://github.com/mensfeld/code-on-incus"}`+"\n", "v"+Version)
+			fmt.Printf(`{"version":%q,"url":"https://github.com/mensfeld/code-on-incus"}`+"\n", "v"+normalizeVersion(Version))
 			return nil
 		}
-		fmt.Printf("code-on-incus (coi) v%s\n", Version)
+		fmt.Printf("code-on-incus (coi) v%s\n", normalizeVersion(Version))
 		fmt.Println("https://github.com/mensfeld/code-on-incus")
 		return nil
 	},

--- a/internal/cli/root_version_test.go
+++ b/internal/cli/root_version_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRootVersionFlagOutput guards the `coi --version` (cobra version flag)
+// display path: it must render the same "code-on-incus (coi) v<semver>" line as
+// the `coi version` subcommand and be normalized, so a stray or doubled 'v' from
+// a mis-tagged release build (e.g. "vv0.10.1") can't leak here either. It renders
+// through the real shared template (rootVersionTemplate) + normalizeVersion.
+func TestRootVersionFlagOutput(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantLine string
+	}{
+		{"0.11.0", "code-on-incus (coi) v0.11.0\n"},
+		{"v0.11.0", "code-on-incus (coi) v0.11.0\n"},
+		{"vv0.10.1", "code-on-incus (coi) v0.10.1\n"}, // the doubled-prefix build artifact
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			cmd := &cobra.Command{
+				Use:     "coi",
+				Version: normalizeVersion(tt.in),
+				Run:     func(*cobra.Command, []string) {},
+			}
+			cmd.SetVersionTemplate(rootVersionTemplate)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{"--version"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute(--version): %v", err)
+			}
+			if got := buf.String(); got != tt.wantLine {
+				t.Errorf("coi --version for injected %q = %q, want %q", tt.in, got, tt.wantLine)
+			}
+		})
+	}
+}
+
+// TestRootCmdVersionWiring guards that the real rootCmd is actually wired to
+// normalize its version and use the shared template, so the fix for the
+// doubled-'v' leak into `coi --version` can't be silently reverted.
+func TestRootCmdVersionWiring(t *testing.T) {
+	if rootCmd.Version != normalizeVersion(Version) {
+		t.Errorf("rootCmd.Version = %q, want normalizeVersion(Version) = %q",
+			rootCmd.Version, normalizeVersion(Version))
+	}
+	if got := rootCmd.VersionTemplate(); got != rootVersionTemplate {
+		t.Errorf("rootCmd version template = %q, want %q", got, rootVersionTemplate)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -99,7 +99,7 @@ type githubAsset struct {
 }
 
 func updateCoreCommand(cmd *cobra.Command, args []string) error {
-	currentVersion := Version
+	currentVersion := normalizeVersion(Version)
 	isDev := currentVersion == "dev"
 
 	// A dev build cannot be version-compared. Unless the user is forcing the
@@ -131,7 +131,7 @@ func updateCoreCommand(cmd *cobra.Command, args []string) error {
 		latestTag = release.TagName
 	}
 
-	latestVersion := strings.TrimPrefix(latestTag, "v")
+	latestVersion := normalizeVersion(latestTag)
 
 	// Show version comparison
 	if isDev {
@@ -384,6 +384,15 @@ func verifyChecksum(data []byte, checksumFile []byte, binaryName string) error {
 	}
 
 	return fmt.Errorf("no checksum found for %s in checksums.txt", binaryName)
+}
+
+// normalizeVersion strips any leading "v" characters from a version string so
+// callers always work with a bare semver (e.g. "0.10.1"). It tolerates a
+// doubled prefix ("vv0.10.1") defensively: a release build once injected a
+// v-prefixed Version because the Makefile's `?=` skipped its `sed 's/^v//'`,
+// producing "vv…" in display and breaking compareVersions' numeric split.
+func normalizeVersion(v string) string {
+	return strings.TrimLeft(v, "v")
 }
 
 // compareVersions compares two semver strings (without "v" prefix)

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -44,6 +44,39 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+// TestNormalizeVersion locks down that a version string is reduced to a bare
+// number regardless of how many leading 'v' characters a build injected.
+// Regression guard for the release-build bug where the Makefile's `?=` skipped
+// its `sed 's/^v//'`, leaving Version="v0.10.1" and rendering as "vv0.10.1".
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"0.10.1", "0.10.1"},
+		{"v0.10.1", "0.10.1"},
+		{"vv0.10.1", "0.10.1"}, // the doubled-prefix release artifact
+		{"dev", "dev"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := normalizeVersion(tt.in); got != tt.want {
+				t.Errorf("normalizeVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompareVersionsToleratesVPrefix reproduces the user-visible failure: a
+// v-prefixed current version made compareVersions fall into string comparison
+// ("v0" > "0"), so `coi update` wrongly reported "already on the latest version"
+// for 0.10.1 when 0.11.0 was out. Normalized inputs must compare numerically.
+func TestCompareVersionsToleratesVPrefix(t *testing.T) {
+	if got := compareVersions(normalizeVersion("vv0.10.1"), normalizeVersion("v0.11.0")); got != -1 {
+		t.Errorf("compareVersions(vv0.10.1, v0.11.0) after normalize = %d, want -1 (update available)", got)
+	}
+}
+
 func TestVerifyChecksum(t *testing.T) {
 	data := []byte("hello world\n")
 	// SHA256 of "hello world\n"


### PR DESCRIPTION
## Problem

On an installed release, `coi version` prints a doubled `v`:

```
code-on-incus (coi) vv0.10.1
```

and `coi update` **wrongly reports "You are already on the latest version"** even though a newer release exists:

```
Current version: vv0.10.1
Latest release:  v0.11.0

You are already on the latest version.
```

This affects every downloaded release binary (what `install.sh` fetches). Locally-built binaries (`make build` with no `VERSION` in env) are unaffected.

## Root cause

The release workflow feeds the raw git tag (e.g. `v0.10.1`) to `make build` through the environment (`release.yml` → `version=${GITHUB_REF#refs/tags/}`, which only strips `refs/tags/`, keeping the `v`).

The Makefile normalizes with:

```make
VERSION ?= $(shell (git describe --tags --always --dirty ... ) | sed 's/^v//')
```

But `?=` only assigns when unset. Since the workflow already exports `VERSION`, the `sed 's/^v//'` **never runs**, so the binary is built with `cli.Version="v0.10.1"`. The print paths then do `v%s` → `vv0.10.1`.

Worse than cosmetics: `compareVersions` splits on `.`, so `"v0"` fails `strconv.Atoi` and falls back to string comparison, where `"v0" > "0"`. The current version therefore looks `>=` latest and the update is suppressed — exactly the reported symptom.

The existing CI "Verify version" guard missed it because `grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+'` matches the digits *inside* `vv0.10.1` and extracts `0.10.1`, passing.

## Fix (defense-in-depth)

1. **Workflow boundary** — strip the leading `v` before `make build`, honoring the Makefile's bare-version contract.
2. **CLI robustness** — add `normalizeVersion()` and apply it wherever `Version`/tags are read (`version` text + JSON output, `update` current + latest), so a stray `v` can never reach display or comparison again.
3. **Tighten the verify guard** — compare the full version line against the exact expected string instead of a `\K` substring, so any doubled/missing `v` fails the release.

## Tests

- `TestNormalizeVersion` — bare/`v`/`vv`/`dev`/empty inputs.
- `TestCompareVersionsToleratesVPrefix` — reproduces the suppressed-update case (`vv0.10.1` vs `v0.11.0` → update available).

Verified locally that a binary built with the buggy `Version=v0.10.1` now prints `v0.10.1` and reports the update correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)