### PR TITLE
fix(installer): detect Incus init by MANAGED network, not any network (#703)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -458,8 +458,9 @@ ensure_incus_initialized() {
         return
     fi
 
-    # Check if Incus has been initialized by looking for any networks.
-    # `incus admin init` creates incusbr0; an empty list means never initialized.
+    # Check for a MANAGED network (CSV column 3), not just any network: unmanaged
+    # physical/loopback interfaces are on every real host and would otherwise
+    # make this non-empty, falsely skipping init (#703).
     # If the query itself fails (daemon down, no permissions), warn and bail out
     # rather than incorrectly triggering init.
     local networks
@@ -468,7 +469,7 @@ ensure_incus_initialized() {
         echo "  Could not query Incus networks. Ensure the Incus daemon is running and your user has access."
         return 1
     fi
-    if [ -n "$networks" ]; then
+    if printf '%s\n' "$networks" | cut -d',' -f3 | grep -q '^YES$'; then
         return
     fi
 
@@ -589,7 +590,7 @@ setup_zfs_storage() {
                 printf "${YELLOW}  %s${NC}\n" "$profile_output"
             fi
             echo -e "${YELLOW}  You can manually configure it later with:${NC}"
-            echo -e "  ${BLUE}incus profile device set default root pool=zfs-pool${NC}"
+            echo -e "  ${BLUE}incus profile device add default root disk pool=zfs-pool path=/${NC}"
         fi
     else
         echo -e "${YELLOW}⚠ ZFS storage pool creation failed${NC}"
@@ -649,7 +650,7 @@ setup_btrfs_storage() {
                 printf "${YELLOW}  %s${NC}\n" "$profile_output"
             fi
             echo -e "${YELLOW}  You can manually configure it later with:${NC}"
-            echo -e "  ${BLUE}incus profile device set default root pool=btrfs-pool${NC}"
+            echo -e "  ${BLUE}incus profile device add default root disk pool=btrfs-pool path=/${NC}"
         fi
     else
         echo -e "${YELLOW}⚠ btrfs storage pool creation failed${NC}"

--- a/install.sh
+++ b/install.sh
@@ -458,18 +458,26 @@ ensure_incus_initialized() {
         return
     fi
 
-    # Check for a MANAGED network (CSV column 3), not just any network: unmanaged
-    # physical/loopback interfaces are on every real host and would otherwise
-    # make this non-empty, falsely skipping init (#703).
-    # If the query itself fails (daemon down, no permissions), warn and bail out
-    # rather than incorrectly triggering init.
-    local networks
+    # Decide whether Incus has been initialized without being fooled by the
+    # unmanaged physical/loopback interfaces that appear on every real host: a
+    # bare "is the network list non-empty?" check is never empty and falsely
+    # skips init (#703). `incus admin init --auto` creates both a MANAGED network
+    # (incusbr0) and a storage pool, so treat either as proof of initialization -
+    # a host set up with an existing/custom network and no managed bridge still
+    # has a pool, which is the reliable signal.
+    # If the network query itself fails (daemon down, no permissions), warn and
+    # bail out rather than incorrectly triggering init.
+    local networks pools
     if ! networks="$(incus network list --format=csv 2>/dev/null)"; then
         echo -e "${YELLOW}⚠ Unable to determine whether Incus has been initialized${NC}"
         echo "  Could not query Incus networks. Ensure the Incus daemon is running and your user has access."
         return 1
     fi
-    if printf '%s\n' "$networks" | cut -d',' -f3 | grep -q '^YES$'; then
+    pools="$(incus storage list --format=csv 2>/dev/null)"
+    # MANAGED is CSV column 3 (YES/NO); awk avoids the cut|grep -q pipe whose
+    # early exit trips `set -o pipefail`.
+    if printf '%s\n' "$networks" | awk -F, '$3 == "YES" { found=1 } END { exit !found }' \
+        || [ -n "$pools" ]; then
         return
     fi
 

--- a/internal/installer/install_sh_test.go
+++ b/internal/installer/install_sh_test.go
@@ -206,8 +206,9 @@ func TestInstallSh_EnsureIncusInitialized_SkipsWhenAlreadyInitialized(t *testing
 
 	script := installShPath(t)
 
-	// Stub incus: when called with "network list", return a fake network line.
-	// This simulates an already-initialized Incus without needing a real one.
+	// Stub incus: when called with "network list", return a fake MANAGED network
+	// line (column 3 = YES). This simulates an already-initialized Incus without
+	// needing a real one.
 	snippet := `
 		tmpdir=$(mktemp -d)
 		trap "rm -rf $tmpdir" EXIT
@@ -215,7 +216,7 @@ func TestInstallSh_EnsureIncusInitialized_SkipsWhenAlreadyInitialized(t *testing
 		cat > "$tmpdir/incus" <<'STUB'
 #!/bin/bash
 if [[ "$*" == *"network list"* ]]; then
-	echo "incusbr0,bridge,,"
+	echo "incusbr0,bridge,YES,10.87.0.1/24,,,3,RUNNING"
 	exit 0
 fi
 exit 0
@@ -302,6 +303,66 @@ STUB
 	// Verify sudo was called with the right command
 	if !strings.Contains(stdout, "INIT_WAS_CALLED") {
 		t.Errorf("expected sudo incus admin init --auto to be called; stdout: %s", stdout)
+	}
+}
+
+// #703: on a real host, `incus network list` is never empty even before
+// `incus admin init` has run, because it also lists unmanaged physical and
+// loopback interfaces. ensure_incus_initialized must still run
+// `sudo incus admin init --auto` in that case rather than treating a
+// non-empty-but-all-unmanaged list as "already initialized".
+func TestInstallSh_EnsureIncusInitialized_RunsInitWhenOnlyUnmanagedNetworksExist(t *testing.T) {
+	script := installShPath(t)
+
+	// Stub incus network list with the exact CSV shape reported in #703: a
+	// physical NIC and loopback, both unmanaged (column 3, MANAGED, is NO).
+	snippet := `
+		tmpdir=$(mktemp -d)
+		trap "rm -rf $tmpdir" EXIT
+
+		cat > "$tmpdir/incus" <<'STUB'
+#!/bin/bash
+if [[ "$*" == *"network list"* ]]; then
+	printf 'enp7s0,physical,NO,,,,0,\n'
+	printf 'lo,loopback,NO,,,,0,\n'
+	exit 0
+fi
+exit 0
+STUB
+		chmod +x "$tmpdir/incus"
+
+		export COI_TEST_MARKER="$tmpdir/init_called"
+		cat > "$tmpdir/sudo" <<'STUB'
+#!/bin/bash
+if [[ "$*" == *"incus admin init --auto"* ]]; then
+	touch "$COI_TEST_MARKER"
+	exit 0
+fi
+exec /usr/bin/sudo "$@"
+STUB
+		chmod +x "$tmpdir/sudo"
+		export PATH="$tmpdir:$PATH"
+
+		export NONINTERACTIVE=1
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		ensure_incus_initialized
+		if [ -f "$COI_TEST_MARKER" ]; then
+			echo "INIT_WAS_CALLED"
+		fi
+		echo "COMPLETED"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "NONINTERACTIVE=1")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stdout: %s", exitCode, stdout)
+	}
+	if !strings.Contains(stdout, "COMPLETED") {
+		t.Errorf("function did not complete; stdout: %s", stdout)
+	}
+	if !strings.Contains(stdout, "has not been initialized") {
+		t.Errorf("expected 'has not been initialized' message when only unmanaged networks exist, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "INIT_WAS_CALLED") {
+		t.Errorf("expected sudo incus admin init --auto to be called when only unmanaged networks exist (#703); stdout: %s", stdout)
 	}
 }
 

--- a/internal/installer/install_sh_test.go
+++ b/internal/installer/install_sh_test.go
@@ -366,6 +366,71 @@ STUB
 	}
 }
 
+// A host can be initialized with an existing/custom network and no managed
+// bridge, so the network list holds only unmanaged interfaces. `incus admin
+// init --auto` always creates a storage pool too, so a non-empty storage list
+// must count as "already initialized" and skip re-running init - otherwise the
+// installer prints a false "not initialized" warning and fires a doomed
+// `sudo incus admin init --auto` (which refuses on a configured host).
+func TestInstallSh_EnsureIncusInitialized_SkipsWhenOnlyStoragePoolExists(t *testing.T) {
+	script := installShPath(t)
+
+	// incus network list returns only unmanaged interfaces (MANAGED=NO), but
+	// storage list returns a pool - the reliable signal of prior init.
+	snippet := `
+		tmpdir=$(mktemp -d)
+		trap "rm -rf $tmpdir" EXIT
+
+		cat > "$tmpdir/incus" <<'STUB'
+#!/bin/bash
+if [[ "$*" == *"network list"* ]]; then
+	printf 'enp7s0,physical,NO,,,,0,\n'
+	printf 'lo,loopback,NO,,,,0,\n'
+	exit 0
+fi
+if [[ "$*" == *"storage list"* ]]; then
+	echo "default,zfs,,,3,CREATED"
+	exit 0
+fi
+exit 0
+STUB
+		chmod +x "$tmpdir/incus"
+
+		export COI_TEST_MARKER="$tmpdir/init_called"
+		cat > "$tmpdir/sudo" <<'STUB'
+#!/bin/bash
+if [[ "$*" == *"incus admin init --auto"* ]]; then
+	touch "$COI_TEST_MARKER"
+	exit 0
+fi
+exec /usr/bin/sudo "$@"
+STUB
+		chmod +x "$tmpdir/sudo"
+		export PATH="$tmpdir:$PATH"
+
+		export NONINTERACTIVE=1
+		source <(sed '/^main "\$@"/d; /^trap error_handler ERR/d' "` + script + `")
+		ensure_incus_initialized
+		if [ -f "$COI_TEST_MARKER" ]; then
+			echo "INIT_WAS_CALLED"
+		fi
+		echo "COMPLETED"
+	`
+	stdout, _, exitCode := runBashSnippet(t, snippet, "NONINTERACTIVE=1")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stdout: %s", exitCode, stdout)
+	}
+	if !strings.Contains(stdout, "COMPLETED") {
+		t.Errorf("function did not complete; stdout: %s", stdout)
+	}
+	if strings.Contains(stdout, "has not been initialized") {
+		t.Errorf("should skip init when a storage pool exists, got: %s", stdout)
+	}
+	if strings.Contains(stdout, "INIT_WAS_CALLED") {
+		t.Errorf("must not run sudo incus admin init --auto when a storage pool already exists; stdout: %s", stdout)
+	}
+}
+
 // When `sudo incus admin init --auto` fails, ensure_incus_initialized should
 // print a warning with the error output and return non-zero.
 func TestInstallSh_EnsureIncusInitialized_HandlesInitFailure(t *testing.T) {

--- a/internal/session/remount_test.go
+++ b/internal/session/remount_test.go
@@ -35,7 +35,9 @@ func (f *fakeRemounter) MountDisk(name, source, path string, shift, readonly boo
 	}
 	return f.mountErr
 }
+
 func (f *fakeRemounter) AddProxyDevice(name, connect, listen string, uid, gid int) error { return nil }
+
 func (f *fakeRemounter) AddHostPortDevice(name, listenAddr string, hostPort, containerPort int) error {
 	return nil
 }

--- a/tests/meta/test_incus_init_detection.py
+++ b/tests/meta/test_incus_init_detection.py
@@ -149,7 +149,9 @@ def incus_init_container():
         # Push the real install.sh and the harness alongside it.
         push = subprocess.run(
             ["incus", "file", "push", INSTALL_SH, f"{name}/root/install.sh"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         assert push.returncode == 0, f"failed to push install.sh: {push.stderr}"
 
@@ -159,7 +161,9 @@ def incus_init_container():
         try:
             push = subprocess.run(
                 ["incus", "file", "push", harness_path, f"{name}/root/harness.sh"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert push.returncode == 0, f"failed to push harness.sh: {push.stderr}"
         finally:
@@ -191,12 +195,8 @@ def test_ensure_incus_initialized_against_real_daemon(incus_init_container):
         "fresh Incus network list was empty; expected unmanaged host interfaces. "
         "Premise of #703 no longer holds on this image."
     )
-    managed_rows = [
-        ln for ln in nets.stdout.splitlines() if ln.split(",")[2:3] == ["YES"]
-    ]
-    assert managed_rows == [], (
-        f"fresh daemon unexpectedly has a MANAGED network: {managed_rows!r}"
-    )
+    managed_rows = [ln for ln in nets.stdout.splitlines() if ln.split(",")[2:3] == ["YES"]]
+    assert managed_rows == [], f"fresh daemon unexpectedly has a MANAGED network: {managed_rows!r}"
 
     # --- Phase A: fresh daemon -> must DECIDE to init --------------------------
     out = _run_harness(container)

--- a/tests/meta/test_incus_init_detection.py
+++ b/tests/meta/test_incus_init_detection.py
@@ -1,0 +1,259 @@
+"""
+Meta test for install.sh's ensure_incus_initialized() against a REAL Incus
+daemon (#703).
+
+Context: the stubbed Go tests in internal/installer/install_sh_test.go drive
+ensure_incus_initialized with a fake `incus` binary, so they can only assert
+what we *assume* real `incus` output looks like. #703 was exactly a wrong
+assumption about that output: the function treated any non-empty
+`incus network list` as "already initialized", but on a real host that list is
+never empty (unmanaged physical/loopback interfaces), so init was skipped on
+fresh installs and the default profile was left deviceless.
+
+This test closes that gap by running the ACTUAL install.sh logic against a
+genuine, freshly-installed-but-not-`admin init`'d Incus daemon inside a nested
+container. It validates the three real-world facts the Go stubs cannot:
+
+  1. A fresh daemon's `incus network list --format=csv` is non-empty but has no
+     MANAGED=YES row  -> ensure_incus_initialized must decide to run init.
+  2. A real storage pool makes `incus storage list --format=csv` non-empty ->
+     ensure_incus_initialized must decide to SKIP init (the mitigation added on
+     top of the #703 fix: a host with a custom network and no managed bridge is
+     still initialized, and its pool is the reliable signal).
+  3. A real MANAGED network renders column 3 of the CSV as the literal `YES` ->
+     ensure_incus_initialized must decide to SKIP init.
+
+Like tests/installer/zfs_gate_arch_e2e.sh, the privileged action is intercepted
+by a RECORDING `sudo` shim: we assert the *decision* install.sh makes (did it
+reach for `incus admin init --auto`?) driven by real `incus` reads, rather than
+actually running a nested `admin init` (whose bridge/pool creation is flaky
+under nesting). The `incus` reads themselves are 100% real.
+
+Requires a host `incus` and nested-Incus support; skips cleanly otherwise.
+"""
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+INSTALL_SH = os.path.join(REPO_ROOT, "install.sh")
+
+# Drops a recording `sudo` shim ahead of the real PATH (so real `incus` still
+# resolves for the reads), sources the real install.sh minus its entrypoint/ERR
+# trap, runs one detection cycle, then prints the exit code and everything the
+# shim recorded. install.sh's `incus admin init --auto` therefore never runs for
+# real -- we only observe whether the function tried to.
+HARNESS_SH = r"""#!/usr/bin/env bash
+set -uo pipefail
+shim="$(mktemp -d)"
+export SUDO_LOG="$shim/sudo.log"
+: > "$SUDO_LOG"
+cat > "$shim/sudo" <<'SHIM'
+#!/usr/bin/env bash
+echo "$*" >> "$SUDO_LOG"
+exit 0
+SHIM
+chmod +x "$shim/sudo"
+export PATH="$shim:$PATH"
+export NONINTERACTIVE=1
+# Source the real installer without its `main "$@"` entrypoint or ERR trap, the
+# same idiom the Go tests and zfs_gate_arch_e2e.sh use.
+# shellcheck disable=SC1090
+source <(sed '/^main "$@"/d; /^trap error_handler ERR/d' /root/install.sh)
+set +e  # the function returns non-zero on soft failures; we assert on output
+ensure_incus_initialized
+echo "===RC=$?==="
+echo "===SUDOLOG_BEGIN==="
+cat "$SUDO_LOG"
+echo "===SUDOLOG_END==="
+"""
+
+
+def _exec(container, command, timeout=300, check=False):
+    return subprocess.run(
+        ["incus", "exec", container, "--", "bash", "-c", command],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _sudolog(output):
+    """Extract the recorded sudo invocations from a harness run's stdout."""
+    if "===SUDOLOG_BEGIN===" not in output or "===SUDOLOG_END===" not in output:
+        return ""
+    return output.split("===SUDOLOG_BEGIN===", 1)[1].split("===SUDOLOG_END===", 1)[0]
+
+
+@pytest.fixture(scope="module")
+def incus_init_container():
+    """Nested Ubuntu container running a fresh, UN-initialized Incus daemon.
+
+    We install Incus but deliberately never run `incus admin init`, reproducing
+    the fresh-host state from #703. Skips (rather than fails) whenever the
+    environment can't provide a nested daemon -- missing host incus, no nesting
+    support, apt failures, or a daemon that won't come ready.
+    """
+    if subprocess.run(["which", "incus"], capture_output=True).returncode != 0:
+        pytest.skip("host `incus` not found; cannot launch nested test container")
+
+    name = "coi-incus-init-detection"
+    subprocess.run(["incus", "delete", name, "--force"], capture_output=True, check=False)
+
+    launch = subprocess.run(
+        ["incus", "launch", "images:ubuntu/24.04", name, "-c", "security.nesting=true"],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if launch.returncode != 0:
+        pytest.skip(f"failed to launch nested container: {launch.stderr}")
+
+    try:
+        # Wait for networking, then install Incus inside the container.
+        install = _exec(
+            name,
+            """
+            set -e
+            for i in $(seq 1 30); do
+                ping -c1 archive.ubuntu.com >/dev/null 2>&1 && break
+                sleep 1
+            done
+            for i in 1 2 3; do apt-get update -qq && break || sleep 5; done
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus
+            systemctl start incus || true
+            # Trigger socket activation and wait for the daemon to accept the API.
+            incus admin waitready --timeout=60
+            """,
+            timeout=600,
+        )
+        if install.returncode != 0:
+            pytest.skip(
+                "nested Incus daemon unavailable "
+                f"(install/waitready failed): {install.stdout}\n{install.stderr}"
+            )
+
+        # Sanity: the daemon must genuinely be un-initialized, or the whole
+        # premise is void. A fresh daemon has no storage pool yet.
+        pools = _exec(name, "incus storage list --format=csv")
+        if pools.returncode != 0 or pools.stdout.strip():
+            pytest.skip(
+                "test container's Incus is not in the expected fresh state "
+                f"(storage list: rc={pools.returncode!r} out={pools.stdout!r})"
+            )
+
+        # Push the real install.sh and the harness alongside it.
+        push = subprocess.run(
+            ["incus", "file", "push", INSTALL_SH, f"{name}/root/install.sh"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert push.returncode == 0, f"failed to push install.sh: {push.stderr}"
+
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as fh:
+            fh.write(HARNESS_SH)
+            harness_path = fh.name
+        try:
+            push = subprocess.run(
+                ["incus", "file", "push", harness_path, f"{name}/root/harness.sh"],
+                capture_output=True, text=True, timeout=30,
+            )
+            assert push.returncode == 0, f"failed to push harness.sh: {push.stderr}"
+        finally:
+            os.unlink(harness_path)
+
+        yield name
+    finally:
+        subprocess.run(["incus", "delete", name, "--force"], capture_output=True, check=False)
+
+
+def _run_harness(container):
+    result = _exec(container, "bash /root/harness.sh", timeout=120)
+    assert "===RC=" in result.stdout, (
+        f"harness did not complete.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    return result.stdout
+
+
+def test_ensure_incus_initialized_against_real_daemon(incus_init_container):
+    container = incus_init_container
+
+    # --- Premise checks against REAL incus output (the #703 root cause) --------
+    # A fresh daemon's network list is non-empty (host interfaces) but has no
+    # MANAGED=YES row. This is exactly the state that fooled the old
+    # `[ -n "$networks" ]` check.
+    nets = _exec(container, "incus network list --format=csv")
+    assert nets.returncode == 0, f"network list failed: {nets.stderr}"
+    assert nets.stdout.strip() != "", (
+        "fresh Incus network list was empty; expected unmanaged host interfaces. "
+        "Premise of #703 no longer holds on this image."
+    )
+    managed_rows = [
+        ln for ln in nets.stdout.splitlines() if ln.split(",")[2:3] == ["YES"]
+    ]
+    assert managed_rows == [], (
+        f"fresh daemon unexpectedly has a MANAGED network: {managed_rows!r}"
+    )
+
+    # --- Phase A: fresh daemon -> must DECIDE to init --------------------------
+    out = _run_harness(container)
+    assert "has not been initialized" in out, (
+        f"on a fresh daemon the installer should report it is not initialized.\n{out}"
+    )
+    assert "incus admin init --auto" in _sudolog(out), (
+        f"on a fresh daemon the installer must reach for `incus admin init --auto`.\n{out}"
+    )
+
+    # --- Phase B: a real storage pool exists -> must DECIDE to SKIP ------------
+    # Reproduces an Incus initialized with a custom/existing network and no
+    # managed bridge: zero MANAGED networks, but a pool. The mitigation on top of
+    # the #703 fix must treat the pool as proof of initialization. Uses a real
+    # `dir` pool (needs no special privileges under nesting).
+    created = _exec(container, "incus storage create coitest dir")
+    assert created.returncode == 0, f"could not create test storage pool: {created.stderr}"
+    try:
+        # Confirm the real pool CSV is what the shell check keys on.
+        pools = _exec(container, "incus storage list --format=csv")
+        assert "coitest" in pools.stdout, f"pool not listed: {pools.stdout!r}"
+
+        out = _run_harness(container)
+        assert "has not been initialized" not in out, (
+            f"with a storage pool present the installer must NOT re-init.\n{out}"
+        )
+        assert "incus admin init --auto" not in _sudolog(out), (
+            f"with a storage pool present the installer must not call admin init.\n{out}"
+        )
+    finally:
+        _exec(container, "incus storage delete coitest", check=False)
+
+    # --- Phase C: a real MANAGED network exists -> must DECIDE to SKIP ---------
+    # Best-effort: creating a managed bridge can require privileges some nested
+    # environments withhold. When it works, it validates that real Incus renders
+    # the MANAGED column as the literal `YES` the shell greps for. When it does
+    # not, the managed-network path is still covered by the Go stub tests, so we
+    # skip only this sub-assertion.
+    created = _exec(container, "incus network create coibr0")
+    if created.returncode != 0:
+        pytest.skip(
+            "could not create a managed network in this nested environment; "
+            f"MANAGED-network path left to the Go stub tests. ({created.stderr.strip()})"
+        )
+    try:
+        nets = _exec(container, "incus network list --format=csv")
+        managed = [ln for ln in nets.stdout.splitlines() if ln.startswith("coibr0,")]
+        assert managed and managed[0].split(",")[2] == "YES", (
+            f"expected coibr0 to render MANAGED=YES in real CSV, got: {managed!r}"
+        )
+
+        out = _run_harness(container)
+        assert "has not been initialized" not in out, (
+            f"with a MANAGED network present the installer must NOT re-init.\n{out}"
+        )
+        assert "incus admin init --auto" not in _sudolog(out), (
+            f"with a MANAGED network present the installer must not call admin init.\n{out}"
+        )
+    finally:
+        _exec(container, "incus network delete coibr0", check=False)

--- a/tests/meta/test_incus_init_detection.py
+++ b/tests/meta/test_incus_init_detection.py
@@ -14,8 +14,11 @@ This test closes that gap by running the ACTUAL install.sh logic against a
 genuine, freshly-installed-but-not-`admin init`'d Incus daemon inside a nested
 container. It validates the three real-world facts the Go stubs cannot:
 
-  1. A fresh daemon's `incus network list --format=csv` is non-empty but has no
-     MANAGED=YES row  -> ensure_incus_initialized must decide to run init.
+  1. A fresh daemon has no MANAGED=YES network -> ensure_incus_initialized must
+     decide to run init. (On bare metal the list is also non-empty with unmanaged
+     interfaces -- the exact #703 trigger -- but a nested daemon does not surface
+     host interfaces, so we don't require that shape here; the Go stub tests pin
+     it deterministically.)
   2. A real storage pool makes `incus storage list --format=csv` non-empty ->
      ensure_incus_initialized must decide to SKIP init (the mitigation added on
      top of the #703 fix: a host with a custom network and no managed bridge is
@@ -185,20 +188,27 @@ def _run_harness(container):
 def test_ensure_incus_initialized_against_real_daemon(incus_init_container):
     container = incus_init_container
 
-    # --- Premise checks against REAL incus output (the #703 root cause) --------
-    # A fresh daemon's network list is non-empty (host interfaces) but has no
-    # MANAGED=YES row. This is exactly the state that fooled the old
-    # `[ -n "$networks" ]` check.
+    # --- Premise check against REAL incus output -------------------------------
+    # A fresh daemon must have no MANAGED=YES network yet. On a bare-metal host
+    # its `incus network list` is additionally non-empty (unmanaged physical /
+    # loopback interfaces) -- that was the exact #703 trigger -- but a nested
+    # daemon does not surface the host's interfaces, so the list is legitimately
+    # empty here. Both shapes correctly mean "not initialized"; the unmanaged-
+    # but-non-empty shape is pinned deterministically by the Go stub test
+    # TestInstallSh_EnsureIncusInitialized_RunsInitWhenOnlyUnmanagedNetworksExist,
+    # so we only require "no managed network" and note which shape we got.
     nets = _exec(container, "incus network list --format=csv")
     assert nets.returncode == 0, f"network list failed: {nets.stderr}"
-    assert nets.stdout.strip() != "", (
-        "fresh Incus network list was empty; expected unmanaged host interfaces. "
-        "Premise of #703 no longer holds on this image."
-    )
     managed_rows = [ln for ln in nets.stdout.splitlines() if ln.split(",")[2:3] == ["YES"]]
     assert managed_rows == [], f"fresh daemon unexpectedly has a MANAGED network: {managed_rows!r}"
+    if nets.stdout.strip():
+        print("premise: fresh list carries unmanaged interfaces (the #703 shape)")
+    else:
+        print("premise: fresh list is empty (nested daemon; no host interfaces surfaced)")
 
     # --- Phase A: fresh daemon -> must DECIDE to init --------------------------
+    # No MANAGED network and no storage pool, whether the list is empty or only
+    # unmanaged interfaces -> ensure_incus_initialized must run init.
     out = _run_harness(container)
     assert "has not been initialized" in out, (
         f"on a fresh daemon the installer should report it is not initialized.\n{out}"


### PR DESCRIPTION
Root cause: `ensure_incus_initialized()` decides whether Incus has been set up by checking if `incus network list --format=csv` returns any output at all. On a real host that list always includes unmanaged physical and loopback interfaces (confirmed against Incus's own CLI source: default columns are `name,type,managed,ipv4,...`, MANAGED is `YES`/`NO`), so the list is never empty and `incus admin init --auto` is skipped even on a fresh install. The default profile is then left deviceless, and the next step's `incus profile device set default root pool=...` fails with "Device doesn't exist" - as does the manual recovery command the script prints for that failure, which used the same `set` instead of `add`.

Fix: filter the CSV on the MANAGED column (field 3) instead of on any output, and point the two recovery hints at `incus profile device add ... disk pool=... path=/` instead of `set`.

Verification:
- New Go test `TestInstallSh_EnsureIncusInitialized_RunsInitWhenOnlyUnmanagedNetworksExist`, stubbing `incus network list` with the exact CSV shape from the report (unmanaged physical NIC + loopback): fails on current master (init is skipped), passes on this branch.
- Existing `TestInstallSh_EnsureIncusInitialized_SkipsWhenAlreadyInitialized` updated to stub a genuinely managed network row, since its old stub had an empty MANAGED field and would no longer represent "already initialized" under the new check.
- Ran the full `internal/installer` package test suite in a clean Docker container (`golang:1.25`, with `libsystemd-dev` for the build): all pass except `TestInstallSh_NftAutoSetup_NonInteractive`, which also fails identically on unpatched master in the same container (it needs outbound `apt-get install nftables`, unavailable here) and is unrelated to this change.
- `go build ./...` and `go vet ./...` clean; `shellcheck install.sh` shows only the two pre-existing SC2064 warnings at lines 275/324, unchanged by this diff.
- Did not verify against a real Incus daemon; the fix and both new/updated tests are shell/CSV-parsing logic exercised through stubbed `incus`/`sudo` binaries, the same pattern the existing test suite already uses for this function.

Fixes #703
