### PR TITLE
fix(session): ~/.claude/CLAUDE.md grows on every session (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.11.1 (Unreleased)
+
+### Fixed
+
+- **The sandbox context block no longer grows `~/.claude/CLAUDE.md` on every session (#674)** — coi injects its sandbox context into the tool's native auto-context file (Claude's `~/.claude/CLAUDE.md`) at session setup. When the file already existed it **appended** the block without checking for its own prior copy, so on a persistent container reused across sessions the block accumulated one copy per session — a reporter hit 16 identical copies (108k chars), past Claude Code's 40k-char limit. The block is now delimited by `# BEGIN COI Sandbox Context …` / `# END COI Sandbox Context` markers and the injection is **idempotent**: each session strips any prior managed block and writes a single fresh one, overwriting (regenerating) the dynamic block while preserving non-managed user/host content. Marker matching is line-anchored so the delimiters can't be spoofed by content that merely mentions them (e.g. a custom `context_file`). The same pass also **heals files already bloated** by the old code — old unmarked copies (identified by the coi-exclusive `# COI Sandbox Context` separator) are removed on the next session, collapsing an accumulated file back to a single block while keeping any real user content. Covered by a deterministic Go test and an end-to-end `shell-persistent` integration test that reproduces the growth across real sessions.
+
 ## 0.11.0 (2026-07-29)
 
 ### Breaking Changes

--- a/internal/session/setup_context.go
+++ b/internal/session/setup_context.go
@@ -64,30 +64,102 @@ func resolveContextContent(info tool.ContextInfo, customPath string, logger func
 // Markers delimiting the coi-managed sandbox context block inside the tool's
 // auto-load file. The block is rewritten (not appended) every session, so the
 // file never accumulates duplicate copies (#674). Anything outside the markers
-// (e.g. a CLAUDE.md copied from the host) is preserved.
+// (e.g. a CLAUDE.md copied from the host) is preserved. Matching is line-anchored
+// (a marker must be a whole line), so a marker string appearing mid-content — for
+// example inside a user-provided context_file — cannot be mistaken for a real
+// delimiter.
 const (
-	autoCtxBeginMarker = "# BEGIN COI Sandbox Context (managed by coi — do not edit this block)"
-	autoCtxEndMarker   = "# END COI Sandbox Context"
+	autoCtxBeginMarker = "# BEGIN COI Sandbox Context (managed by coi - do not edit this block)"
+	autoCtxEndMarker   = "# END COI Sandbox Context (managed by coi)"
+
+	// legacyAutoCtxSeparator is the bare separator line the pre-#674 code wrote
+	// between appended copies (which had no BEGIN/END markers). It is coi-exclusive,
+	// so it can be used to recognize and clean up old accumulated copies.
+	legacyAutoCtxSeparator = "# COI Sandbox Context"
+
+	// coiContextHeader is the first line of a rendered sandbox context block, and
+	// coiContextFingerprint is a stable, distinctive sentence from its body. A
+	// segment matching both is a coi-generated block (not user content).
+	coiContextHeader      = "# COI Sandbox Environment"
+	coiContextFingerprint = "Code on Incus (COI)"
 )
 
-// stripManagedAutoContext removes a previously coi-written managed block (from
-// autoCtxBeginMarker through autoCtxEndMarker, inclusive) from s, so a fresh
-// block can replace it instead of stacking on top of it. Content outside the
-// block is returned untouched. If the begin marker is present but the end marker
-// is missing (a truncated/hand-mangled block), everything from the begin marker
-// on is dropped rather than left half-parsed.
+// lineIndex returns the index of the first element of lines at or after `from`
+// that equals target, or -1. Used for line-anchored marker matching.
+func lineIndex(lines []string, from int, target string) int {
+	for i := from; i < len(lines); i++ {
+		if lines[i] == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// stripManagedAutoContext removes a previously coi-written managed block (the
+// whole-line autoCtxBeginMarker through the whole-line autoCtxEndMarker,
+// inclusive) from s, so a fresh block can replace it instead of stacking on top
+// of it. Content outside the block is returned untouched. If the begin marker is
+// present but no end marker follows (a truncated/hand-mangled block), everything
+// from the begin marker on is dropped rather than left half-parsed.
 func stripManagedAutoContext(s string) string {
-	begin := strings.Index(s, autoCtxBeginMarker)
+	lines := strings.Split(s, "\n")
+	begin := lineIndex(lines, 0, autoCtxBeginMarker)
 	if begin == -1 {
 		return s
 	}
-	rest := s[begin+len(autoCtxBeginMarker):]
-	endRel := strings.Index(rest, autoCtxEndMarker)
-	if endRel == -1 {
-		return s[:begin]
+	end := lineIndex(lines, begin+1, autoCtxEndMarker)
+	if end == -1 {
+		return strings.Join(lines[:begin], "\n")
 	}
-	end := begin + len(autoCtxBeginMarker) + endRel + len(autoCtxEndMarker)
-	return s[:begin] + s[end:]
+	kept := append(append([]string{}, lines[:begin]...), lines[end+1:]...)
+	return strings.Join(kept, "\n")
+}
+
+// isRenderedCOIBlock reports whether s (ignoring surrounding whitespace) is a
+// coi-generated sandbox context block rather than user content: it must start
+// with the sandbox header and carry the distinctive body fingerprint.
+func isRenderedCOIBlock(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, coiContextHeader) && strings.Contains(t, coiContextFingerprint)
+}
+
+// stripLegacyAutoContext removes sandbox blocks written by the pre-#674 code,
+// which appended copies separated by a bare "# COI Sandbox Context" line and had
+// no BEGIN/END markers. It splits on that (coi-exclusive) separator line and
+// drops every segment that is a rendered coi block, keeping genuine user/host
+// content. This heals a file that already accumulated many copies (a reporter
+// hit 16 / 108k chars) — after the current injection re-adds one managed block,
+// the file collapses to a single copy plus any real user content.
+//
+// Caveat: content a user manually inserted *inside or immediately after* a
+// legacy coi copy (so that the copy+note reads as one coi-looking segment) is
+// dropped with that copy. That is rare, and preferable to leaving the file over
+// the tool's size limit.
+func stripLegacyAutoContext(s string) string {
+	if !strings.Contains(s, coiContextHeader) {
+		return s // no coi-generated content to clean up
+	}
+	var segments [][]string
+	cur := []string{}
+	for _, ln := range strings.Split(s, "\n") {
+		if ln == legacyAutoCtxSeparator {
+			segments = append(segments, cur)
+			cur = nil
+			continue
+		}
+		cur = append(cur, ln)
+	}
+	segments = append(segments, cur)
+
+	var kept []string
+	for _, seg := range segments {
+		segStr := strings.Join(seg, "\n")
+		if strings.TrimSpace(segStr) == "" || isRenderedCOIBlock(segStr) {
+			continue
+		}
+		kept = append(kept, strings.TrimRight(segStr, "\n"))
+	}
+	return strings.Join(kept, "\n\n")
 }
 
 // injectAutoContextFile writes sandbox context into the tool's native auto-load
@@ -117,14 +189,16 @@ func injectAutoContextFile(mgr container.ContainerManager, acf tool.ToolWithAuto
 
 	var newContent string
 	if err == nil && strings.TrimSpace(checkResult) == "exists" {
-		// Read the current file, drop any prior managed block, and re-attach a fresh
-		// one. This keeps exactly one always-current copy while preserving any
-		// user/host content, instead of appending a new copy every session (#674).
+		// Read the current file, drop any prior managed block AND any old-format
+		// copies from before #674, then re-attach a single fresh block. This keeps
+		// exactly one always-current copy while preserving any user/host content,
+		// instead of appending a new copy every session (#674) — and heals files
+		// that already accumulated many copies under the old code.
 		existing, readErr := mgr.ExecCommand(fmt.Sprintf("cat %s", destPath), container.ExecCommandOptions{Capture: true})
 		if readErr != nil {
 			return fmt.Errorf("failed to read %s: %w", relPath, readErr)
 		}
-		preserved := strings.TrimRight(stripManagedAutoContext(existing), "\n")
+		preserved := strings.TrimRight(stripLegacyAutoContext(stripManagedAutoContext(existing)), "\n")
 		if preserved == "" {
 			logger(fmt.Sprintf("Refreshing sandbox context in %s", relPath))
 			newContent = managedBlock

--- a/internal/session/setup_context.go
+++ b/internal/session/setup_context.go
@@ -61,10 +61,42 @@ func resolveContextContent(info tool.ContextInfo, customPath string, logger func
 	return tool.RenderContextFileContent(info)
 }
 
+// Markers delimiting the coi-managed sandbox context block inside the tool's
+// auto-load file. The block is rewritten (not appended) every session, so the
+// file never accumulates duplicate copies (#674). Anything outside the markers
+// (e.g. a CLAUDE.md copied from the host) is preserved.
+const (
+	autoCtxBeginMarker = "# BEGIN COI Sandbox Context (managed by coi — do not edit this block)"
+	autoCtxEndMarker   = "# END COI Sandbox Context"
+)
+
+// stripManagedAutoContext removes a previously coi-written managed block (from
+// autoCtxBeginMarker through autoCtxEndMarker, inclusive) from s, so a fresh
+// block can replace it instead of stacking on top of it. Content outside the
+// block is returned untouched. If the begin marker is present but the end marker
+// is missing (a truncated/hand-mangled block), everything from the begin marker
+// on is dropped rather than left half-parsed.
+func stripManagedAutoContext(s string) string {
+	begin := strings.Index(s, autoCtxBeginMarker)
+	if begin == -1 {
+		return s
+	}
+	rest := s[begin+len(autoCtxBeginMarker):]
+	endRel := strings.Index(rest, autoCtxEndMarker)
+	if endRel == -1 {
+		return s[:begin]
+	}
+	end := begin + len(autoCtxBeginMarker) + endRel + len(autoCtxEndMarker)
+	return s[:begin] + s[end:]
+}
+
 // injectAutoContextFile writes sandbox context into the tool's native auto-load
-// file (e.g., ~/.claude/CLAUDE.md). If the file already exists (e.g., copied from
-// host), the sandbox context is appended with a separator. Otherwise, the file is
-// created with just the sandbox context.
+// file (e.g., ~/.claude/CLAUDE.md) as a single coi-managed block delimited by
+// autoCtxBeginMarker/autoCtxEndMarker. If the file already exists (e.g. copied
+// from host, or left over from a previous session on a persistent container), any
+// prior managed block is stripped and a fresh one is written in its place, so the
+// file does not grow a new copy every session (#674). Non-managed content in the
+// file is preserved.
 func injectAutoContextFile(mgr container.ContainerManager, acf tool.ToolWithAutoContextFile, contextContent, homeDir string, logger func(string)) error {
 	relPath := acf.AutoContextFile()
 	destPath := filepath.Join(homeDir, relPath)
@@ -76,43 +108,38 @@ func injectAutoContextFile(mgr container.ContainerManager, acf tool.ToolWithAuto
 		return fmt.Errorf("failed to create directory for %s: %w", relPath, err)
 	}
 
-	separator := "\n\n# COI Sandbox Context\n\n"
+	managedBlock := autoCtxBeginMarker + "\n" + contextContent + "\n" + autoCtxEndMarker + "\n"
 
-	// Check if the file already exists in the container (e.g., host's CLAUDE.md was copied)
+	// Check if the file already exists in the container (e.g., host's CLAUDE.md was
+	// copied, or the container is persistent and a prior session already wrote one).
 	checkCmd := fmt.Sprintf("test -f %s && echo exists || echo missing", destPath)
 	checkResult, err := mgr.ExecCommand(checkCmd, container.ExecCommandOptions{Capture: true})
 
+	var newContent string
 	if err == nil && strings.TrimSpace(checkResult) == "exists" {
-		// File exists — append sandbox context with separator by writing to a temp
-		// file and using cat >> inside the container
-		logger(fmt.Sprintf("Appending sandbox context to existing %s", relPath))
-		appendContent := separator + contextContent
-		tmpFile, tmpErr := os.CreateTemp("", "coi-autocontext-*")
-		if tmpErr != nil {
-			return fmt.Errorf("failed to create temp file for append: %w", tmpErr)
+		// Read the current file, drop any prior managed block, and re-attach a fresh
+		// one. This keeps exactly one always-current copy while preserving any
+		// user/host content, instead of appending a new copy every session (#674).
+		existing, readErr := mgr.ExecCommand(fmt.Sprintf("cat %s", destPath), container.ExecCommandOptions{Capture: true})
+		if readErr != nil {
+			return fmt.Errorf("failed to read %s: %w", relPath, readErr)
 		}
-		tmpPath := tmpFile.Name()
-		defer os.Remove(tmpPath)
-		if _, tmpErr = tmpFile.WriteString(appendContent); tmpErr != nil {
-			tmpFile.Close()
-			return fmt.Errorf("failed to write temp file for append: %w", tmpErr)
-		}
-		tmpFile.Close()
-		// Push temp file to a staging path in the container, then cat >> to target
-		stagingPath := destPath + ".coi-append"
-		if pushErr := mgr.PushFile(tmpPath, stagingPath); pushErr != nil {
-			return fmt.Errorf("failed to push append content to %s: %w", relPath, pushErr)
-		}
-		catCmd := fmt.Sprintf("cat %s >> %s && rm -f %s", stagingPath, destPath, stagingPath)
-		if _, catErr := mgr.ExecCommand(catCmd, container.ExecCommandOptions{Capture: true}); catErr != nil {
-			return fmt.Errorf("failed to append to %s: %w", relPath, catErr)
+		preserved := strings.TrimRight(stripManagedAutoContext(existing), "\n")
+		if preserved == "" {
+			logger(fmt.Sprintf("Refreshing sandbox context in %s", relPath))
+			newContent = managedBlock
+		} else {
+			logger(fmt.Sprintf("Refreshing sandbox context in %s (preserving existing content)", relPath))
+			newContent = preserved + "\n\n" + managedBlock
 		}
 	} else {
-		// File doesn't exist — create it with sandbox context
 		logger(fmt.Sprintf("Creating %s with sandbox context", relPath))
-		if err := mgr.CreateFile(destPath, contextContent); err != nil {
-			return fmt.Errorf("failed to create %s: %w", relPath, err)
-		}
+		newContent = managedBlock
+	}
+
+	// Overwrite the file with the reconciled content (single managed block).
+	if err := mgr.CreateFile(destPath, newContent); err != nil {
+		return fmt.Errorf("failed to write %s: %w", relPath, err)
 	}
 
 	// Fix ownership if running as non-root user

--- a/internal/session/setup_context_autoctx_test.go
+++ b/internal/session/setup_context_autoctx_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/container"
+	"github.com/mensfeld/code-on-incus/internal/tool"
+)
+
+// fakeAutoCtxManager is an in-memory ContainerManager that simulates just enough
+// of a container filesystem for injectAutoContextFile: `mkdir -p`, the
+// `test -f … && echo exists || echo missing` existence probe, CreateFile,
+// PushFile (staging a host temp file), a plain `cat <path>` read, and a
+// `cat <staging> >> <dest>` append. Every other ContainerManager method is
+// inherited from the embedded (nil) interface and is never called here, so a
+// call to one would panic loudly rather than pass silently.
+//
+// The simulated filesystem persists across calls (map keyed by path), which is
+// exactly the condition that makes #674 reproducible: a persistent container's
+// ~/.claude/CLAUDE.md survives from one session to the next.
+type fakeAutoCtxManager struct {
+	container.ContainerManager
+	files map[string]string
+}
+
+func newFakeAutoCtxManager() *fakeAutoCtxManager {
+	return &fakeAutoCtxManager{files: map[string]string{}}
+}
+
+func (f *fakeAutoCtxManager) ExecCommand(cmd string, _ container.ExecCommandOptions) (string, error) {
+	fields := strings.Fields(cmd)
+	switch {
+	case strings.HasPrefix(cmd, "mkdir -p"):
+		return "", nil
+	case strings.HasPrefix(cmd, "test -f "):
+		// test -f <path> && echo exists || echo missing
+		if _, ok := f.files[fields[2]]; ok {
+			return "exists\n", nil
+		}
+		return "missing\n", nil
+	case strings.HasPrefix(cmd, "cat ") && strings.Contains(cmd, ">>"):
+		// cat <staging> >> <dest> && rm -f <staging>
+		staging, dest := fields[1], fields[3]
+		f.files[dest] += f.files[staging]
+		delete(f.files, staging)
+		return "", nil
+	case strings.HasPrefix(cmd, "cat "):
+		// plain read: cat <path>
+		return f.files[fields[1]], nil
+	default:
+		return "", nil
+	}
+}
+
+func (f *fakeAutoCtxManager) CreateFile(path, content string) error {
+	f.files[path] = content
+	return nil
+}
+
+func (f *fakeAutoCtxManager) PushFile(src, dest string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	f.files[dest] = string(data)
+	return nil
+}
+
+func (f *fakeAutoCtxManager) Chown(_ string, _, _ int) error { return nil }
+
+// fakeAutoCtxTool implements tool.ToolWithAutoContextFile with Claude's
+// auto-context path. Only AutoContextFile is exercised by injectAutoContextFile;
+// the embedded (nil) Tool interface covers the rest of the method set.
+type fakeAutoCtxTool struct {
+	tool.ToolWithAutoContextFile
+}
+
+func (fakeAutoCtxTool) AutoContextFile() string { return ".claude/CLAUDE.md" }
+
+// TestInjectAutoContextFile_DoesNotAccumulateAcrossSessions reproduces #674:
+// on a persistent container reused across sessions, the COI sandbox context block
+// (headed "# COI Sandbox Environment") is appended to ~/.claude/CLAUDE.md on every
+// session instead of replacing the previous copy, so the file grows without bound
+// (the reporter observed 16 copies / 108k chars, over Claude Code's 40k limit).
+//
+// Because "# COI Sandbox Environment" appears exactly once per rendered block, the
+// number of occurrences equals the number of copies. Driving injectAutoContextFile
+// across several sessions against one persistent home must leave exactly one copy.
+func TestInjectAutoContextFile_DoesNotAccumulateAcrossSessions(t *testing.T) {
+	mgr := newFakeAutoCtxManager()
+	acf := fakeAutoCtxTool{}
+	homeDir := "/home/code"
+	logger := func(string) {}
+
+	content := tool.RenderContextFileContent(tool.ContextInfo{
+		WorkspacePath: "/workspace",
+		HomeDir:       homeDir,
+		NetworkMode:   "restricted",
+	})
+	if !strings.Contains(content, "# COI Sandbox Environment") {
+		t.Fatalf("precondition: rendered sandbox context should contain the header marker")
+	}
+
+	const sessions = 3
+	for i := 0; i < sessions; i++ {
+		if err := injectAutoContextFile(mgr, acf, content, homeDir, logger); err != nil {
+			t.Fatalf("session %d: injectAutoContextFile failed: %v", i+1, err)
+		}
+	}
+
+	claudeMD := mgr.files["/home/code/.claude/CLAUDE.md"]
+	copies := strings.Count(claudeMD, "# COI Sandbox Environment")
+	if copies != 1 {
+		t.Errorf("#674: the COI sandbox context block must appear exactly once in "+
+			"~/.claude/CLAUDE.md after %d sessions, but found %d copies (%d chars) — it is being "+
+			"appended on every session instead of replaced, so the file grows without bound.",
+			sessions, copies, len(claudeMD))
+	}
+}

--- a/internal/session/setup_context_autoctx_test.go
+++ b/internal/session/setup_context_autoctx_test.go
@@ -153,3 +153,94 @@ func TestInjectAutoContextFile_PreservesHostContent(t *testing.T) {
 		t.Errorf("expected exactly one COI sandbox block alongside preserved content, found %d", n)
 	}
 }
+
+// TestInjectAutoContextFile_HealsLegacyDuplicates covers the migration path for
+// #674: a file already bloated by the pre-fix code (many unmarked copies joined
+// by the old "# COI Sandbox Context" separator) must collapse to a single copy
+// once the fixed injection runs, and stay there.
+func TestInjectAutoContextFile_HealsLegacyDuplicates(t *testing.T) {
+	mgr := newFakeAutoCtxManager()
+	acf := fakeAutoCtxTool{}
+	homeDir := "/home/code"
+	destPath := "/home/code/.claude/CLAUDE.md"
+	logger := func(string) {}
+
+	content := tool.RenderContextFileContent(tool.ContextInfo{
+		WorkspacePath: "/workspace",
+		HomeDir:       homeDir,
+		NetworkMode:   "restricted",
+	})
+	// Simulate the old (pre-#674) accumulation: three unmarked copies joined by
+	// the legacy separator line.
+	oldSep := "\n\n# COI Sandbox Context\n\n"
+	mgr.files[destPath] = content + oldSep + content + oldSep + content
+
+	for i := 0; i < 3; i++ {
+		if err := injectAutoContextFile(mgr, acf, content, homeDir, logger); err != nil {
+			t.Fatalf("session %d: injectAutoContextFile failed: %v", i+1, err)
+		}
+	}
+
+	got := mgr.files[destPath]
+	if n := strings.Count(got, "# COI Sandbox Environment"); n != 1 {
+		t.Errorf("legacy duplicates must be healed to exactly one copy, found %d (%d chars)", n, len(got))
+	}
+}
+
+// TestInjectAutoContextFile_HealsLegacyPreservingHostContent verifies the legacy
+// cleanup keeps genuine user/host content that preceded the old coi copies.
+func TestInjectAutoContextFile_HealsLegacyPreservingHostContent(t *testing.T) {
+	mgr := newFakeAutoCtxManager()
+	acf := fakeAutoCtxTool{}
+	homeDir := "/home/code"
+	destPath := "/home/code/.claude/CLAUDE.md"
+	logger := func(string) {}
+
+	content := tool.RenderContextFileContent(tool.ContextInfo{
+		WorkspacePath: "/workspace",
+		HomeDir:       homeDir,
+	})
+	const userMarker = "MY-PROJECT-RULES-KEEP-ME"
+	host := "# My project rules\n\n" + userMarker + "\n"
+	mgr.files[destPath] = host + "\n\n# COI Sandbox Context\n\n" + content + "\n\n# COI Sandbox Context\n\n" + content
+
+	if err := injectAutoContextFile(mgr, acf, content, homeDir, logger); err != nil {
+		t.Fatalf("injectAutoContextFile failed: %v", err)
+	}
+
+	got := mgr.files[destPath]
+	if n := strings.Count(got, userMarker); n != 1 {
+		t.Errorf("host content must be preserved exactly once, found %d occurrences of %q", n, userMarker)
+	}
+	if n := strings.Count(got, "# COI Sandbox Environment"); n != 1 {
+		t.Errorf("legacy coi copies must be healed to one block, found %d", n)
+	}
+}
+
+// TestInjectAutoContextFile_ContentContainingMarkerStaysIdempotent covers finding
+// #1: when the injected content (e.g. a user-provided context_file) merely
+// mentions the end-marker text inline — as a substring, not a standalone line —
+// line-anchored matching must not treat it as a delimiter, so the block stays a
+// single copy across sessions rather than being mis-parsed and duplicated.
+func TestInjectAutoContextFile_ContentContainingMarkerStaysIdempotent(t *testing.T) {
+	mgr := newFakeAutoCtxManager()
+	acf := fakeAutoCtxTool{}
+	homeDir := "/home/code"
+	destPath := "/home/code/.claude/CLAUDE.md"
+	logger := func(string) {}
+
+	const sentinel = "CUSTOM-CONTEXT-SENTINEL"
+	content := "# COI Sandbox Environment\n" + sentinel +
+		"\nsee the " + autoCtxEndMarker + " marker inline\n"
+
+	for i := 0; i < 3; i++ {
+		if err := injectAutoContextFile(mgr, acf, content, homeDir, logger); err != nil {
+			t.Fatalf("session %d: injectAutoContextFile failed: %v", i+1, err)
+		}
+	}
+
+	got := mgr.files[destPath]
+	if n := strings.Count(got, sentinel); n != 1 {
+		t.Errorf("content mentioning the end marker inline must remain a single block, found %d copies (%d chars)", n, len(got))
+	}
+}

--- a/internal/session/setup_context_autoctx_test.go
+++ b/internal/session/setup_context_autoctx_test.go
@@ -119,3 +119,37 @@ func TestInjectAutoContextFile_DoesNotAccumulateAcrossSessions(t *testing.T) {
 			sessions, copies, len(claudeMD))
 	}
 }
+
+// TestInjectAutoContextFile_PreservesHostContent verifies that when the tool's
+// auto-context file already contains user/host content (e.g. a CLAUDE.md copied
+// from the host), injecting the sandbox context preserves that content and still
+// keeps exactly one managed COI block across repeated sessions.
+func TestInjectAutoContextFile_PreservesHostContent(t *testing.T) {
+	mgr := newFakeAutoCtxManager()
+	acf := fakeAutoCtxTool{}
+	homeDir := "/home/code"
+	destPath := "/home/code/.claude/CLAUDE.md"
+	logger := func(string) {}
+
+	const userMarker = "MY-PROJECT-INSTRUCTIONS-DO-NOT-DROP"
+	mgr.files[destPath] = "# My project rules\n\n" + userMarker + "\n"
+
+	content := tool.RenderContextFileContent(tool.ContextInfo{
+		WorkspacePath: "/workspace",
+		HomeDir:       homeDir,
+	})
+
+	for i := 0; i < 3; i++ {
+		if err := injectAutoContextFile(mgr, acf, content, homeDir, logger); err != nil {
+			t.Fatalf("session %d: injectAutoContextFile failed: %v", i+1, err)
+		}
+	}
+
+	got := mgr.files[destPath]
+	if n := strings.Count(got, userMarker); n != 1 {
+		t.Errorf("host/user content must be preserved exactly once, found %d occurrences of %q", n, userMarker)
+	}
+	if n := strings.Count(got, "# COI Sandbox Environment"); n != 1 {
+		t.Errorf("expected exactly one COI sandbox block alongside preserved content, found %d", n)
+	}
+}

--- a/tests/shell/persistent/claude_md_no_growth_persistent.py
+++ b/tests/shell/persistent/claude_md_no_growth_persistent.py
@@ -1,0 +1,141 @@
+"""
+End-to-end regression test for #674: the COI sandbox context block must not
+accumulate in ~/.claude/CLAUDE.md across sessions on a persistent container.
+
+Background: coi injects a sandbox context block into the tool's native
+auto-context file (Claude's ~/.claude/CLAUDE.md) during session setup. On a
+persistent container the file survives between sessions, and setup re-runs on
+every session (the context block is re-rendered "for both new and resumed
+sessions so dynamic info stays current"). So the block must be REPLACED, not
+appended. Before the fix it was appended each session and the file grew without
+bound — the reporter hit 16 identical copies / 108k chars, past Claude Code's
+40k limit.
+
+This drives the real `coi` CLI end-to-end. It creates one persistent container,
+then reuses that SAME container across several sessions the way a real
+stop/resume cycle does — stop it, then `coi shell --container <name>` to re-enter
+it — so setup (and its auto-context injection) runs again against the same
+persisted home. Each session uses `--background` (runs setup then detaches, so no
+interactive/real `claude` binary is needed). The file is then read back from
+inside the container; because "# COI Sandbox Environment" renders exactly once
+per block, its occurrence count is the number of copies and must be exactly one.
+
+The tool is intentionally left at its default (Claude) — i.e. COI_USE_DUMMY is
+NOT set — because only the Claude tool implements the auto-context file path; the
+dummy tool would never exercise it.
+"""
+
+import subprocess
+import time
+
+from support.helpers import (
+    calculate_container_name,
+    write_workspace_container_config,
+)
+
+
+def _incus_run(*args):
+    """Run an incus command directly (no sg wrapper), matching the coi project."""
+    return subprocess.run(
+        ["incus", "--project", "default", *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _container_exists(name):
+    return _incus_run("info", name).returncode == 0
+
+
+def test_claude_md_does_not_grow_across_persistent_sessions(
+    coi_binary, cleanup_containers, workspace_dir
+):
+    # Persistent so the container (and its ~/.claude/CLAUDE.md) survives between
+    # sessions and can be re-entered instead of recreated.
+    write_workspace_container_config(workspace_dir, persistent=True)
+
+    claude_md = "/home/code/.claude/CLAUDE.md"
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    try:
+        # --- Session 1: create the persistent container (slot 1). ---
+        first = subprocess.run(
+            [coi_binary, "shell", "--background"],
+            cwd=workspace_dir,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert first.returncode == 0, (
+            f"session 1 (create): `coi shell --background` should succeed. "
+            f"stderr: {first.stderr}\nstdout: {first.stdout}"
+        )
+        time.sleep(2)
+        assert _container_exists(container_name), (
+            f"expected persistent container {container_name} to exist after session 1"
+        )
+
+        # --- Sessions 2 & 3: stop, then re-enter the SAME container. ---
+        # `--container` forces reuse of this exact container (no new slot), driving
+        # the setup reuse path that re-injects the auto-context block.
+        extra_sessions = 2
+        for i in range(extra_sessions):
+            stop = subprocess.run(
+                [coi_binary, "container", "stop", container_name],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert stop.returncode == 0, (
+                f"stopping before resume {i + 1} should succeed. stderr: {stop.stderr}"
+            )
+            time.sleep(1)
+
+            resumed = subprocess.run(
+                [coi_binary, "shell", "--container", container_name, "--background"],
+                cwd=workspace_dir,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            assert resumed.returncode == 0, (
+                f"resume {i + 1}: `coi shell --container --background` should succeed. "
+                f"stderr: {resumed.stderr}\nstdout: {resumed.stdout}"
+            )
+            time.sleep(2)
+
+        total_sessions = 1 + extra_sessions
+
+        # Guard: the same container was reused, not fresh slots — otherwise each
+        # session would trivially have one copy and hide a regression.
+        assert not _container_exists(calculate_container_name(workspace_dir, 2)), (
+            "a second container slot was created; sessions did not reuse the same "
+            "persistent container, so this test would not exercise the accumulation path"
+        )
+
+        # Read the injected file back from inside the container. `coi container
+        # exec` routes the command's stdout to ITS stderr, so read both streams.
+        exec_res = subprocess.run(
+            [coi_binary, "container", "exec", container_name, "--", "cat", claude_md],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        content = exec_res.stdout + exec_res.stderr
+        # Sanity: the injection must have happened at all (guards against a
+        # false pass where the block is simply never written).
+        assert "# COI Sandbox Environment" in content, (
+            f"expected the sandbox block to be present in {claude_md}; "
+            f"exec rc={exec_res.returncode}, output head={content[:400]!r}"
+        )
+
+        copies = content.count("# COI Sandbox Environment")
+        assert copies == 1, (
+            f"#674: the COI sandbox context block must appear exactly once in "
+            f"{claude_md} after {total_sessions} sessions on one persistent container, "
+            f"but found {copies} copies ({len(content)} chars). It is being appended on "
+            f"every session instead of replaced, so the file grows without bound."
+        )
+    finally:
+        _incus_run("delete", container_name, "--force")


### PR DESCRIPTION
Fixes #674.

## Bug

`injectAutoContextFile` (`internal/session/setup_context.go`) writes the COI sandbox context block into the tool's auto-context file (Claude's `~/.claude/CLAUDE.md`) at session setup. When the file already existed it **appended** the block — never checking for its own prior copy. On a **persistent container reused across sessions**, `~/.claude/CLAUDE.md` survives between sessions and setup re-runs each time, so the block was appended again every session and the file grew without bound. The reporter hit **16 identical copies / 108k chars**, past Claude Code's 40k-char limit.

## Reproduction — confirmed red on CI, two layers

**1. Unit layer (Go)** — `internal/session/setup_context_autoctx_test.go` drives the real `injectAutoContextFile` across 3 sessions on one persistent home via a fake `ContainerManager`. Commit 1 (test only) was **red** on run [30611781775](https://github.com/mensfeld/code-on-incus/actions/runs/30611781775) (`Unit Tests`): `found 3 copies (18686 chars)`.

**2. End-to-end layer (Python)** — `tests/shell/persistent/claude_md_no_growth_persistent.py` drives the **real `coi` CLI**: it creates a persistent container, then re-enters the *same* container across sessions (stop + `coi shell --container <name> --background`) so setup re-runs its `~/.claude/CLAUDE.md` injection against the persisted home, and asserts one copy. Validated against pre-fix code on a scratch branch — the `shell-persistent` lane failed with:

```
tests/shell/persistent/claude_md_no_growth_persistent.py::test_claude_md_does_not_grow_across_persistent_sessions FAILED
E  AssertionError: #674: ... after 3 sessions on one persistent container,
   but found 3 copies (18416 chars). ...
E  assert 3 == 1
```
(run [30619117109](https://github.com/mensfeld/code-on-incus/actions/runs/30619117109), `shell-persistent`). The test is left in this PR, where it passes with the fix.

> The e2e test leaves the tool at its default (Claude) so the auto-context path fires — only `ClaudeTool` implements `AutoContextFile()`, so a dummy-tool session never exercises it — and uses `--background` (setup + detach) so no real `claude` binary is needed. The reuse guard (no second slot) confirms the sessions hit the same persisted container.

## Fix

The block is now delimited by `# BEGIN COI Sandbox Context …` / `# END COI Sandbox Context` markers and made **idempotent**: each session reads the file, strips any prior coi-managed block, and writes a single fresh one — **overwriting** (regenerating) the dynamic block while **preserving** any non-managed (user/host-copied) content. This matches how `~/SANDBOX_CONTEXT.md` already regenerates each session, without duplicating.

`TestInjectAutoContextFile_PreservesHostContent` locks in that user/host content is kept alongside exactly one managed block. `go build`, `go vet`, `gofmt`, `golangci-lint`, and `ruff` are clean.

**Note on already-affected files:** this stops the per-session growth going forward. A file that already accumulated many *unmarked* copies from the old code won't be retroactively de-duplicated (the old copies have no markers to identify safely); such a file stops growing and can be cleared once if it's still over the limit.