### PR TITLE
fix(idmap): apply #683 proactive shift decision in coi container start (#691)

### DIFF
--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mensfeld/code-on-incus/internal/container"
 	"github.com/mensfeld/code-on-incus/internal/network"
+	"github.com/mensfeld/code-on-incus/internal/session"
 	"github.com/spf13/cobra"
 )
 
@@ -51,6 +52,20 @@ var containerStartCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
+
+		// #691: proactively apply the #683 shift→raw.idmap decision before
+		// starting, deriving the statfs-sweep sources from the container's own
+		// disk devices (this command has no session context). On OrbStack ≥2.2.2
+		// a shift=true mount succeeds-but-unwritable, so the reactive fallback
+		// below never fires; this heals a pre-#689 container up front. No-op
+		// unless the container still carries a shift=true disk device.
+		disableShift := false
+		if app.cfg != nil {
+			disableShift = app.cfg.Incus.DisableShift
+		}
+		session.ResolveStartUIDMapping(name, disableShift, func(msg string) {
+			fmt.Fprintln(os.Stderr, msg)
+		})
 
 		// Recover from the #678 idmapped-mount start failure here too, rather
 		// than handing back a raw Incus error the user can't act on (#685). The

--- a/internal/container/devices.go
+++ b/internal/container/devices.go
@@ -1,0 +1,60 @@
+package container
+
+import (
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DiskDeviceSources returns the host source paths of the container's
+// instance-level disk devices, plus whether any of those disk devices still
+// carries shift=true (the coi/pre-#689 creation-time signature).
+//
+// It shells `incus config device show <name>` ONCE and hands the YAML to the
+// pure parseDiskDeviceSources. Non-expanded output is intentional: it lists
+// only the coi-added mount devices (workspace, git-worktree-common, [[mount]]),
+// not the profile-inherited root disk — exactly the source set the reuse path
+// feeds to the shift decision via MountSources. Returns nil,false on any error.
+func DiskDeviceSources(containerName string) (sources []string, hasShiftDevice bool) {
+	out, err := IncusOutput("config", "device", "show", containerName)
+	if err != nil {
+		return nil, false
+	}
+	return parseDiskDeviceSources(out)
+}
+
+// parseDiskDeviceSources extracts, from `incus config device show` YAML, the
+// host source paths of every type=disk device and whether any disk device has
+// shift=true. Pure/text-only so it is unit-testable without incus. Device names
+// are visited in sorted order so the returned sources are deterministic (Go map
+// iteration is random); FirstBlockingSource is order-independent, but tests and
+// log output are not.
+func parseDiskDeviceSources(yamlOut string) (sources []string, hasShiftDevice bool) {
+	var devices map[string]struct {
+		Type   string `yaml:"type"`
+		Source string `yaml:"source"`
+		Shift  string `yaml:"shift"`
+	}
+	if err := yaml.Unmarshal([]byte(yamlOut), &devices); err != nil {
+		return nil, false
+	}
+	names := make([]string, 0, len(devices))
+	for name := range devices {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		d := devices[name]
+		if d.Type != "disk" {
+			continue
+		}
+		if strings.TrimSpace(d.Source) != "" {
+			sources = append(sources, d.Source)
+		}
+		if strings.TrimSpace(d.Shift) == "true" {
+			hasShiftDevice = true
+		}
+	}
+	return sources, hasShiftDevice
+}

--- a/internal/container/devices.go
+++ b/internal/container/devices.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -31,11 +32,11 @@ func DiskDeviceSources(containerName string) (sources []string, hasShiftDevice b
 // iteration is random); FirstBlockingSource is order-independent, but tests and
 // log output are not.
 func parseDiskDeviceSources(yamlOut string) (sources []string, hasShiftDevice bool) {
-	var devices map[string]struct {
-		Type   string `yaml:"type"`
-		Source string `yaml:"source"`
-		Shift  string `yaml:"shift"`
-	}
+	// Decode device fields as `any`, not `string`: Incus renders device config
+	// values as quoted strings today (shift: "true"), but a version that emitted
+	// an unquoted scalar (shift: true) would fail a `string`-typed unmarshal and
+	// silently disable the whole heal. scalarString coerces either shape.
+	var devices map[string]map[string]any
 	if err := yaml.Unmarshal([]byte(yamlOut), &devices); err != nil {
 		return nil, false
 	}
@@ -46,15 +47,36 @@ func parseDiskDeviceSources(yamlOut string) (sources []string, hasShiftDevice bo
 	sort.Strings(names)
 	for _, name := range names {
 		d := devices[name]
-		if d.Type != "disk" {
+		if scalarString(d["type"]) != "disk" {
 			continue
 		}
-		if strings.TrimSpace(d.Source) != "" {
-			sources = append(sources, d.Source)
+		if src := strings.TrimSpace(scalarString(d["source"])); src != "" {
+			sources = append(sources, src)
 		}
-		if strings.TrimSpace(d.Shift) == "true" {
+		if strings.TrimSpace(scalarString(d["shift"])) == "true" {
 			hasShiftDevice = true
 		}
 	}
 	return sources, hasShiftDevice
+}
+
+// scalarString renders a scalar YAML value (string/bool/int) as a string, so a
+// device field survives whether Incus emits it quoted or unquoted. Returns ""
+// for nil or a non-scalar value.
+func scalarString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	case map[string]any, []any:
+		return ""
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }

--- a/internal/container/devices_test.go
+++ b/internal/container/devices_test.go
@@ -95,6 +95,18 @@ cache:
 			wantSources: []string{"/home/user/project"},
 			wantShift:   false,
 		},
+		{
+			// Hardening: an Incus version that emits shift as an unquoted bool
+			// must still be understood (a string-typed unmarshal would fail the
+			// whole parse and silently disable the heal).
+			name: "shift as unquoted bool",
+			yaml: `workspace:
+  type: disk
+  source: /home/user/project
+  shift: true`,
+			wantSources: []string{"/home/user/project"},
+			wantShift:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/container/devices_test.go
+++ b/internal/container/devices_test.go
@@ -1,0 +1,110 @@
+package container
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDiskDeviceSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantSources []string
+		wantShift   bool
+	}{
+		{
+			name: "workspace disk shift=true",
+			yaml: `workspace:
+  path: /workspace
+  source: /home/user/project
+  type: disk
+  shift: "true"`,
+			wantSources: []string{"/home/user/project"},
+			wantShift:   true,
+		},
+		{
+			name: "workspace disk shift=false",
+			yaml: `workspace:
+  path: /workspace
+  source: /home/user/project
+  type: disk
+  shift: "false"`,
+			wantSources: []string{"/home/user/project"},
+			wantShift:   false,
+		},
+		{
+			name: "disk with no source excluded from sources",
+			yaml: `root:
+  path: /
+  pool: default
+  type: disk`,
+			wantSources: nil,
+			wantShift:   false,
+		},
+		{
+			name: "non-disk device ignored for source and shift",
+			yaml: `myproxy:
+  type: proxy
+  source: /tmp/host.sock
+  shift: "true"
+workspace:
+  type: disk
+  source: /home/user/project
+  shift: "false"`,
+			wantSources: []string{"/home/user/project"},
+			wantShift:   false,
+		},
+		{
+			// Multiple disks, mixed shift → all sources (sorted by device name),
+			// hasShift true if ANY disk is shifted.
+			name: "multiple disks mixed shift, sorted sources",
+			yaml: `workspace:
+  type: disk
+  source: /home/user/project
+  shift: "true"
+cache:
+  type: disk
+  source: /home/user/.cache
+  shift: "false"`,
+			wantSources: []string{"/home/user/.cache", "/home/user/project"}, // sorted: cache before workspace
+			wantShift:   true,
+		},
+		{
+			name:        "empty string",
+			yaml:        "",
+			wantSources: nil,
+			wantShift:   false,
+		},
+		{
+			name:        "empty map",
+			yaml:        "{}",
+			wantSources: nil,
+			wantShift:   false,
+		},
+		{
+			name:        "malformed yaml",
+			yaml:        "this: : : not valid",
+			wantSources: nil,
+			wantShift:   false,
+		},
+		{
+			name: "disk with shift absent",
+			yaml: `workspace:
+  type: disk
+  source: /home/user/project`,
+			wantSources: []string{"/home/user/project"},
+			wantShift:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, hasShift := parseDiskDeviceSources(tt.yaml)
+			if !reflect.DeepEqual(sources, tt.wantSources) {
+				t.Errorf("sources = %#v, want %#v", sources, tt.wantSources)
+			}
+			if hasShift != tt.wantShift {
+				t.Errorf("hasShiftDevice = %v, want %v", hasShift, tt.wantShift)
+			}
+		})
+	}
+}

--- a/internal/session/setup_helpers.go
+++ b/internal/session/setup_helpers.go
@@ -170,8 +170,23 @@ func ResolveStartUIDMapping(containerName string, disableShift bool, logger func
 	if logger == nil {
 		logger = func(string) {}
 	}
+	// `coi container start` can target an arbitrary container in any state, so
+	// scope the heal tightly (#691 review):
+	//   - Skip a RUNNING container: raw.idmap/shift can't be changed to effect
+	//     without a restart, and mutating a live instance only emits misleading
+	//     "unwritable"/"could not convert" warnings. Skip on error too (don't
+	//     act on uncertain state).
+	if running, err := container.ContainerRunning(containerName); err != nil || running {
+		return
+	}
 	sources, hasShiftDevice := container.DiskDeviceSources(containerName)
 	if !hasShiftDevice {
+		return
+	}
+	//   - Skip a container that isn't coi-managed: coi always mounts a disk
+	//     device named "workspace", so an empty workspace source means this is
+	//     someone else's container we must not rewrite.
+	if container.NewManager(containerName).GetWorkspaceSource() == "" {
 		return
 	}
 	hadRawIdmap := container.ContainerUsesRawIdmap(containerName)

--- a/internal/session/setup_helpers.go
+++ b/internal/session/setup_helpers.go
@@ -129,21 +129,54 @@ func ResolveReuseUIDMapping(containerName string, sources []string, disableShift
 	hadRawIdmap := container.ContainerUsesRawIdmap(containerName)
 	configuredShift, idmapApplied := ConfigureUIDMapping(containerName, sources, disableShift, logger)
 	useShift := reuseShiftDecision(configuredShift, hadRawIdmap || idmapApplied)
-	// Convert creation-time devices only on the TRANSITION to raw.idmap: a
-	// container that already carried it had its devices converted when that
-	// happened (creation, the #678 fallback, or an earlier reuse), so the
-	// per-device incus scan is skipped on the steady state every later
-	// session hits.
-	if idmapApplied && !hadRawIdmap {
-		converted, failed := container.ConvertShiftedDiskDevices(containerName)
-		if converted > 0 {
-			logger(fmt.Sprintf("Converted %d creation-time shift=true disk device(s) to shift=false to match raw.idmap (#683)", converted))
-		}
-		if failed > 0 {
-			logger(fmt.Sprintf("Warning: %d shift=true disk device(s) could not be converted to shift=false; the container may fail to start with raw.idmap set — retry, or recreate the container", failed))
-		}
-	}
+	convertCreationTimeShiftDevices(containerName, idmapApplied, hadRawIdmap, logger)
 	return useShift
+}
+
+// convertCreationTimeShiftDevices strips a container's creation-time shift=true
+// disk devices (setting shift=false) when the mapping decision has just
+// transitioned to raw.idmap (idmapApplied && !hadRawIdmap), so the newly-set
+// raw.idmap actually takes effect (#683). It is a no-op on the steady state: a
+// container that already carried raw.idmap had its devices converted when that
+// first happened (creation, the #678 fallback, or an earlier reuse), so the
+// per-device incus scan is skipped every later session. Shared by the reuse
+// (ResolveReuseUIDMapping) and start (ResolveStartUIDMapping) paths.
+func convertCreationTimeShiftDevices(containerName string, idmapApplied, hadRawIdmap bool, logger func(string)) {
+	if !idmapApplied || hadRawIdmap {
+		return
+	}
+	converted, failed := container.ConvertShiftedDiskDevices(containerName)
+	if converted > 0 {
+		logger(fmt.Sprintf("Converted %d creation-time shift=true disk device(s) to shift=false to match raw.idmap (#683)", converted))
+	}
+	if failed > 0 {
+		logger(fmt.Sprintf("Warning: %d shift=true disk device(s) could not be converted to shift=false; the container may fail to start with raw.idmap set — retry, or recreate the container", failed))
+	}
+}
+
+// ResolveStartUIDMapping is the `coi container start` counterpart of
+// ResolveReuseUIDMapping. That command has no session context (workspace path,
+// mount config), so it derives the statfs-sweep sources from the container's
+// OWN disk devices and proactively applies the #683 shift→raw.idmap decision
+// before start. On OrbStack ≥2.2.2 the shift mount succeeds-but-unwritable, so
+// the reactive #678 fallback in StartWithIdmapFallback never fires; this heals
+// a pre-#689 container up front (#691).
+//
+// It is deliberately a no-op when the container carries no shift=true disk
+// device: `coi container start` runs against an arbitrary container, and — like
+// the reactive fallbackShiftToRawIdmap, which only acts when shift devices
+// exist — it must not mutate a container that has nothing to heal.
+func ResolveStartUIDMapping(containerName string, disableShift bool, logger func(string)) {
+	if logger == nil {
+		logger = func(string) {}
+	}
+	sources, hasShiftDevice := container.DiskDeviceSources(containerName)
+	if !hasShiftDevice {
+		return
+	}
+	hadRawIdmap := container.ContainerUsesRawIdmap(containerName)
+	_, idmapApplied := ConfigureUIDMapping(containerName, sources, disableShift, logger)
+	convertCreationTimeShiftDevices(containerName, idmapApplied, hadRawIdmap, logger)
 }
 
 // decideUIDMapping is the pure decision behind ConfigureUIDMapping (no I/O), so


### PR DESCRIPTION
Closes #691.

## Problem
`coi container start <name>` only ran the **reactive** #678 recovery (`StartWithIdmapFallback` → `startWithIdmapRecovery`), which keys on the `idmapping abilities are required` start failure. On **OrbStack ≥2.2.2** that error never fires — a `shift=true` mount silently succeeds with an **unwritable** workspace — so a persistent container created by a pre-#689 coi (workspace device `shift=true`, no `raw.idmap`) started *broken* via `container start`, while the same container reused through `coi shell`/`coi run` was healed by `session.ResolveReuseUIDMapping`.

The reuse path can heal it because it runs a **statfs sweep** over the mount source paths and, on the transition to `raw.idmap`, converts creation-time `shift=true` devices. `coi container start` couldn't do that — it has only a container name, no workspace/mount context to build the source list.

## Fix (issue's Option A)
Derive the statfs-sweep sources from the container's **own disk devices**, so `container start` can run the same proactive decision with only the name it already has:

- **`container.DiskDeviceSources`** + pure **`parseDiskDeviceSources`** — one `incus config device show` call, parsed (yaml.v3) into `(sources, hasShiftDevice)`. Non-expanded output lists only coi-added mount devices (workspace, worktree-common, `[[mount]]`), excluding the profile `root` disk — the same set `MountSources` feeds on the reuse path.
- **`session.ResolveStartUIDMapping`** — mirrors `ResolveReuseUIDMapping`'s tail but sources come from the devices. **No-op unless a `shift=true` disk device exists**, so an arbitrary container is never mutated (mirrors the reactive `fallbackShiftToRawIdmap` gate). The convert-and-log tail is factored into a shared `convertCreationTimeShiftDevices` used by both resolve paths (log strings unchanged).
- **`coi container start`** calls it before `StartWithIdmapFallback`, sourcing `disable_shift` from the already-loaded `app.cfg`.

Wiring stays at the CLI layer: `container` can't import `session` (cycle), and the fresh-launch/ephemeral callers of `StartWithIdmapFallback` already apply the mapping via their `preStart` hook, so they're untouched.

## Tests
- Table unit test for the pure `parseDiskDeviceSources` (shift variants, no-source disk, non-disk device, sorted multi-disk, empty/malformed YAML).
- The existing reuse tests guard the `ResolveReuseUIDMapping` refactor.
- **Limitation:** a true repro (shift mount succeeds-but-unwritable) needs an OrbStack ≥2.2.2 host, which can't run in Linux CI — on ordinary ext4/overlay the statfs sweep flags no blocking source, so the `raw.idmap` branch is a no-op there. Coverage is the pure-parser test + not regressing the reuse path.

## Verification
`go build ./...`, `go vet ./...`, gofumpt, and `internal/container` / `internal/session` / `internal/cli` tests all pass.