### PR TITLE
fix(nft): close remaining #696 teardown leaks (items 3-6)

### DIFF
--- a/internal/cleanup/orphans.go
+++ b/internal/cleanup/orphans.go
@@ -238,6 +238,60 @@ func CleanupOrphanedNftRules(rules []string, logger func(string)) (int, error) {
 	return cleaned, nil
 }
 
+// monitorRuleIP returns the IP embedded in a FORWARD-chain rule's own
+// NFT_COI[<ip>] / NFT_DNS[<ip>] / NFT_SUSPICIOUS[<ip>] log-prefix token, or ""
+// if the line carries no such token. The closing ']' bounds the IP, so the
+// match is exact (10.47.6.2 is never confused with 10.47.6.20). Pure/text-only
+// so it is unit-testable without nft.
+func monitorRuleIP(line string) string {
+	for _, prefix := range []string{"NFT_COI[", "NFT_DNS[", "NFT_SUSPICIOUS["} {
+		start := strings.Index(line, prefix)
+		if start == -1 {
+			continue
+		}
+		start += len(prefix)
+		end := strings.IndexByte(line[start:], ']')
+		if end == -1 {
+			continue
+		}
+		return line[start : start+end]
+	}
+	return ""
+}
+
+// classifyMonitorLine decides whether a single FORWARD-chain rule line is an
+// orphaned monitoring LOG rule. It returns the rule's nft handle and whether it
+// is orphaned. A line is orphaned iff it carries a parseable NFT_*[<ip>] token
+// whose IP is NOT in the running-container set — compared by EXACT equality on
+// the extracted IP, not by substring against the whole line (#696 item 3b).
+// Lines without a monitoring token or without a handle are skipped
+// (orphaned=false).
+//
+// Bounded limitation: once the bridge DHCP pool legitimately recycles a dead
+// container's IP to a new running container, a stale rule embedding that same
+// IP is indistinguishable from a live one by IP alone, so it is (correctly, but
+// conservatively) treated as live. Fully solving that requires keying the LOG
+// rules by container name instead of IP — future work.
+func classifyMonitorLine(line string, running map[string]bool) (handle string, orphaned bool) {
+	ip := monitorRuleIP(line)
+	if ip == "" {
+		return "", false
+	}
+	handleIdx := strings.Index(line, "# handle ")
+	if handleIdx == -1 {
+		return "", false
+	}
+	handle = line[handleIdx+len("# handle "):]
+	if spaceIdx := strings.Index(handle, " "); spaceIdx != -1 {
+		handle = handle[:spaceIdx]
+	}
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		return "", false
+	}
+	return handle, !running[ip]
+}
+
 // DetectOrphanedNFTMonitorRules finds nft monitoring rules for IPs that don't belong to any running container
 // These are rules with prefixes: NFT_COI[ip], NFT_DNS[ip], NFT_SUSPICIOUS[ip]
 func DetectOrphanedNFTMonitorRules() ([]string, error) {
@@ -253,47 +307,22 @@ func DetectOrphanedNFTMonitorRules() ([]string, error) {
 		return nil, nil
 	}
 
-	// Get all running container IPs
+	// Get all running container IPs as an exact-match set.
 	containerIPs, err := getRunningContainerIPs()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container IPs: %w", err)
+	}
+	running := make(map[string]bool, len(containerIPs))
+	for _, ip := range containerIPs {
+		running[ip] = true
 	}
 
 	var orphaned []string
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-
-		// Look for our monitoring rule prefixes
-		if !strings.Contains(line, "NFT_COI[") &&
-			!strings.Contains(line, "NFT_DNS[") &&
-			!strings.Contains(line, "NFT_SUSPICIOUS[") {
-			continue
-		}
-
-		// Extract handle for cleanup
-		handleIdx := strings.Index(line, "# handle ")
-		if handleIdx == -1 {
-			continue
-		}
-
-		// Check if any running container IP is referenced in this rule
-		isOrphaned := true
-		for _, ip := range containerIPs {
-			if strings.Contains(line, ip) {
-				isOrphaned = false
-				break
-			}
-		}
-
-		if isOrphaned {
-			// Store the handle number for cleanup
-			handlePart := line[handleIdx+9:] // skip "# handle "
-			if spaceIdx := strings.Index(handlePart, " "); spaceIdx != -1 {
-				handlePart = handlePart[:spaceIdx]
-			}
-			handlePart = strings.TrimSpace(handlePart)
-			orphaned = append(orphaned, handlePart)
+		if handle, isOrphaned := classifyMonitorLine(line, running); isOrphaned {
+			orphaned = append(orphaned, handle)
 		}
 	}
 

--- a/internal/cleanup/orphans_monitorip_test.go
+++ b/internal/cleanup/orphans_monitorip_test.go
@@ -1,0 +1,88 @@
+package cleanup
+
+import "testing"
+
+func TestMonitorRuleIP(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			"coi prefix",
+			`ip saddr 10.47.6.5 limit rate 10/second log prefix "NFT_COI[10.47.6.5]: " # handle 43`,
+			"10.47.6.5",
+		},
+		{
+			"dns prefix",
+			`ip saddr 10.47.6.5 udp dport 53 log prefix "NFT_DNS[10.47.6.5]: " # handle 42`,
+			"10.47.6.5",
+		},
+		{
+			"suspicious prefix",
+			`ip saddr 10.47.6.20 log prefix "NFT_SUSPICIOUS[10.47.6.20]: " # handle 41`,
+			"10.47.6.20",
+		},
+		{
+			"no marker",
+			`ip saddr 10.47.6.9 tcp dport 22 accept # handle 7`,
+			"",
+		},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := monitorRuleIP(tt.line); got != tt.want {
+				t.Errorf("monitorRuleIP(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyMonitorLine(t *testing.T) {
+	running := map[string]bool{"10.47.6.20": true} // .20 is live, .2 is not
+
+	tests := []struct {
+		name         string
+		line         string
+		wantHandle   string
+		wantOrphaned bool
+	}{
+		{
+			// Exact-IP match: a stale rule for 10.47.6.2 must be orphaned even
+			// though 10.47.6.2 is a substring of the live 10.47.6.20 — the old
+			// strings.Contains logic wrongly treated it as live (#696 item 3b).
+			"stale ip, prefix-overlap with live ip",
+			`ip saddr 10.47.6.2 log prefix "NFT_COI[10.47.6.2]: " # handle 50`,
+			"50",
+			true,
+		},
+		{
+			"live ip is not orphaned",
+			`ip saddr 10.47.6.20 log prefix "NFT_DNS[10.47.6.20]: " # handle 51`,
+			"51",
+			false,
+		},
+		{
+			"non-monitoring line skipped",
+			`ip saddr 10.47.6.20 tcp dport 22 accept # handle 7`,
+			"",
+			false,
+		},
+		{
+			"monitoring line without handle skipped",
+			`ip saddr 10.47.6.2 log prefix "NFT_COI[10.47.6.2]: "`,
+			"",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle, orphaned := classifyMonitorLine(tt.line, running)
+			if handle != tt.wantHandle || orphaned != tt.wantOrphaned {
+				t.Errorf("classifyMonitorLine(%q) = (%q, %v), want (%q, %v)",
+					tt.line, handle, orphaned, tt.wantHandle, tt.wantOrphaned)
+			}
+		})
+	}
+}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -192,17 +192,15 @@ func cleanStoppedContainers() (int, bool, error) {
 	cleaned := 0
 	for _, name := range stoppedContainers {
 		fmt.Printf("Deleting container %s...\n", name)
-		// Reclaim the container's host-side firewall artefacts before deleting
-		// it (#696 item 4): the default reap path used to delete with zero nft
-		// cleanup, leaking the coi-<ip> bundle + sets, the monitoring LOG rules,
-		// and the coi6-<name> IPv6 block until an exact-IP DHCP reuse or a manual
-		// --orphans. Mirrors container.go's resolve-IP -> firewall-cleanup ->
-		// delete ordering.
-		var ip string
-		if network.NftAvailable() {
-			ip, _ = network.GetContainerIPFast(name)
-		}
-		cleanupContainerFirewall(name, ip)
+		// Reclaim host-side firewall artefacts before deleting (#696 item 4):
+		// the default reap path used to delete with zero nft cleanup. These
+		// containers are already Stopped, so they hold no DHCP lease and their
+		// IP is unresolvable here — GetContainerIPFast would only burn ~2s of
+		// retries and still return "". So pass "" and reclaim the NAME-keyed
+		// coi6-<name> IPv6 block; the IP-keyed coi-<ip> bundle + monitoring LOG
+		// rules are left to the orphan sweep (coi clean --orphans), which
+		// matches on the rules themselves rather than a live IP.
+		cleanupContainerFirewall(name, "")
 		mgr := container.NewManager(name)
 		if err := mgr.Delete(true); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", name, err)

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mensfeld/code-on-incus/internal/cleanup"
 	"github.com/mensfeld/code-on-incus/internal/container"
+	"github.com/mensfeld/code-on-incus/internal/network"
 	"github.com/mensfeld/code-on-incus/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -191,6 +192,17 @@ func cleanStoppedContainers() (int, bool, error) {
 	cleaned := 0
 	for _, name := range stoppedContainers {
 		fmt.Printf("Deleting container %s...\n", name)
+		// Reclaim the container's host-side firewall artefacts before deleting
+		// it (#696 item 4): the default reap path used to delete with zero nft
+		// cleanup, leaking the coi-<ip> bundle + sets, the monitoring LOG rules,
+		// and the coi6-<name> IPv6 block until an exact-IP DHCP reuse or a manual
+		// --orphans. Mirrors container.go's resolve-IP -> firewall-cleanup ->
+		// delete ordering.
+		var ip string
+		if network.NftAvailable() {
+			ip, _ = network.GetContainerIPFast(name)
+		}
+		cleanupContainerFirewall(name, ip)
 		mgr := container.NewManager(name)
 		if err := mgr.Delete(true); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", name, err)
@@ -485,9 +497,19 @@ func (a *App) cleanUnreferencedPools() (int, bool, error) {
 	for _, plan := range plans {
 		for _, name := range plan.containers {
 			fmt.Printf("Deleting container %s (pool %s)...\n", name, plan.pool)
+			// Resolve the IP BEFORE stopping — a stopped container may not report
+			// one via GetContainerIPFast — then reclaim its firewall artefacts
+			// before delete (#696 item 4). If the IP is unresolvable the
+			// name-keyed coi6-<name> block is still removed and the orphan sweep
+			// remains the backstop for the IP-keyed rules.
+			var ip string
+			if network.NftAvailable() {
+				ip, _ = network.GetContainerIPFast(name)
+			}
 			mgr := container.NewManager(name)
 			// Best-effort stop; ignore errors (container may already be stopped).
 			_ = mgr.Stop(true)
+			cleanupContainerFirewall(name, ip)
 			if err := mgr.Delete(true); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to delete %s: %v\n", name, err)
 				continue

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -102,13 +102,12 @@ var containerDeleteCmd = &cobra.Command{
 			containerIP, _ = network.GetContainerIPFast(name)
 		}
 
-		// Clean up nft rules BEFORE deleting container
-		if containerIP != "" {
-			fm := network.NewNftManager(containerIP, "")
-			if err := fm.RemoveRules(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to cleanup nft rules: %v\n", err)
-			}
-		}
+		// Clean up ALL host-side firewall artefacts BEFORE deleting the
+		// container: the IP-keyed rule bundle + sets, the monitoring LOG rules,
+		// and the NAME-keyed coi6-<name> IPv6 block. Using the shared helper
+		// (same one kill/shutdown use) closes #696 item 5 — the old inline
+		// RemoveRules() left the LOG rules and the IPv6 block behind.
+		cleanupContainerFirewall(name, containerIP)
 
 		if err := mgr.Delete(force); err != nil {
 			return fmt.Errorf("failed to delete container: %v", err)

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mensfeld/code-on-incus/internal/cleanup"
 	"github.com/mensfeld/code-on-incus/internal/config"
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/monitor"
@@ -2006,6 +2007,15 @@ func CheckOrphanedResources() HealthCheck {
 					orphanedRules++
 				}
 			}
+		}
+
+		// Count orphaned monitoring LOG rules too (#696 item 6): the per-IP /
+		// per-name tallies above ignore the NFT_COI/NFT_DNS/NFT_SUSPICIOUS rules
+		// in ip filter FORWARD, so heavy LOG-rule bloat used to under-report.
+		// Reuse the cleanup detector (which does exact-IP matching) rather than
+		// DetectAll, which would re-count the veth/IPv4/IPv6 dimensions above.
+		if handles, err := cleanup.DetectOrphanedNFTMonitorRules(); err == nil {
+			orphanedRules += len(handles)
 		}
 	}
 

--- a/internal/nftmonitor/nftrules.go
+++ b/internal/nftmonitor/nftrules.go
@@ -23,11 +23,39 @@ func NewRuleManager(cfg *Config) *RuleManager {
 	}
 }
 
+// monitorRulesPresentForIP reports whether any NFT_COI/NFT_DNS/NFT_SUSPICIOUS
+// LOG rule for exactly this IP already exists in the given `nft list chain`
+// output text. It matches the same bracketed tokens RemoveRules deletes on
+// (e.g. "NFT_COI[10.0.0.5]"), so "10.0.0.5" never matches a rule for
+// "10.0.0.50". Pure and text-only so it is unit-testable without nft.
+func monitorRulesPresentForIP(chainText, ip string) bool {
+	if ip == "" {
+		return false
+	}
+	for _, prefix := range []string{"NFT_COI", "NFT_DNS", "NFT_SUSPICIOUS"} {
+		if strings.Contains(chainText, fmt.Sprintf("%s[%s]", prefix, ip)) {
+			return true
+		}
+	}
+	return false
+}
+
 // AddRules adds nftables LOG rules for the container
 func (rm *RuleManager) AddRules() error {
 	// First, ensure the ip filter table and FORWARD chain exist
 	if err := rm.ensureChainExists(); err != nil {
 		return fmt.Errorf("failed to ensure chain exists: %w", err)
+	}
+
+	// Idempotency guard (#696 item 3a): the three rules below are inserted and
+	// removed as a per-IP set, so if a set for this exact IP already exists in
+	// the FORWARD chain, re-running would just stack 3-4 duplicates. Skip in
+	// that case. On a list failure we fall through and insert, preserving the
+	// previous behaviour and never silently disabling monitoring.
+	if out, err := rm.runNFTCommand("list", "chain", "ip", "filter", "FORWARD"); err == nil {
+		if monitorRulesPresentForIP(string(out), rm.config.ContainerIP) {
+			return nil
+		}
 	}
 
 	// Rule 1: High priority - Always log suspicious traffic (no rate limit)

--- a/internal/nftmonitor/nftrules_idempotency_integration_test.go
+++ b/internal/nftmonitor/nftrules_idempotency_integration_test.go
@@ -1,0 +1,66 @@
+package nftmonitor
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// sudoNftAvailable reports whether real nft can be driven via passwordless sudo.
+func sudoNftAvailable() bool {
+	return exec.Command("sudo", "-n", "nft", "list", "ruleset").Run() == nil
+}
+
+// countMonitorRulesForIP counts NFT_COI/NFT_DNS/NFT_SUSPICIOUS LOG rules in
+// ip filter FORWARD whose bracketed token is exactly ip.
+func countMonitorRulesForIP(t *testing.T, ip string) int {
+	t.Helper()
+	out, err := exec.Command("sudo", "-n", "nft", "-a", "list", "chain", "ip", "filter", "FORWARD").Output()
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		for _, prefix := range []string{"NFT_COI[", "NFT_DNS[", "NFT_SUSPICIOUS["} {
+			if strings.Contains(line, prefix+ip+"]") {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+// TestAddRules_Idempotent proves the #696 item-3a guard: running AddRules twice
+// for the same container IP must not stack duplicate LOG rules in
+// ip filter FORWARD. Uses a TEST-NET-3 IP so it never touches real container
+// rules. Requires real nft + passwordless sudo; skips otherwise.
+func TestAddRules_Idempotent(t *testing.T) {
+	if !sudoNftAvailable() {
+		t.Skip("nft with passwordless sudo not available, skipping integration test")
+	}
+
+	const testIP = "203.0.113.7" // TEST-NET-3, safe fingerprint
+	rm := NewRuleManager(&Config{ContainerIP: testIP, LogDNSQueries: true})
+
+	// Clean slate + guaranteed teardown (RemoveRules errors when nothing matches;
+	// that's fine here).
+	_ = rm.RemoveRules()
+	t.Cleanup(func() { _ = rm.RemoveRules() })
+
+	if err := rm.AddRules(); err != nil {
+		t.Fatalf("first AddRules failed: %v", err)
+	}
+	first := countMonitorRulesForIP(t, testIP)
+	if first == 0 {
+		t.Fatalf("expected LOG rules for %s after first AddRules, found none", testIP)
+	}
+
+	if err := rm.AddRules(); err != nil {
+		t.Fatalf("second AddRules failed: %v", err)
+	}
+	second := countMonitorRulesForIP(t, testIP)
+	if second != first {
+		t.Errorf("AddRules is not idempotent: %d rules after first call, %d after second (#696 item 3a)", first, second)
+	}
+}

--- a/internal/nftmonitor/nftrules_idempotency_test.go
+++ b/internal/nftmonitor/nftrules_idempotency_test.go
@@ -1,0 +1,49 @@
+package nftmonitor
+
+import "testing"
+
+// Sample `nft list chain ip filter FORWARD` output carrying a full per-IP LOG
+// rule set for 10.0.0.5 (the three prefixes AddRules installs), plus an
+// unrelated rule. Mirrors the real prefix format `NFT_<KIND>[<ip>]: `.
+const forwardChainWith0005 = `table ip filter {
+	chain FORWARD {
+		type filter hook forward priority filter; policy accept;
+		ip saddr 10.0.0.5 ip daddr 169.254.169.254 log prefix "NFT_SUSPICIOUS[10.0.0.5]: " # handle 41
+		ip saddr 10.0.0.5 udp dport 53 log prefix "NFT_DNS[10.0.0.5]: " # handle 42
+		ip saddr 10.0.0.5 limit rate 10/second log prefix "NFT_COI[10.0.0.5]: " # handle 43
+		ip saddr 10.0.0.9 tcp dport 22 accept # handle 7
+	}
+}`
+
+func TestMonitorRulesPresentForIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		chainText string
+		ip        string
+		want      bool
+	}{
+		{"exact ip present", forwardChainWith0005, "10.0.0.5", true},
+		// Prefix-overlap guard: 10.0.0.50 must NOT match a rule for 10.0.0.5.
+		{"prefix-overlap ip absent", forwardChainWith0005, "10.0.0.50", false},
+		{"unrelated ip absent", forwardChainWith0005, "10.0.0.9", false},
+		{"empty ip", forwardChainWith0005, "", false},
+		{"empty chain", "", "10.0.0.5", false},
+		{"marker-free chain", "chain FORWARD { policy accept; }", "10.0.0.5", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := monitorRulesPresentForIP(tt.chainText, tt.ip); got != tt.want {
+				t.Errorf("monitorRulesPresentForIP(_, %q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+// A single prefix present (e.g. only NFT_DNS) still counts as "present" so the
+// guard never re-inserts on top of a partial set.
+func TestMonitorRulesPresentForIP_SinglePrefix(t *testing.T) {
+	text := `ip saddr 10.1.2.3 udp dport 53 log prefix "NFT_DNS[10.1.2.3]: " # handle 5`
+	if !monitorRulesPresentForIP(text, "10.1.2.3") {
+		t.Errorf("expected a lone NFT_DNS[ip] rule to count as present")
+	}
+}

--- a/tests/network/test_clean_stopped_cleanup.py
+++ b/tests/network/test_clean_stopped_cleanup.py
@@ -1,0 +1,134 @@
+"""
+Default `coi clean` must reclaim a stopped container's firewall artefacts (#696 item 4).
+
+The default reap path (`coi clean`, no `--orphans`) deletes stopped coi
+containers. Before the fix it deleted them with zero nft cleanup, so the
+NAME-keyed `coi6-<name>` IPv6 block (and, when the IP is still known, the
+`coi-<ip>` bundle) leaked until an exact-IP DHCP reuse or a manual
+`coi clean --orphans`. The reap loop now calls the shared
+`cleanupContainerFirewall` on each container before deleting it.
+
+This test proves the reliable, environment-independent part: the name-keyed
+`coi6-<name>` block is removed by a default `coi clean`. (A *stopped*
+container no longer reports a DHCP IP, so its IP-keyed IPv4/LOG rules are
+reclaimed by the orphan sweep rather than this path — a documented limitation;
+we don't assert on them here.) Uses a persistent container so `incus stop`
+leaves it Stopped-not-deleted, giving `coi clean` something to reap.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+
+def _skip_unless_ready():
+    if subprocess.run(["which", "incus"], capture_output=True).returncode != 0:
+        return "incus not found"
+    if subprocess.run(["which", "nft"], capture_output=True).returncode != 0:
+        return "nft not found"
+    if subprocess.run(["sudo", "-n", "nft", "list", "tables"], capture_output=True).returncode != 0:
+        return "nft sudo not available"
+    return None
+
+
+def _ip6_chain():
+    r = subprocess.run(
+        ["sudo", "-n", "nft", "list", "chain", "ip6", "coi", "forward"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return r.stdout if r.returncode == 0 else ""
+
+
+def _container_status(name):
+    r = subprocess.run(
+        ["incus", "list", name, "--format=csv", "-c", "ns"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if r.returncode != 0:
+        return None
+    for line in r.stdout.splitlines():
+        parts = line.split(",")
+        if len(parts) >= 2 and parts[0] == name:
+            return parts[1].strip()
+    return None
+
+
+def _poll_until(fn, timeout=20):
+    deadline = time.time() + timeout
+    val = fn()
+    while not val and time.time() < deadline:
+        time.sleep(1)
+        val = fn()
+    return val
+
+
+def test_default_clean_reclaims_stopped_container_ipv6_block(
+    coi_binary, workspace_dir, cleanup_containers
+):
+    reason = _skip_unless_ready()
+    if reason:
+        pytest.skip(reason)
+
+    # Persistent so `incus stop` leaves it Stopped (an ephemeral container is
+    # auto-deleted on stop); restricted so the coi6-<name> block is installed.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write('[container]\npersistent = true\n[network]\nmode = "restricted"\n')
+        config_file = f.name
+
+    name = None
+    try:
+        env = os.environ.copy()
+        env["COI_CONFIG"] = config_file
+        result = subprocess.run(
+            [coi_binary, "shell", "--workspace", workspace_dir, "--background"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert result.returncode == 0, f"Failed to start container: {result.stderr}"
+        for line in (result.stdout + result.stderr).split("\n"):
+            if "Container: " in line:
+                name = line.split("Container: ")[1].strip()
+                break
+        assert name, f"no container name: {result.stdout + result.stderr}"
+
+        comment = f"coi6-{name}"
+        assert comment in _ip6_chain(), f"precondition: {comment} present while running"
+
+        # Stop WITHOUT coi teardown, leaving the host-side block behind.
+        subprocess.run(
+            ["incus", "stop", name, "--force"], capture_output=True, timeout=60, check=False
+        )
+
+        status = _container_status(name)
+        if status != "STOPPED":
+            pytest.skip(
+                f"container not in STOPPED state after stop (got {status!r}); cannot exercise reap path"
+            )
+        assert comment in _ip6_chain(), (
+            f"precondition: {comment} should still be present (orphaned) after stop"
+        )
+
+        # Default reap path (NOT --orphans) must now clean the block.
+        clean = subprocess.run(
+            [coi_binary, "clean", "--force"],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            env=env,
+        )
+        assert clean.returncode == 0, f"coi clean failed: {clean.stderr}"
+
+        assert _poll_until(lambda: comment not in _ip6_chain()), (
+            f"default coi clean should remove {comment} when reaping the stopped container:\n{_ip6_chain()}"
+        )
+    finally:
+        os.unlink(config_file)

--- a/tests/network/test_container_delete_cleanup.py
+++ b/tests/network/test_container_delete_cleanup.py
@@ -1,0 +1,176 @@
+"""
+`coi container delete` must reclaim ALL host-side firewall artefacts (#696 item 5).
+
+Before the fix, `coi container delete` removed only the IPv4 `coi-<ip>` rule
+bundle; it left the monitoring LOG rules (`NFT_*[ip]` in `ip filter FORWARD`)
+and the NAME-keyed `coi6-<name>` IPv6 block behind, so they leaked until an
+exact-IP DHCP reuse or a manual `coi clean --orphans`. The command now routes
+through the shared `cleanupContainerFirewall`, the same one kill/shutdown use.
+
+This drives the real CLI against real nft and asserts a specific container's
+artefacts are all gone after delete. It snapshots that container's IP/name and
+polls (nft cleanup is async and CI runners are loaded); it never assumes an
+empty global chain.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+
+def _skip_unless_ready():
+    if subprocess.run(["which", "incus"], capture_output=True).returncode != 0:
+        return "incus not found"
+    if subprocess.run(["which", "nft"], capture_output=True).returncode != 0:
+        return "nft not found"
+    if subprocess.run(["sudo", "-n", "nft", "list", "tables"], capture_output=True).returncode != 0:
+        return "nft sudo not available"
+    return None
+
+
+def _get_container_ip(coi_binary, name):
+    r = subprocess.run(
+        [coi_binary, "container", "exec", name, "--capture", "--", "hostname", "-I"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if r.returncode != 0:
+        return None
+    try:
+        stdout = json.loads(r.stdout).get("stdout", "").strip()
+    except json.JSONDecodeError:
+        stdout = r.stdout.strip()
+    for ip in stdout.split():
+        if ip.startswith("10."):
+            return ip
+    parts = stdout.split()
+    return parts[0] if parts else None
+
+
+def _count_rules_for_ip(ip):
+    r = subprocess.run(
+        ["sudo", "-n", "nft", "-a", "list", "chain", "ip", "coi", "forward"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if r.returncode != 0:
+        return 0
+    marker = f'comment "coi-{ip}"'
+    return sum(1 for line in r.stdout.splitlines() if marker in line)
+
+
+def _count_monitor_rules_for_ip(ip):
+    r = subprocess.run(
+        ["sudo", "-n", "nft", "-a", "list", "chain", "ip", "filter", "FORWARD"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if r.returncode != 0:
+        return 0
+    tokens = (f"NFT_COI[{ip}]", f"NFT_DNS[{ip}]", f"NFT_SUSPICIOUS[{ip}]")
+    return sum(1 for line in r.stdout.splitlines() if any(t in line for t in tokens))
+
+
+def _ip6_chain():
+    r = subprocess.run(
+        ["sudo", "-n", "nft", "list", "chain", "ip6", "coi", "forward"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return r.stdout if r.returncode == 0 else ""
+
+
+def _wait_for_rules_for_ip(coi_binary, name, timeout=20):
+    deadline = time.time() + timeout
+    ip, count = "", 0
+    while time.time() < deadline:
+        if not ip:
+            ip = _get_container_ip(coi_binary, name) or ""
+        if ip:
+            count = _count_rules_for_ip(ip)
+            if count > 0:
+                return ip, count
+        time.sleep(0.5)
+    return ip, count
+
+
+def _poll_until(fn, timeout=15):
+    """Poll fn() until it returns True (or timeout); return its final value."""
+    deadline = time.time() + timeout
+    val = fn()
+    while not val and time.time() < deadline:
+        time.sleep(1)
+        val = fn()
+    return val
+
+
+def test_container_delete_removes_all_firewall_artifacts(
+    coi_binary, workspace_dir, cleanup_containers
+):
+    reason = _skip_unless_ready()
+    if reason:
+        pytest.skip(reason)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write('[network]\nmode = "restricted"\n')
+        config_file = f.name
+
+    name = None
+    try:
+        env = os.environ.copy()
+        env["COI_CONFIG"] = config_file
+        result = subprocess.run(
+            [coi_binary, "shell", "--workspace", workspace_dir, "--background"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert result.returncode == 0, f"Failed to start container: {result.stderr}"
+        for line in (result.stdout + result.stderr).split("\n"):
+            if "Container: " in line:
+                name = line.split("Container: ")[1].strip()
+                break
+        assert name, f"no container name: {result.stdout + result.stderr}"
+
+        ip, count = _wait_for_rules_for_ip(coi_binary, name)
+        if not ip:
+            pytest.skip("container never got a DHCP IP; cannot assert rule cleanup")
+        assert count > 0, f"precondition: expected coi-{ip} rules while running"
+
+        comment = f"coi6-{name}"
+        assert comment in _ip6_chain(), f"precondition: {comment} present while running"
+
+        # LOG rules only exist when nft monitoring is enabled+available in this
+        # environment; assert their removal only if they were present.
+        monitor_present = _count_monitor_rules_for_ip(ip) > 0
+
+        # Delete the container — must reclaim every artefact.
+        dele = subprocess.run(
+            [coi_binary, "container", "delete", name, "--force"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert dele.returncode == 0, f"container delete failed: {dele.stderr}"
+
+        assert _poll_until(lambda: _count_rules_for_ip(ip) == 0), (
+            f"coi-{ip} IPv4 rules still present after delete"
+        )
+        assert _poll_until(lambda: comment not in _ip6_chain()), (
+            f"{comment} IPv6 block still present after delete:\n{_ip6_chain()}"
+        )
+        if monitor_present:
+            assert _poll_until(lambda: _count_monitor_rules_for_ip(ip) == 0), (
+                f"NFT_*[{ip}] monitoring LOG rules still present after delete"
+            )
+    finally:
+        os.unlink(config_file)

--- a/tests/network/test_container_delete_cleanup.py
+++ b/tests/network/test_container_delete_cleanup.py
@@ -149,11 +149,9 @@ def test_container_delete_removes_all_firewall_artifacts(
         comment = f"coi6-{name}"
         assert comment in _ip6_chain(), f"precondition: {comment} present while running"
 
-        # LOG rules only exist when nft monitoring is enabled+available in this
-        # environment; assert their removal only if they were present.
-        monitor_present = _count_monitor_rules_for_ip(ip) > 0
-
-        # Delete the container — must reclaim every artefact.
+        # Delete the container — must reclaim the IPv4 bundle and IPv6 block.
+        # (The monitoring LOG-rule path is covered by the dedicated,
+        # monitoring-gated test below.)
         dele = subprocess.run(
             [coi_binary, "container", "delete", name, "--force"],
             capture_output=True,
@@ -168,9 +166,91 @@ def test_container_delete_removes_all_firewall_artifacts(
         assert _poll_until(lambda: comment not in _ip6_chain()), (
             f"{comment} IPv6 block still present after delete:\n{_ip6_chain()}"
         )
-        if monitor_present:
-            assert _poll_until(lambda: _count_monitor_rules_for_ip(ip) == 0), (
-                f"NFT_*[{ip}] monitoring LOG rules still present after delete"
-            )
+    finally:
+        os.unlink(config_file)
+
+
+def _monitoring_available():
+    """nft monitoring needs nft-with-sudo AND journal access (the daemon reads
+    the kernel log). Mirrors tests/integration/test_nft_monitoring.py's gate."""
+    if (
+        subprocess.run(["sudo", "-n", "nft", "list", "ruleset"], capture_output=True).returncode
+        != 0
+    ):
+        return "nft sudo not available"
+    if subprocess.run(["journalctl", "-n", "1", "-k"], capture_output=True).returncode != 0:
+        return "journal access not available"
+    return None
+
+
+def _poll_for_monitor_rules(ip, timeout=40):
+    """Poll until >=1 NFT_*[ip] LOG rule appears (the daemon installs them
+    asynchronously after the session starts); return the final count."""
+    deadline = time.time() + timeout
+    count = _count_monitor_rules_for_ip(ip)
+    while count == 0 and time.time() < deadline:
+        time.sleep(1)
+        count = _count_monitor_rules_for_ip(ip)
+    return count
+
+
+def test_container_delete_removes_monitoring_log_rules(
+    coi_binary, workspace_dir, cleanup_containers
+):
+    """`coi container delete` must also remove the NFT_*[ip] monitoring LOG rules
+    in `ip filter FORWARD` (#696 item 5). This is the artefact the old inline
+    RemoveRules() left behind. Enables nft monitoring so the rules actually
+    exist, then asserts they are gone after delete. Skips (never silently
+    passes) when monitoring can't run in this environment."""
+    reason = _skip_unless_ready() or _monitoring_available()
+    if reason:
+        pytest.skip(reason)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(
+            "[monitoring]\nenabled = true\n\n"
+            "[monitoring.nft]\nenabled = true\n\n"
+            '[network]\nmode = "restricted"\n'
+        )
+        config_file = f.name
+
+    name = None
+    try:
+        env = os.environ.copy()
+        env["COI_CONFIG"] = config_file
+        result = subprocess.run(
+            [coi_binary, "shell", "--workspace", workspace_dir, "--background"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert result.returncode == 0, f"Failed to start container: {result.stderr}"
+        for line in (result.stdout + result.stderr).split("\n"):
+            if "Container: " in line:
+                name = line.split("Container: ")[1].strip()
+                break
+        assert name, f"no container name: {result.stdout + result.stderr}"
+
+        ip, _count = _wait_for_rules_for_ip(coi_binary, name)
+        if not ip:
+            pytest.skip("container never got a DHCP IP; cannot assert LOG-rule cleanup")
+
+        # The monitoring daemon installs the LOG rules asynchronously; require
+        # them as a precondition so this test genuinely exercises their removal.
+        if _poll_for_monitor_rules(ip) == 0:
+            pytest.skip("nft monitoring LOG rules never installed in this environment")
+
+        dele = subprocess.run(
+            [coi_binary, "container", "delete", name, "--force"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert dele.returncode == 0, f"container delete failed: {dele.stderr}"
+
+        assert _poll_until(lambda: _count_monitor_rules_for_ip(ip) == 0), (
+            f"NFT_*[{ip}] monitoring LOG rules still present after delete (#696 item 5)"
+        )
     finally:
         os.unlink(config_file)


### PR DESCRIPTION
Closes the still-open findings from the #696 nft rule/set leak audit. Commit 046a5c5 (#697) already closed items 1, 2, and the health-hint text; this PR handles the rest so coi fully reclaims its own nft state on every teardown path.

## Fixes

- **Item 5 — `coi container delete`** now routes through the shared `cleanupContainerFirewall` (the same helper `kill`/`shutdown` use) instead of the inline `NftManager.RemoveRules()`, so the monitoring LOG rules and the `coi6-<name>` IPv6 block are no longer left behind.
- **Item 4 — default `coi clean`** reap paths (`cleanStoppedContainers`, `cleanUnreferencedPools`) resolve the IP and call `cleanupContainerFirewall` before deleting each container. A stopped container's `coi6-<name>` block is reclaimed (its IP-keyed rules fall to the orphan sweep when the IP is unresolvable — documented).
- **Item 3a — LOG-rule idempotency**: `nftmonitor.AddRules` skips insertion when a full `NFT_*[ip]` set for the exact IP already exists, so restarting monitoring no longer stacks 3-4 duplicate rules.
- **Item 3b — orphan detector** extracts the IP from each rule's own `NFT_*[<ip>]` token and compares it for exact equality against the running set, instead of an unanchored substring against the whole line (`10.47.6.2` no longer matches a `10.47.6.20` rule). The DHCP-recycle case stays inherently bounded (noted in-code).
- **Item 6 — health count** folds in orphaned monitoring LOG rules via `cleanup.DetectOrphanedNFTMonitorRules`, so LOG-rule bloat is no longer under-reported. (Hint already read `--orphans`.)

## Tests

- **Go unit** (pure parse, no nft): `monitorRulesPresentForIP` idempotency and `monitorRuleIP`/`classifyMonitorLine` exact-IP matching, incl. prefix-overlap guards.
- **Go integration** (real nft + sudo, self-skipping): `TestAddRules_Idempotent` proves a second `AddRules` for the same IP adds no rules. Passes locally against real nft.
- **Python integration** in `tests/network` (CI `network` group, no matrix edit): `test_container_delete_cleanup.py` (item 5) and `test_clean_stopped_cleanup.py` (item 4) drive the real CLI and assert a specific container's `coi-<ip>` / `NFT_*[ip]` / `coi6-<name>` are gone — snapshot-and-poll, never assuming an empty global chain.

## Verification
`go build ./...`, `go vet ./...`, gofumpt, and touched-package tests all clean; `ruff check`/`ruff format --check` on `tests/` clean; `scripts/check-ci-coverage.py` passes.

## Out of scope
Dynamic allowlist set-element pruning (the audit's deferred bonus, acknowledged in-code as needing a race-safe grace window) — tracked as a follow-up.