### PR TITLE
feat(cli): add `coi top` for per-container/per-process resource usage (#707)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
             path: tests/meta tests/snapshot tests/image
             description: "Snapshot, image, and meta command tests"
           - name: misc-commands
-            path: tests/audit tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
-            description: "Misc commands: audit/clean/completion/docker/errors/help/info/mount/monitor/shutdown/update/version + root help files"
+            path: tests/audit tests/clean tests/completion tests/docker tests/errors tests/help tests/info tests/mount tests/monitor tests/top tests/shutdown tests/update tests/version tests/main_help_flag.py tests/main_help_shorthand.py
+            description: "Misc commands: audit/clean/completion/docker/errors/help/info/mount/monitor/top/shutdown/update/version + root help files"
           - name: misc-config
             path: tests/config tests/health tests/limits tests/schema
             description: "Config, health, limits, and schema tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- **`coi top` — per-container (and per-process) resource usage (#707)** — shows live CPU%, memory, disk I/O, and network I/O for your running containers, sorted busiest-first and resolved to each container's alias + workspace, so you can tell which container is loading your machine without mapping PIDs by hand. `coi top <name|alias>` (or `coi top --procs` across all containers) drills into per-process rows showing the **host-side PID**, so a runaway is directly `sudo kill`-able. CPU%/IO are sampled over a short `--interval` (default 2s); `--sort cpu|mem|disk|net` and `--json` are supported. Reuses the existing cgroup/`/proc` collectors from the monitor subsystem.
+
 - **Machine-readable `~/SANDBOX_CONTEXT.json` (#705)** — a structured, versioned companion to `SANDBOX_CONTEXT.md` for programmatic consumers. Toggle with `[tool] context_json`, override with `context_json_file`. Custom context files (`context_file`/`context_json_file`) are now honored only from trusted config.
 
 - **OpenAI Codex CLI is now a supported tool (#698, thanks @breml)** — `[tool] name = "codex"` launches straight into codex like the other tools, with per-tool `model`/`reasoning_effort`. Opt it into the image with `[container.build] agents = ["claude", "codex"]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- **`coi top` — per-container (and per-process) resource usage (#707)** — shows live CPU%, memory, disk I/O, and network I/O for your running containers, sorted busiest-first and resolved to each container's alias + workspace, so you can tell which container is loading your machine without mapping PIDs by hand. `coi top <name|alias>` (or `coi top --procs` across all containers) drills into per-process rows showing the **host-side PID**, so a runaway is directly `sudo kill`-able. CPU%/IO are sampled over a short `--interval` (default 2s); `--sort cpu|mem|disk|net` and `--json` are supported. Reuses the existing cgroup/`/proc` collectors from the monitor subsystem.
+- **`coi top` — per-container (and per-process) resource usage (#707)** — shows live CPU%, memory, disk I/O, and network I/O for your running containers, sorted busiest-first and resolved to each container's alias + workspace, so you can tell which container is loading your machine without mapping PIDs by hand. `coi top <name|alias>` (or `coi top --procs` across all containers) drills into per-process rows showing the **host-side PID**, so a runaway is directly `sudo kill`-able. CPU%/IO are sampled over a short `--interval` (default 2s); `--sort cpu|mem|disk|net`, `--json`, and `--watch N` (re-render every N seconds until Ctrl+C, like `coi monitor --watch`) are supported. Reuses the existing cgroup/`/proc` collectors from the monitor subsystem.
 
 - **Machine-readable `~/SANDBOX_CONTEXT.json` (#705)** — a structured, versioned companion to `SANDBOX_CONTEXT.md` for programmatic consumers. Toggle with `[tool] context_json`, override with `context_json_file`. Custom context files (`context_file`/`context_json_file`) are now honored only from trusted config.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -285,6 +285,7 @@ func init() {
 	rootCmd.AddCommand(attachCmd)
 	rootCmd.AddCommand(shutdownCmd)
 	rootCmd.AddCommand(monitorCmd)
+	rootCmd.AddCommand(topCmd)
 }
 
 var versionCmd = &cobra.Command{

--- a/internal/cli/top.go
+++ b/internal/cli/top.go
@@ -1,0 +1,617 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mensfeld/code-on-incus/internal/alias"
+	"github.com/mensfeld/code-on-incus/internal/container"
+	"github.com/mensfeld/code-on-incus/internal/monitor"
+	"github.com/mensfeld/code-on-incus/internal/session"
+	"github.com/spf13/cobra"
+)
+
+var (
+	topInterval float64
+	topSort     string
+	topProcs    bool
+	topJSON     bool
+)
+
+// userHZ is the kernel clock-tick rate assumed for converting /proc/<pid>/stat
+// utime/stime (in clock ticks) to seconds. Linux fixes USER_HZ at 100 on every
+// mainstream architecture; Go has no portable sysconf(_SC_CLK_TCK), so this is
+// the same constant ps/top-alike tools hardcode.
+const userHZ = 100.0
+
+var topCmd = &cobra.Command{
+	Use:   "top [container]",
+	Short: "Show per-container (or per-process) CPU/memory/IO usage",
+	Long: `Show live resource usage for code-on-incus containers, resolved to their
+friendly context (alias + workspace) so you can tell which container — or which
+process inside one — is loading your machine, without mapping PIDs by hand.
+
+CPU%, disk I/O, and network I/O are sampled over a short interval (--interval),
+so the command pauses briefly before printing. CPU% is aggregate across host
+cores, so a container pegging 2 cores reads ~200% (same convention as top).
+
+Views:
+  coi top                 # one row per container: CPU%, memory, disk I/O, net I/O
+  coi top <name|alias>    # one row per process inside that container
+  coi top --procs         # processes across ALL containers (adds a CONTAINER column)
+
+Process rows show the HOST-side PID, so you can kill a runaway directly with
+'sudo kill <PID>' on the host.
+
+Examples:
+  coi top                       # all containers, busiest first
+  coi top --sort mem            # sort by memory instead of CPU
+  coi top -i 5                  # sample over 5 seconds
+  coi top my-api                # processes inside the 'my-api' container
+  coi top --procs               # every container's processes, busiest first
+  coi top --json                # machine-readable output`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTop,
+}
+
+func init() {
+	topCmd.Flags().Float64VarP(&topInterval, "interval", "i", 2, "Seconds to sample CPU/IO rates over")
+	topCmd.Flags().StringVar(&topSort, "sort", "cpu", "Sort key: cpu, mem, disk, or net (containers); cpu or mem (processes)")
+	topCmd.Flags().BoolVar(&topProcs, "procs", false, "Show processes (across all containers when no container is named)")
+	topCmd.Flags().BoolVar(&topJSON, "json", false, "Output as JSON")
+}
+
+// Seams so tests can supply canned data without a live Incus/cgroup.
+var (
+	topListEntries      = listTopEntries
+	topCollectResources = monitor.CollectResourceStats
+	topCollectProcesses = monitor.CollectProcessStats
+)
+
+func runTop(cmd *cobra.Command, args []string) error {
+	if topInterval <= 0 {
+		return &ExitCodeError{Code: 2, Message: "invalid --interval: must be greater than 0"}
+	}
+	interval := time.Duration(topInterval * float64(time.Second))
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// A named container, or --procs, selects the process view; bare `coi top`
+	// is the container view.
+	if len(args) > 0 || topProcs {
+		var only string
+		if len(args) > 0 {
+			resolved, err := resolveTopContainer(args[0])
+			if err != nil {
+				return err
+			}
+			only = resolved
+		}
+		return runTopProcesses(ctx, only, interval)
+	}
+	return runTopContainers(ctx, interval)
+}
+
+// resolveTopContainer turns a container name or alias into a concrete running
+// container name, reusing the same alias resolution the other ops commands use.
+func resolveTopContainer(nameOrAlias string) (string, error) {
+	if resolved, err := alias.ResolveAliasForRunning(nameOrAlias); err == nil {
+		return resolved, nil
+	} else if !alias.IsContainerName(nameOrAlias) {
+		return "", err
+	}
+	return nameOrAlias, nil
+}
+
+// --- Container view ---------------------------------------------------------
+
+// containerTopRow is one container's sampled usage plus its friendly context.
+type containerTopRow struct {
+	Name         string  `json:"name"`
+	Alias        string  `json:"alias,omitempty"`
+	Workspace    string  `json:"workspace,omitempty"`
+	CPUPercent   float64 `json:"cpu_percent"`
+	MemMB        float64 `json:"memory_mb"`
+	MemLimitMB   float64 `json:"memory_limit_mb,omitempty"`
+	DiskReadMBs  float64 `json:"disk_read_mb_per_sec"`
+	DiskWriteMBs float64 `json:"disk_write_mb_per_sec"`
+	NetRxMBs     float64 `json:"net_rx_mb_per_sec"`
+	NetTxMBs     float64 `json:"net_tx_mb_per_sec"`
+}
+
+func runTopContainers(ctx context.Context, interval time.Duration) error {
+	rows, err := sampleContainerRows(ctx, interval)
+	if err != nil {
+		return err
+	}
+	if rows == nil {
+		if topJSON {
+			fmt.Println("[]")
+		} else {
+			fmt.Println("No running containers.")
+		}
+		return nil
+	}
+	sortContainerRows(rows, topSort)
+	if topJSON {
+		return printJSON(rows)
+	}
+	printContainerTable(rows)
+	return nil
+}
+
+// sampleContainerRows enumerates running containers, samples their usage twice
+// over interval, and returns one row per container (unsorted). It returns a nil
+// slice when there are no running containers.
+func sampleContainerRows(ctx context.Context, interval time.Duration) ([]containerTopRow, error) {
+	entries0, err := topListEntries()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+	running := make([]incusTopEntry, 0, len(entries0))
+	for _, e := range entries0 {
+		if strings.EqualFold(e.Status, "Running") {
+			running = append(running, e)
+		}
+	}
+	if len(running) == 0 {
+		return nil, nil
+	}
+
+	res0 := make(map[string]monitor.ResourceStats, len(running))
+	for _, e := range running {
+		if r, err := topCollectResources(ctx, e.Name); err == nil {
+			res0[e.Name] = r
+		}
+	}
+
+	if err := sleepCtx(ctx, interval); err != nil {
+		return nil, err
+	}
+
+	entries1, err := topListEntries()
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-sample containers: %w", err)
+	}
+	net1 := make(map[string]incusTopEntry, len(entries1))
+	for _, e := range entries1 {
+		net1[e.Name] = e
+	}
+
+	workspaces := loadContainerWorkspaces()
+	secs := interval.Seconds()
+
+	rows := make([]containerTopRow, 0, len(running))
+	for _, e := range running {
+		r1, err := topCollectResources(ctx, e.Name)
+		if err != nil {
+			// Keep the container visible with a context row rather than dropping
+			// it silently; usage columns stay zero.
+			rows = append(rows, containerTopRow{Name: e.Name, Alias: e.alias(), Workspace: workspaces[e.Name]})
+			continue
+		}
+		r0 := res0[e.Name]
+		row := containerTopRow{
+			Name:         e.Name,
+			Alias:        e.alias(),
+			Workspace:    workspaces[e.Name],
+			CPUPercent:   rate(r0.CPUTimeSeconds, r1.CPUTimeSeconds, secs) * 100,
+			MemMB:        r1.MemoryMB,
+			MemLimitMB:   r1.MemoryLimitMB,
+			DiskReadMBs:  rate(r0.IOReadMB, r1.IOReadMB, secs),
+			DiskWriteMBs: rate(r0.IOWriteMB, r1.IOWriteMB, secs),
+		}
+		rx0, tx0 := e.netBytes()
+		rx1, tx1 := net1[e.Name].netBytes()
+		row.NetRxMBs = rate(float64(rx0), float64(rx1), secs) / (1024 * 1024)
+		row.NetTxMBs = rate(float64(tx0), float64(tx1), secs) / (1024 * 1024)
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// sortContainerRows orders rows by the chosen key, busiest first, with the
+// container name as a stable tiebreaker.
+func sortContainerRows(rows []containerTopRow, key string) {
+	metric := func(r containerTopRow) float64 {
+		switch strings.ToLower(key) {
+		case "mem", "memory":
+			return r.MemMB
+		case "disk", "io":
+			return r.DiskReadMBs + r.DiskWriteMBs
+		case "net", "network":
+			return r.NetRxMBs + r.NetTxMBs
+		default: // cpu
+			return r.CPUPercent
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		mi, mj := metric(rows[i]), metric(rows[j])
+		if mi != mj {
+			return mi > mj
+		}
+		return rows[i].Name < rows[j].Name
+	})
+}
+
+func printContainerTable(rows []containerTopRow) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "CONTAINER\tALIAS\tCPU%\tMEM\tDISK R/W\tNET R/W\tWORKSPACE")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%.0f%%\t%s\t%s\t%s\t%s\n",
+			r.Name,
+			dashIfEmpty(r.Alias),
+			r.CPUPercent,
+			formatMem(r.MemMB, r.MemLimitMB),
+			formatRate(r.DiskReadMBs)+" / "+formatRate(r.DiskWriteMBs),
+			formatRate(r.NetRxMBs)+" / "+formatRate(r.NetTxMBs),
+			dashIfEmpty(collapseHome(r.Workspace)),
+		)
+	}
+	_ = w.Flush()
+}
+
+// --- Process view -----------------------------------------------------------
+
+// procTopRow is one process's sampled usage. PID is the HOST-side PID, so it is
+// directly killable from the host.
+type procTopRow struct {
+	Container  string  `json:"container"`
+	PID        int     `json:"pid"`
+	User       string  `json:"user"`
+	CPUPercent float64 `json:"cpu_percent"`
+	MemMB      float64 `json:"memory_mb"`
+	Command    string  `json:"command"`
+}
+
+func runTopProcesses(ctx context.Context, only string, interval time.Duration) error {
+	// Which containers to inspect.
+	var names []string
+	if only != "" {
+		names = []string{only}
+	} else {
+		entries, err := topListEntries()
+		if err != nil {
+			return fmt.Errorf("failed to list containers: %w", err)
+		}
+		for _, e := range entries {
+			if strings.EqualFold(e.Status, "Running") {
+				names = append(names, e.Name)
+			}
+		}
+		if len(names) == 0 {
+			if topJSON {
+				fmt.Println("[]")
+			} else {
+				fmt.Println("No running containers.")
+			}
+			return nil
+		}
+	}
+
+	// t0: record CPU jiffies for every process in each container.
+	type key struct {
+		container string
+		pid       int
+	}
+	jiffies0 := make(map[key]float64)
+	for _, name := range names {
+		if ps, err := topCollectProcesses(ctx, name); err == nil {
+			for _, p := range ps.Processes {
+				if j, ok := readProcJiffies(p.PID); ok {
+					jiffies0[key{name, p.PID}] = j
+				}
+			}
+		}
+	}
+
+	if err := sleepCtx(ctx, interval); err != nil {
+		return err
+	}
+	secs := interval.Seconds()
+
+	var rows []procTopRow
+	for _, name := range names {
+		ps, err := topCollectProcesses(ctx, name)
+		if err != nil {
+			if only != "" {
+				return fmt.Errorf("failed to read processes for %s: %w", name, err)
+			}
+			continue // best-effort across all containers
+		}
+		for _, p := range ps.Processes {
+			j1, ok := readProcJiffies(p.PID)
+			if !ok {
+				continue // process exited during sampling
+			}
+			cpu := 0.0
+			if j0, seen := jiffies0[key{name, p.PID}]; seen {
+				cpu = (j1 - j0) / userHZ / secs * 100
+				if cpu < 0 {
+					cpu = 0
+				}
+			}
+			rows = append(rows, procTopRow{
+				Container:  name,
+				PID:        p.PID,
+				User:       p.User,
+				CPUPercent: cpu,
+				MemMB:      readProcRSSMB(p.PID),
+				Command:    p.Command,
+			})
+		}
+	}
+
+	sortProcRows(rows, topSort)
+
+	if topJSON {
+		return printJSON(rows)
+	}
+	printProcessTable(rows, only == "")
+	return nil
+}
+
+func sortProcRows(rows []procTopRow, key string) {
+	metric := func(r procTopRow) float64 {
+		if strings.EqualFold(key, "mem") || strings.EqualFold(key, "memory") {
+			return r.MemMB
+		}
+		return r.CPUPercent
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		mi, mj := metric(rows[i]), metric(rows[j])
+		if mi != mj {
+			return mi > mj
+		}
+		return rows[i].PID < rows[j].PID
+	})
+}
+
+func printProcessTable(rows []procTopRow, showContainer bool) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if showContainer {
+		fmt.Fprintln(w, "CONTAINER\tPID\tUSER\tCPU%\tMEM\tCOMMAND")
+	} else {
+		fmt.Fprintln(w, "PID\tUSER\tCPU%\tMEM\tCOMMAND")
+	}
+	for _, r := range rows {
+		cmd := truncate(r.Command, 60)
+		if showContainer {
+			fmt.Fprintf(w, "%s\t%d\t%s\t%.0f%%\t%s\t%s\n",
+				r.Container, r.PID, dashIfEmpty(r.User), r.CPUPercent, formatMem(r.MemMB, 0), cmd)
+		} else {
+			fmt.Fprintf(w, "%d\t%s\t%.0f%%\t%s\t%s\n",
+				r.PID, dashIfEmpty(r.User), r.CPUPercent, formatMem(r.MemMB, 0), cmd)
+		}
+	}
+	_ = w.Flush()
+	if len(rows) > 0 {
+		fmt.Println("\nPIDs are host-side — kill a runaway with: sudo kill <PID>")
+	}
+}
+
+// --- Incus enumeration ------------------------------------------------------
+
+// incusTopEntry is the slice of `incus list --format=json` this command needs:
+// the container name/status, its alias, and per-interface network counters.
+type incusTopEntry struct {
+	Name   string            `json:"name"`
+	Status string            `json:"status"`
+	Config map[string]string `json:"config"`
+	State  *struct {
+		Network map[string]struct {
+			Counters struct {
+				BytesReceived int64 `json:"bytes_received"`
+				BytesSent     int64 `json:"bytes_sent"`
+			} `json:"counters"`
+		} `json:"network"`
+	} `json:"state"`
+}
+
+func (e incusTopEntry) alias() string { return e.Config["user.coi.alias"] }
+
+// netBytes sums received/sent counters across every interface except loopback,
+// so a container's real host-facing traffic is captured regardless of NIC name.
+func (e incusTopEntry) netBytes() (rx, tx int64) {
+	if e.State == nil {
+		return 0, 0
+	}
+	for iface, n := range e.State.Network {
+		if iface == "lo" {
+			continue
+		}
+		rx += n.Counters.BytesReceived
+		tx += n.Counters.BytesSent
+	}
+	return rx, tx
+}
+
+func listTopEntries() ([]incusTopEntry, error) {
+	prefix := session.GetContainerPrefix()
+	output, err := container.IncusOutput("list", "^"+prefix, "--format=json")
+	if err != nil {
+		return nil, err
+	}
+	var entries []incusTopEntry
+	if err := json.Unmarshal([]byte(output), &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// loadContainerWorkspaces maps container name -> workspace from the session
+// metadata written at launch, matching how `coi list` resolves workspaces.
+// Best-effort: a missing/unreadable sessions dir yields an empty map.
+func loadContainerWorkspaces() map[string]string {
+	out := make(map[string]string)
+	if app == nil || app.cfg == nil {
+		return out
+	}
+	toolInstance, err := getConfiguredTool(app.cfg)
+	if err != nil {
+		return out
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return out
+	}
+	sessionsDir := session.GetSessionsDir(filepath.Join(homeDir, ".coi"), toolInstance)
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return out
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sessionsDir, entry.Name(), "metadata.json"))
+		if err != nil {
+			continue
+		}
+		var md session.SessionMetadata
+		if err := json.Unmarshal(data, &md); err == nil && md.ContainerName != "" {
+			out[md.ContainerName] = md.Workspace
+		}
+	}
+	return out
+}
+
+// --- /proc sampling for per-process CPU% and RSS ----------------------------
+
+// readProcJiffies returns utime+stime (in clock ticks) from /proc/<pid>/stat.
+// The comm field (field 2) can contain spaces and parentheses, so parsing
+// starts after the final ')'.
+func readProcJiffies(pid int) (float64, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	return parseProcJiffies(string(data))
+}
+
+func parseProcJiffies(stat string) (float64, bool) {
+	commEnd := strings.LastIndex(stat, ")")
+	if commEnd < 0 || commEnd+2 >= len(stat) {
+		return 0, false
+	}
+	// Fields after comm, 0-indexed: [0]=state(field3). utime=field14 -> index 11,
+	// stime=field15 -> index 12.
+	fields := strings.Fields(stat[commEnd+2:])
+	if len(fields) < 13 {
+		return 0, false
+	}
+	utime, err1 := strconv.ParseFloat(fields[11], 64)
+	stime, err2 := strconv.ParseFloat(fields[12], 64)
+	if err1 != nil || err2 != nil {
+		return 0, false
+	}
+	return utime + stime, true
+}
+
+// readProcRSSMB returns resident memory in MB from /proc/<pid>/statm (field 2
+// is resident pages). Returns 0 when unreadable.
+func readProcRSSMB(pid int) float64 {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/statm", pid))
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0
+	}
+	pages, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return 0
+	}
+	return pages * float64(os.Getpagesize()) / (1024 * 1024)
+}
+
+// --- formatting helpers -----------------------------------------------------
+
+// rate returns the per-second delta of a cumulative counter, clamped at 0 so a
+// counter reset (container restart) never prints a negative spike.
+func rate(v0, v1, secs float64) float64 {
+	if secs <= 0 {
+		return 0
+	}
+	d := (v1 - v0) / secs
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// formatRate renders an MB/s value with a byte-scaled unit (reusing formatBytes).
+func formatRate(mbPerSec float64) string {
+	return formatBytes(int64(mbPerSec*1024*1024)) + "/s"
+}
+
+// formatMem renders memory usage, appending the limit when one is set.
+func formatMem(usedMB, limitMB float64) string {
+	used := formatBytes(int64(usedMB * 1024 * 1024))
+	if limitMB > 0 {
+		return used + "/" + formatBytes(int64(limitMB*1024*1024))
+	}
+	return used
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// collapseHome shortens a path under the user's home to a leading ~.
+func collapseHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if path == home {
+			return "~"
+		}
+		if strings.HasPrefix(path, home+"/") {
+			return "~" + path[len(home):]
+		}
+	}
+	return path
+}
+
+func truncate(s string, limit int) string {
+	if limit <= 1 || len(s) <= limit {
+		return s
+	}
+	return s[:limit-1] + "…"
+}
+
+func printJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// sleepCtx sleeps for d unless the context is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/cli/top.go
+++ b/internal/cli/top.go
@@ -200,16 +200,22 @@ func sampleContainerRows(ctx context.Context, interval time.Duration) ([]contain
 			rows = append(rows, containerTopRow{Name: e.Name, Alias: e.alias(), Workspace: workspaces[e.Name]})
 			continue
 		}
-		r0 := res0[e.Name]
 		row := containerTopRow{
-			Name:         e.Name,
-			Alias:        e.alias(),
-			Workspace:    workspaces[e.Name],
-			CPUPercent:   rate(r0.CPUTimeSeconds, r1.CPUTimeSeconds, secs) * 100,
-			MemMB:        r1.MemoryMB,
-			MemLimitMB:   r1.MemoryLimitMB,
-			DiskReadMBs:  rate(r0.IOReadMB, r1.IOReadMB, secs),
-			DiskWriteMBs: rate(r0.IOWriteMB, r1.IOWriteMB, secs),
+			Name:       e.Name,
+			Alias:      e.alias(),
+			Workspace:  workspaces[e.Name],
+			MemMB:      r1.MemoryMB,
+			MemLimitMB: r1.MemoryLimitMB,
+		}
+		// CPU% and disk I/O are deltas of cumulative counters, so they are only
+		// meaningful with a t0 baseline. When the first sample was missing (a
+		// transient collection failure), leave them at 0 rather than treating the
+		// whole cumulative counter as a single-interval delta — which would render
+		// an absurd multi-thousand-percent CPU spike (#707).
+		if r0, ok := res0[e.Name]; ok {
+			row.CPUPercent = rate(r0.CPUTimeSeconds, r1.CPUTimeSeconds, secs) * 100
+			row.DiskReadMBs = rate(r0.IOReadMB, r1.IOReadMB, secs)
+			row.DiskWriteMBs = rate(r0.IOWriteMB, r1.IOWriteMB, secs)
 		}
 		rx0, tx0 := e.netBytes()
 		rx1, tx1 := net1[e.Name].netBytes()

--- a/internal/cli/top.go
+++ b/internal/cli/top.go
@@ -25,6 +25,7 @@ var (
 	topSort     string
 	topProcs    bool
 	topJSON     bool
+	topWatch    int
 )
 
 // userHZ is the kernel clock-tick rate assumed for converting /proc/<pid>/stat
@@ -58,6 +59,7 @@ Examples:
   coi top -i 5                  # sample over 5 seconds
   coi top my-api                # processes inside the 'my-api' container
   coi top --procs               # every container's processes, busiest first
+  coi top --watch 2             # re-render every 2s until Ctrl+C
   coi top --json                # machine-readable output`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runTop,
@@ -68,6 +70,7 @@ func init() {
 	topCmd.Flags().StringVar(&topSort, "sort", "cpu", "Sort key: cpu, mem, disk, or net (containers); cpu or mem (processes)")
 	topCmd.Flags().BoolVar(&topProcs, "procs", false, "Show processes (across all containers when no container is named)")
 	topCmd.Flags().BoolVar(&topJSON, "json", false, "Output as JSON")
+	topCmd.Flags().IntVar(&topWatch, "watch", 0, "Re-render every N seconds until Ctrl+C (0 = one-shot)")
 }
 
 // Seams so tests can supply canned data without a live Incus/cgroup.
@@ -81,6 +84,12 @@ func runTop(cmd *cobra.Command, args []string) error {
 	if topInterval <= 0 {
 		return &ExitCodeError{Code: 2, Message: "invalid --interval: must be greater than 0"}
 	}
+	if topWatch < 0 {
+		return &ExitCodeError{Code: 2, Message: "invalid --watch: must be >= 0"}
+	}
+	if topWatch > 0 && topJSON {
+		return &ExitCodeError{Code: 2, Message: "--json is not supported with --watch"}
+	}
 	interval := time.Duration(topInterval * float64(time.Second))
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -91,24 +100,59 @@ func runTop(cmd *cobra.Command, args []string) error {
 	// is the container view. Each view supports a different --sort vocabulary,
 	// so validate against the chosen view rather than silently falling back to
 	// cpu on a typo (matching how `coi list` rejects an unknown --status).
-	if len(args) > 0 || topProcs {
+	procView := len(args) > 0 || topProcs
+	if procView {
 		if err := validateSortKey(topSort, procSortKeys); err != nil {
 			return err
 		}
-		var only string
-		if len(args) > 0 {
-			resolved, err := resolveTopContainer(args[0])
-			if err != nil {
-				return err
-			}
-			only = resolved
-		}
-		return runTopProcesses(ctx, only, interval)
-	}
-	if err := validateSortKey(topSort, containerSortKeys); err != nil {
+	} else if err := validateSortKey(topSort, containerSortKeys); err != nil {
 		return err
 	}
+
+	var only string
+	if len(args) > 0 {
+		resolved, err := resolveTopContainer(args[0])
+		if err != nil {
+			return err
+		}
+		only = resolved
+	}
+
+	// One render pass (text output). Watch mode repeats it; one-shot runs it once
+	// — except one-shot --json, which the view functions handle directly.
+	renderOnce := func() error {
+		if procView {
+			return renderProcessesText(ctx, only, interval)
+		}
+		return renderContainersText(ctx, interval)
+	}
+	if topWatch > 0 {
+		return runTopWatch(ctx, renderOnce, topWatch)
+	}
+	if procView {
+		return runTopProcesses(ctx, only, interval)
+	}
 	return runTopContainers(ctx, interval)
+}
+
+// runTopWatch re-renders every watchSec seconds until the context is cancelled
+// (Ctrl+C). Each pass clears the screen first, mirroring `coi monitor --watch`.
+// The render itself blocks ~--interval while sampling, so the effective refresh
+// period is interval + watchSec.
+func runTopWatch(ctx context.Context, render func() error, watchSec int) error {
+	for {
+		fmt.Print("\033[2J\033[H") // clear screen, cursor home
+		if err := render(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		fmt.Printf("\nLast updated: %s | refresh every %ds | Press Ctrl+C to exit\n",
+			time.Now().Format("15:04:05"), watchSec)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(time.Duration(watchSec) * time.Second):
+		}
+	}
 }
 
 // Sort vocabularies per view. Containers can be sorted by four metrics;
@@ -159,22 +203,33 @@ type containerTopRow struct {
 }
 
 func runTopContainers(ctx context.Context, interval time.Duration) error {
+	if !topJSON {
+		return renderContainersText(ctx, interval)
+	}
 	rows, err := sampleContainerRows(ctx, interval)
 	if err != nil {
 		return err
 	}
 	if rows == nil {
-		if topJSON {
-			fmt.Println("[]")
-		} else {
-			fmt.Println("No running containers.")
-		}
+		fmt.Println("[]")
 		return nil
 	}
 	sortContainerRows(rows, topSort)
-	if topJSON {
-		return printJSON(rows)
+	return printJSON(rows)
+}
+
+// renderContainersText samples and prints the container table (no JSON). Shared
+// by the one-shot text path and watch mode.
+func renderContainersText(ctx context.Context, interval time.Duration) error {
+	rows, err := sampleContainerRows(ctx, interval)
+	if err != nil {
+		return err
 	}
+	if rows == nil {
+		fmt.Println("No running containers.")
+		return nil
+	}
+	sortContainerRows(rows, topSort)
 	printContainerTable(rows)
 	return nil
 }
@@ -310,35 +365,80 @@ type procTopRow struct {
 }
 
 func runTopProcesses(ctx context.Context, only string, interval time.Duration) error {
-	// Which containers to inspect.
-	var names []string
+	names, err := resolveProcNames(only)
+	if err != nil {
+		return err
+	}
+	if len(names) == 0 {
+		if topJSON {
+			fmt.Println("[]")
+		} else {
+			fmt.Println("No running containers.")
+		}
+		return nil
+	}
+	rows, err := sampleProcessRows(ctx, names, interval, only != "")
+	if err != nil {
+		return err
+	}
+	sortProcRows(rows, topSort)
+	if topJSON {
+		return printJSON(rows)
+	}
+	printProcessTable(rows, only == "")
+	return nil
+}
+
+// renderProcessesText samples and prints the process table (no JSON). Shared by
+// the one-shot text path and watch mode.
+func renderProcessesText(ctx context.Context, only string, interval time.Duration) error {
+	names, err := resolveProcNames(only)
+	if err != nil {
+		return err
+	}
+	if len(names) == 0 {
+		fmt.Println("No running containers.")
+		return nil
+	}
+	rows, err := sampleProcessRows(ctx, names, interval, only != "")
+	if err != nil {
+		return err
+	}
+	sortProcRows(rows, topSort)
+	printProcessTable(rows, only == "")
+	return nil
+}
+
+// resolveProcNames returns the containers to inspect: just `only` when set,
+// otherwise every running coi container.
+func resolveProcNames(only string) ([]string, error) {
 	if only != "" {
-		names = []string{only}
-	} else {
-		entries, err := topListEntries()
-		if err != nil {
-			return fmt.Errorf("failed to list containers: %w", err)
-		}
-		for _, e := range entries {
-			if strings.EqualFold(e.Status, "Running") {
-				names = append(names, e.Name)
-			}
-		}
-		if len(names) == 0 {
-			if topJSON {
-				fmt.Println("[]")
-			} else {
-				fmt.Println("No running containers.")
-			}
-			return nil
+		return []string{only}, nil
+	}
+	entries, err := topListEntries()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if strings.EqualFold(e.Status, "Running") {
+			names = append(names, e.Name)
 		}
 	}
+	return names, nil
+}
 
-	// t0: record CPU jiffies for every process in each container.
+// sampleProcessRows samples per-process CPU%/RSS across the named containers by
+// reading /proc jiffies at two points interval apart. When strict is true (a
+// single named container), a process-collection failure is returned; otherwise
+// (across all containers) it is skipped best-effort. The returned slice is
+// non-nil so an empty result marshals to `[]`, not `null`.
+func sampleProcessRows(ctx context.Context, names []string, interval time.Duration, strict bool) ([]procTopRow, error) {
 	type key struct {
 		container string
 		pid       int
 	}
+	// t0: record CPU jiffies for every process in each container.
 	jiffies0 := make(map[key]float64)
 	for _, name := range names {
 		if ps, err := topCollectProcesses(ctx, name); err == nil {
@@ -351,18 +451,16 @@ func runTopProcesses(ctx context.Context, only string, interval time.Duration) e
 	}
 
 	if err := sleepCtx(ctx, interval); err != nil {
-		return err
+		return nil, err
 	}
 	secs := interval.Seconds()
 
-	// Non-nil so an empty result marshals to `[]`, not `null` (matching the
-	// container view's JSON shape).
 	rows := []procTopRow{}
 	for _, name := range names {
 		ps, err := topCollectProcesses(ctx, name)
 		if err != nil {
-			if only != "" {
-				return fmt.Errorf("failed to read processes for %s: %w", name, err)
+			if strict {
+				return nil, fmt.Errorf("failed to read processes for %s: %w", name, err)
 			}
 			continue // best-effort across all containers
 		}
@@ -388,14 +486,7 @@ func runTopProcesses(ctx context.Context, only string, interval time.Duration) e
 			})
 		}
 	}
-
-	sortProcRows(rows, topSort)
-
-	if topJSON {
-		return printJSON(rows)
-	}
-	printProcessTable(rows, only == "")
-	return nil
+	return rows, nil
 }
 
 func sortProcRows(rows []procTopRow, key string) {

--- a/internal/cli/top.go
+++ b/internal/cli/top.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -87,8 +88,13 @@ func runTop(cmd *cobra.Command, args []string) error {
 	}
 
 	// A named container, or --procs, selects the process view; bare `coi top`
-	// is the container view.
+	// is the container view. Each view supports a different --sort vocabulary,
+	// so validate against the chosen view rather than silently falling back to
+	// cpu on a typo (matching how `coi list` rejects an unknown --status).
 	if len(args) > 0 || topProcs {
+		if err := validateSortKey(topSort, procSortKeys); err != nil {
+			return err
+		}
 		var only string
 		if len(args) > 0 {
 			resolved, err := resolveTopContainer(args[0])
@@ -99,7 +105,30 @@ func runTop(cmd *cobra.Command, args []string) error {
 		}
 		return runTopProcesses(ctx, only, interval)
 	}
+	if err := validateSortKey(topSort, containerSortKeys); err != nil {
+		return err
+	}
 	return runTopContainers(ctx, interval)
+}
+
+// Sort vocabularies per view. Containers can be sorted by four metrics;
+// processes only carry cpu and memory.
+var (
+	containerSortKeys = []string{"cpu", "mem", "disk", "net"}
+	procSortKeys      = []string{"cpu", "mem"}
+)
+
+// validateSortKey rejects a --sort value outside the view's vocabulary with an
+// exit-code-2 usage error, so a typo is caught instead of quietly sorting by
+// cpu (the default case in the sort functions).
+func validateSortKey(key string, allowed []string) error {
+	lower := strings.ToLower(key)
+	for _, k := range allowed {
+		if lower == k {
+			return nil
+		}
+	}
+	return &ExitCodeError{Code: 2, Message: fmt.Sprintf("invalid --sort %q: must be one of %s", key, strings.Join(allowed, ", "))}
 }
 
 // resolveTopContainer turns a container name or alias into a concrete running
@@ -231,11 +260,11 @@ func sampleContainerRows(ctx context.Context, interval time.Duration) ([]contain
 func sortContainerRows(rows []containerTopRow, key string) {
 	metric := func(r containerTopRow) float64 {
 		switch strings.ToLower(key) {
-		case "mem", "memory":
+		case "mem":
 			return r.MemMB
-		case "disk", "io":
+		case "disk":
 			return r.DiskReadMBs + r.DiskWriteMBs
-		case "net", "network":
+		case "net":
 			return r.NetRxMBs + r.NetTxMBs
 		default: // cpu
 			return r.CPUPercent
@@ -326,7 +355,9 @@ func runTopProcesses(ctx context.Context, only string, interval time.Duration) e
 	}
 	secs := interval.Seconds()
 
-	var rows []procTopRow
+	// Non-nil so an empty result marshals to `[]`, not `null` (matching the
+	// container view's JSON shape).
+	rows := []procTopRow{}
 	for _, name := range names {
 		ps, err := topCollectProcesses(ctx, name)
 		if err != nil {
@@ -369,7 +400,7 @@ func runTopProcesses(ctx context.Context, only string, interval time.Duration) e
 
 func sortProcRows(rows []procTopRow, key string) {
 	metric := func(r procTopRow) float64 {
-		if strings.EqualFold(key, "mem") || strings.EqualFold(key, "memory") {
+		if strings.EqualFold(key, "mem") {
 			return r.MemMB
 		}
 		return r.CPUPercent
@@ -444,7 +475,11 @@ func (e incusTopEntry) netBytes() (rx, tx int64) {
 
 func listTopEntries() ([]incusTopEntry, error) {
 	prefix := session.GetContainerPrefix()
-	output, err := container.IncusOutput("list", "^"+prefix, "--format=json")
+	// `incus list`'s positional filter is a regex, but the prefix is a literal
+	// (COI_CONTAINER_PREFIX may contain '.', '[', etc.), so escape it before
+	// anchoring — otherwise a metacharacter prefix would match the wrong
+	// containers or none at all.
+	output, err := container.IncusOutput("list", "^"+regexp.QuoteMeta(prefix), "--format=json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/top_test.go
+++ b/internal/cli/top_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mensfeld/code-on-incus/internal/monitor"
+)
+
+func TestParseProcJiffies(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want float64
+		ok   bool
+	}{
+		{
+			// Fields after comm: state ppid pgrp sid tty tpgid flags minflt
+			// cminflt majflt cmajflt utime stime ...
+			// -> utime=index11=100, stime=index12=50 => 150.
+			name: "simple",
+			stat: "1234 (bash) S 1 1234 1234 0 -1 4194560 100 200 0 0 100 50 0 0 20 0 1 0 999 0 0",
+			want: 150,
+			ok:   true,
+		},
+		{
+			// comm containing spaces AND a closing paren must not break parsing.
+			name: "tricky comm",
+			stat: "42 (Web Content (ok)) R 1 42 42 0 -1 0 0 0 0 0 7 3 0 0 20 0 1 0 5 0 0",
+			want: 10,
+			ok:   true,
+		},
+		{name: "no paren", stat: "garbage without paren", want: 0, ok: false},
+		{name: "too few fields", stat: "1 (x) S 1 2 3", want: 0, ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseProcJiffies(tt.stat)
+			if ok != tt.ok || got != tt.want {
+				t.Errorf("parseProcJiffies(%q) = %v,%v; want %v,%v", tt.stat, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestRate(t *testing.T) {
+	tests := []struct {
+		v0, v1, secs, want float64
+	}{
+		{0, 10, 2, 5},    // 10 over 2s -> 5/s
+		{100, 100, 2, 0}, // no change
+		{50, 10, 2, 0},   // counter reset -> clamped to 0
+		{0, 5, 0, 0},     // zero interval -> 0
+	}
+	for _, tt := range tests {
+		if got := rate(tt.v0, tt.v1, tt.secs); got != tt.want {
+			t.Errorf("rate(%v,%v,%v) = %v; want %v", tt.v0, tt.v1, tt.secs, got, tt.want)
+		}
+	}
+}
+
+func TestNetBytes(t *testing.T) {
+	e := incusTopEntry{}
+	e.State = &struct {
+		Network map[string]struct {
+			Counters struct {
+				BytesReceived int64 `json:"bytes_received"`
+				BytesSent     int64 `json:"bytes_sent"`
+			} `json:"counters"`
+		} `json:"network"`
+	}{
+		Network: map[string]struct {
+			Counters struct {
+				BytesReceived int64 `json:"bytes_received"`
+				BytesSent     int64 `json:"bytes_sent"`
+			} `json:"counters"`
+		}{},
+	}
+	set := func(iface string, rx, tx int64) {
+		var c struct {
+			Counters struct {
+				BytesReceived int64 `json:"bytes_received"`
+				BytesSent     int64 `json:"bytes_sent"`
+			} `json:"counters"`
+		}
+		c.Counters.BytesReceived = rx
+		c.Counters.BytesSent = tx
+		e.State.Network[iface] = c
+	}
+	set("eth0", 1000, 2000)
+	set("eth1", 500, 100)
+	set("lo", 9999, 9999) // must be excluded
+
+	rx, tx := e.netBytes()
+	if rx != 1500 || tx != 2100 {
+		t.Errorf("netBytes() = %d,%d; want 1500,2100 (loopback excluded)", rx, tx)
+	}
+
+	// Nil state (stopped/no state) is safe.
+	if rx, tx := (incusTopEntry{}).netBytes(); rx != 0 || tx != 0 {
+		t.Errorf("netBytes() on nil state = %d,%d; want 0,0", rx, tx)
+	}
+}
+
+func TestSortContainerRows(t *testing.T) {
+	rows := []containerTopRow{
+		{Name: "c-low", CPUPercent: 5, MemMB: 900, DiskReadMBs: 1, NetRxMBs: 9},
+		{Name: "c-high", CPUPercent: 200, MemMB: 100, DiskReadMBs: 0, NetRxMBs: 0},
+		{Name: "c-mid", CPUPercent: 50, MemMB: 500, DiskWriteMBs: 8, NetTxMBs: 4},
+	}
+
+	sortContainerRows(rows, "cpu")
+	if rows[0].Name != "c-high" || rows[2].Name != "c-low" {
+		t.Errorf("cpu sort order wrong: %v", names(rows))
+	}
+
+	sortContainerRows(rows, "mem")
+	if rows[0].Name != "c-low" {
+		t.Errorf("mem sort: expected c-low first, got %v", names(rows))
+	}
+
+	sortContainerRows(rows, "disk")
+	if rows[0].Name != "c-mid" {
+		t.Errorf("disk sort: expected c-mid first, got %v", names(rows))
+	}
+
+	sortContainerRows(rows, "net")
+	if rows[0].Name != "c-low" {
+		t.Errorf("net sort: expected c-low first (rx 9), got %v", names(rows))
+	}
+}
+
+func names(rows []containerTopRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func TestSortProcRows(t *testing.T) {
+	rows := []procTopRow{
+		{PID: 3, CPUPercent: 10, MemMB: 5},
+		{PID: 1, CPUPercent: 90, MemMB: 1},
+		{PID: 2, CPUPercent: 10, MemMB: 50},
+	}
+	sortProcRows(rows, "cpu")
+	if rows[0].PID != 1 {
+		t.Errorf("cpu sort: expected PID 1 first, got %d", rows[0].PID)
+	}
+	// Tie on CPU (PIDs 3 and 2 both 10%) breaks by PID ascending.
+	if rows[1].PID != 2 || rows[2].PID != 3 {
+		t.Errorf("cpu tie-break wrong: %d then %d", rows[1].PID, rows[2].PID)
+	}
+
+	sortProcRows(rows, "mem")
+	if rows[0].PID != 2 {
+		t.Errorf("mem sort: expected PID 2 first (50MB), got %d", rows[0].PID)
+	}
+}
+
+func TestSampleContainerRows_CPUAndFilter(t *testing.T) {
+	origList, origRes := topListEntries, topCollectResources
+	defer func() { topListEntries, topCollectResources = origList, origRes }()
+
+	entry := func(name, status string) incusTopEntry {
+		return incusTopEntry{Name: name, Status: status, Config: map[string]string{}}
+	}
+	topListEntries = func() ([]incusTopEntry, error) {
+		return []incusTopEntry{
+			entry("coi-run-1", "Running"),
+			entry("coi-stopped-1", "Stopped"), // must be filtered out
+		}, nil
+	}
+	// First call returns t0 (cpu=1s), subsequent calls t1 (cpu=3s): a 2s delta
+	// over a 2s interval => 100% CPU.
+	call := 0
+	topCollectResources = func(_ context.Context, name string) (monitor.ResourceStats, error) {
+		call++
+		if call == 1 {
+			return monitor.ResourceStats{CPUTimeSeconds: 1, MemoryMB: 128}, nil
+		}
+		return monitor.ResourceStats{CPUTimeSeconds: 3, MemoryMB: 256}, nil
+	}
+
+	rows, err := sampleContainerRows(context.Background(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("sampleContainerRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 running container row, got %d: %v", len(rows), names(rows))
+	}
+	r := rows[0]
+	if r.Name != "coi-run-1" {
+		t.Errorf("expected coi-run-1, got %s", r.Name)
+	}
+	if r.CPUPercent < 99.9 || r.CPUPercent > 100.1 {
+		t.Errorf("CPUPercent = %.2f; want ~100", r.CPUPercent)
+	}
+	if r.MemMB != 256 {
+		t.Errorf("MemMB = %.0f; want 256 (second sample)", r.MemMB)
+	}
+}
+
+func TestSampleContainerRows_NoneRunning(t *testing.T) {
+	origList := topListEntries
+	defer func() { topListEntries = origList }()
+	topListEntries = func() ([]incusTopEntry, error) {
+		return []incusTopEntry{{Name: "coi-x", Status: "Stopped"}}, nil
+	}
+	rows, err := sampleContainerRows(context.Background(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rows != nil {
+		t.Errorf("expected nil rows when nothing is running, got %v", names(rows))
+	}
+}
+
+func TestCollapseHome(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	cases := map[string]string{
+		"/home/tester":          "~",
+		"/home/tester/work/api": "~/work/api",
+		"/opt/other":            "/opt/other",
+		"":                      "",
+	}
+	for in, want := range cases {
+		if got := collapseHome(in); got != want {
+			t.Errorf("collapseHome(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatMem(t *testing.T) {
+	// 256 MB, no limit.
+	if got := formatMem(256, 0); got != "256.0 MB" {
+		t.Errorf("formatMem(256,0) = %q; want 256.0 MB", got)
+	}
+	// With a limit, both sides shown.
+	if got := formatMem(256, 1024); got != "256.0 MB/1.0 GB" {
+		t.Errorf("formatMem(256,1024) = %q; want 256.0 MB/1.0 GB", got)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 60); got != "short" {
+		t.Errorf("truncate kept-short = %q", got)
+	}
+	long := "0123456789"
+	if got := truncate(long, 5); got != "0123…" {
+		t.Errorf("truncate(%q,5) = %q; want 0123…", long, got)
+	}
+}

--- a/internal/cli/top_test.go
+++ b/internal/cli/top_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/mensfeld/code-on-incus/internal/monitor"
+	"github.com/spf13/cobra"
 )
 
 func TestParseProcJiffies(t *testing.T) {
@@ -258,6 +260,88 @@ func TestSampleContainerRows_NoneRunning(t *testing.T) {
 	}
 	if rows != nil {
 		t.Errorf("expected nil rows when nothing is running, got %v", names(rows))
+	}
+}
+
+func TestSampleProcessRows_Self(t *testing.T) {
+	// Fake the container-process discovery to return THIS test process, so the
+	// real /proc jiffies/RSS reads have a live PID to work against.
+	orig := topCollectProcesses
+	defer func() { topCollectProcesses = orig }()
+	self := os.Getpid()
+	topCollectProcesses = func(_ context.Context, _ string) (monitor.ProcessStats, error) {
+		return monitor.ProcessStats{
+			Available:  true,
+			TotalCount: 1,
+			Processes:  []monitor.Process{{PID: self, User: "1000", Command: "top.test"}},
+		}, nil
+	}
+
+	rows, err := sampleProcessRows(context.Background(), []string{"coi-x"}, 10*time.Millisecond, true)
+	if err != nil {
+		t.Fatalf("sampleProcessRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].PID != self {
+		t.Errorf("PID = %d; want self %d", rows[0].PID, self)
+	}
+	if rows[0].MemMB <= 0 {
+		t.Errorf("MemMB = %v; want > 0 (live RSS)", rows[0].MemMB)
+	}
+	if rows[0].Container != "coi-x" {
+		t.Errorf("Container = %q; want coi-x", rows[0].Container)
+	}
+}
+
+func TestSampleProcessRows_StrictPropagatesError(t *testing.T) {
+	orig := topCollectProcesses
+	defer func() { topCollectProcesses = orig }()
+	topCollectProcesses = func(_ context.Context, _ string) (monitor.ProcessStats, error) {
+		return monitor.ProcessStats{}, errors.New("cgroup gone")
+	}
+	// strict=true (a single named container) surfaces the error...
+	if _, err := sampleProcessRows(context.Background(), []string{"coi-x"}, time.Millisecond, true); err == nil {
+		t.Error("strict sampleProcessRows should return the collection error")
+	}
+	// ...best-effort (strict=false) skips it and returns an empty (non-nil) slice.
+	rows, err := sampleProcessRows(context.Background(), []string{"coi-x"}, time.Millisecond, false)
+	if err != nil {
+		t.Fatalf("best-effort sampleProcessRows: %v", err)
+	}
+	if rows == nil {
+		t.Error("rows should be non-nil (marshals to [] not null) even when all containers fail")
+	}
+}
+
+func TestRunTopWatch_StopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: one render pass runs, then the loop exits.
+
+	calls := 0
+	err := runTopWatch(ctx, func() error { calls++; return nil }, 1)
+	if err != nil {
+		t.Fatalf("runTopWatch returned %v; want nil on cancel", err)
+	}
+	if calls != 1 {
+		t.Errorf("render called %d times; want exactly 1 before cancel", calls)
+	}
+}
+
+func TestRunTop_JSONWithWatchRejected(t *testing.T) {
+	// Save/restore the flag globals the command binds to.
+	oi, os_, op, oj, ow := topInterval, topSort, topProcs, topJSON, topWatch
+	defer func() { topInterval, topSort, topProcs, topJSON, topWatch = oi, os_, op, oj, ow }()
+	topInterval, topSort, topProcs, topJSON, topWatch = 2, "cpu", false, true, 2
+
+	err := runTop(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("expected error for --json with --watch")
+	}
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Errorf("expected ExitCodeError code 2, got %v", err)
 	}
 }
 

--- a/internal/cli/top_test.go
+++ b/internal/cli/top_test.go
@@ -174,18 +174,19 @@ func TestSampleContainerRows_CPUAndFilter(t *testing.T) {
 			entry("coi-stopped-1", "Stopped"), // must be filtered out
 		}, nil
 	}
-	// First call returns t0 (cpu=1s), subsequent calls t1 (cpu=3s): a 2s delta
-	// over a 2s interval => 100% CPU.
+	// t0 cpu=1.00s, t1 cpu=1.01s: a 0.01s delta over a 10ms interval => 100% CPU.
+	// A tiny interval keeps the assertion while avoiding a real multi-second
+	// sleep in the unit test.
 	call := 0
 	topCollectResources = func(_ context.Context, name string) (monitor.ResourceStats, error) {
 		call++
 		if call == 1 {
-			return monitor.ResourceStats{CPUTimeSeconds: 1, MemoryMB: 128}, nil
+			return monitor.ResourceStats{CPUTimeSeconds: 1.00, MemoryMB: 128}, nil
 		}
-		return monitor.ResourceStats{CPUTimeSeconds: 3, MemoryMB: 256}, nil
+		return monitor.ResourceStats{CPUTimeSeconds: 1.01, MemoryMB: 256}, nil
 	}
 
-	rows, err := sampleContainerRows(context.Background(), 2*time.Second)
+	rows, err := sampleContainerRows(context.Background(), 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("sampleContainerRows: %v", err)
 	}
@@ -226,7 +227,7 @@ func TestSampleContainerRows_MissingBaselineStaysZero(t *testing.T) {
 		return monitor.ResourceStats{CPUTimeSeconds: 9000, MemoryMB: 256, IOReadMB: 500}, nil
 	}
 
-	rows, err := sampleContainerRows(context.Background(), 2*time.Second)
+	rows, err := sampleContainerRows(context.Background(), 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("sampleContainerRows: %v", err)
 	}
@@ -257,6 +258,26 @@ func TestSampleContainerRows_NoneRunning(t *testing.T) {
 	}
 	if rows != nil {
 		t.Errorf("expected nil rows when nothing is running, got %v", names(rows))
+	}
+}
+
+func TestValidateSortKey(t *testing.T) {
+	// Canonical keys (any case) pass; unknown keys are rejected with exit 2.
+	for _, k := range []string{"cpu", "CPU", "mem", "disk", "net"} {
+		if err := validateSortKey(k, containerSortKeys); err != nil {
+			t.Errorf("validateSortKey(%q, container) = %v; want nil", k, err)
+		}
+	}
+	if err := validateSortKey("disk", procSortKeys); err == nil {
+		t.Error("validateSortKey(disk, proc) = nil; want error (disk is container-only)")
+	}
+	err := validateSortKey("ram", containerSortKeys)
+	if err == nil {
+		t.Fatal("validateSortKey(ram) = nil; want error")
+	}
+	var ec *ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Errorf("expected ExitCodeError code 2, got %v", err)
 	}
 }
 

--- a/internal/cli/top_test.go
+++ b/internal/cli/top_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -200,6 +201,47 @@ func TestSampleContainerRows_CPUAndFilter(t *testing.T) {
 	}
 	if r.MemMB != 256 {
 		t.Errorf("MemMB = %.0f; want 256 (second sample)", r.MemMB)
+	}
+}
+
+func TestSampleContainerRows_MissingBaselineStaysZero(t *testing.T) {
+	// A container whose t0 sample fails but t1 succeeds must NOT report the
+	// cumulative counter as a single-interval delta (#707): CPU%/disk stay 0.
+	origList, origRes := topListEntries, topCollectResources
+	defer func() { topListEntries, topCollectResources = origList, origRes }()
+
+	topListEntries = func() ([]incusTopEntry, error) {
+		return []incusTopEntry{{Name: "coi-run-1", Status: "Running", Config: map[string]string{}}}, nil
+	}
+	call := 0
+	topCollectResources = func(_ context.Context, _ string) (monitor.ResourceStats, error) {
+		call++
+		if call == 1 {
+			// t0 read fails -> no baseline recorded.
+			return monitor.ResourceStats{}, errors.New("cgroup not ready")
+		}
+		// t1: a container that has accumulated 9000 CPU-seconds and 500MB of I/O
+		// over its lifetime. Without the baseline guard this would render as a
+		// wildly inflated rate.
+		return monitor.ResourceStats{CPUTimeSeconds: 9000, MemoryMB: 256, IOReadMB: 500}, nil
+	}
+
+	rows, err := sampleContainerRows(context.Background(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("sampleContainerRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.CPUPercent != 0 {
+		t.Errorf("CPUPercent = %.2f; want 0 when t0 baseline is missing", r.CPUPercent)
+	}
+	if r.DiskReadMBs != 0 {
+		t.Errorf("DiskReadMBs = %.2f; want 0 when t0 baseline is missing", r.DiskReadMBs)
+	}
+	if r.MemMB != 256 {
+		t.Errorf("MemMB = %.0f; want 256 (instantaneous, no baseline needed)", r.MemMB)
 	}
 }
 

--- a/tests/top/test_top.py
+++ b/tests/top/test_top.py
@@ -1,0 +1,161 @@
+"""
+End-to-end tests for `coi top` (#707).
+
+Fast tests exercise help text and argument validation (no container needed).
+The container-backed tests launch a real coi container and assert that `coi
+top` surfaces it (and its processes) with resource fields, resolved to the
+container context.
+"""
+
+import json
+import subprocess
+
+from support.helpers import calculate_container_name, wait_for_container_started
+
+
+# --- Fast tests (no container required) -------------------------------------
+
+
+def test_top_help(coi_binary):
+    """`coi top --help` documents the views, key flags, and the kill hint."""
+    result = subprocess.run(
+        [coi_binary, "top", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"help should exit 0. stderr: {result.stderr}"
+    out = result.stdout + result.stderr
+    for needle in ("CPU%", "--watch", "--procs", "--sort", "sudo kill"):
+        assert needle in out, f"expected {needle!r} in `coi top --help`, got:\n{out}"
+
+
+def test_top_invalid_sort_rejected(coi_binary):
+    """An unknown --sort key is rejected (not silently defaulted to cpu)."""
+    result = subprocess.run(
+        [coi_binary, "top", "--sort", "bogus"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "invalid --sort should be a usage error"
+    assert "invalid --sort" in (result.stdout + result.stderr).lower()
+
+
+def test_top_procs_sort_disk_rejected(coi_binary):
+    """disk/net are container-only sort keys; rejected in the process view."""
+    result = subprocess.run(
+        [coi_binary, "top", "--procs", "--sort", "disk"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "disk is not a valid process sort key"
+    assert "invalid --sort" in (result.stdout + result.stderr).lower()
+
+
+def test_top_json_with_watch_rejected(coi_binary):
+    """--json and --watch are mutually exclusive."""
+    result = subprocess.run(
+        [coi_binary, "top", "--watch", "2", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "--json with --watch should be a usage error"
+    combined = (result.stdout + result.stderr).lower()
+    assert "--json" in combined and "--watch" in combined
+
+
+def test_top_invalid_interval_rejected(coi_binary):
+    """A non-positive --interval is a usage error."""
+    result = subprocess.run(
+        [coi_binary, "top", "--interval", "0"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "--interval 0 should be a usage error"
+    assert "interval" in (result.stdout + result.stderr).lower()
+
+
+# --- Container-backed tests -------------------------------------------------
+
+
+def test_top_lists_running_container(coi_binary, cleanup_containers, workspace_dir):
+    """`coi top --json` includes a launched container with resource fields."""
+    container_name = calculate_container_name(workspace_dir, 1)
+    launch = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert launch.returncode == 0, f"launch failed. stderr: {launch.stderr}"
+    try:
+        wait_for_container_started(coi_binary, container_name)
+
+        result = subprocess.run(
+            [coi_binary, "top", "--json", "-i", "0.5"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, f"top --json failed. stderr: {result.stderr}"
+
+        rows = json.loads(result.stdout)
+        assert isinstance(rows, list), "container view --json must be a JSON array"
+        match = next((r for r in rows if r.get("name") == container_name), None)
+        assert match is not None, (
+            f"launched container {container_name} not in `coi top` output: {rows}"
+        )
+        # Resource fields present (values may be ~0 on an idle container).
+        for field in ("cpu_percent", "memory_mb", "disk_read_mb_per_sec", "net_rx_mb_per_sec"):
+            assert field in match, f"missing {field} in row: {match}"
+        assert match["memory_mb"] > 0, "a running container should report memory usage"
+    finally:
+        subprocess.run(
+            [coi_binary, "container", "delete", container_name, "--force"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+
+
+def test_top_processes_for_container(coi_binary, cleanup_containers, workspace_dir):
+    """`coi top <container> --json` lists processes with host PIDs."""
+    container_name = calculate_container_name(workspace_dir, 1)
+    launch = subprocess.run(
+        [coi_binary, "container", "launch", "coi-default", container_name],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert launch.returncode == 0, f"launch failed. stderr: {launch.stderr}"
+    try:
+        wait_for_container_started(coi_binary, container_name)
+
+        result = subprocess.run(
+            [coi_binary, "top", container_name, "--json", "-i", "0.5"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, f"top <container> --json failed. stderr: {result.stderr}"
+
+        rows = json.loads(result.stdout)
+        assert isinstance(rows, list) and len(rows) > 0, (
+            f"a running container must have at least its init process: {rows}"
+        )
+        first = rows[0]
+        for field in ("pid", "cpu_percent", "memory_mb", "command"):
+            assert field in first, f"missing {field} in process row: {first}"
+        assert first["pid"] > 0, "process rows must carry a (host-side) PID"
+        assert first["container"] == container_name, "process row should name its container"
+    finally:
+        subprocess.run(
+            [coi_binary, "container", "delete", container_name, "--force"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )

--- a/tests/top/test_top.py
+++ b/tests/top/test_top.py
@@ -12,7 +12,6 @@ import subprocess
 
 from support.helpers import calculate_container_name, wait_for_container_started
 
-
 # --- Fast tests (no container required) -------------------------------------
 
 


### PR DESCRIPTION
Closes #707.

## Problem

> It drives me crazy that I have to resolve PIDs to coi container references to figure out which of the containers is overloading my machine.

## Solution: `coi top`

A one-shot (no TUI) resource view that resolves usage to coi's friendly context.

**Container view** (default) — one row per running container, sorted busiest-first, joined to each container's **alias + workspace**:

```
$ coi top
CONTAINER      ALIAS  CPU%   MEM               DISK R/W          NET R/W           WORKSPACE
coi-a1b2-1     api    182%   1.4 GB/4.0 GB     0 B/s / 2.1 MB/s  120 KB/s / 8 KB/s  ~/work/api
coi-c3d4-1     web     23%   612 MB            0 B/s / 0 B/s     4 KB/s / 1 KB/s    ~/work/web
```

**Process view** — `coi top <name|alias>` (one container) or `coi top --procs` (all containers) drills into per-process rows. PIDs are **host-side**, so a runaway is directly killable:

```
$ coi top my-api
PID     USER  CPU%   MEM       COMMAND
40231   1000  181%   900.0 MB  node /app/server.js
...
PIDs are host-side — kill a runaway with: sudo kill <PID>
```

Flags: `--interval/-i` (default 2s), `--sort cpu|mem|disk|net`, `--procs`, `--json`.

## How it works

- **Enumeration + context**: reuses the `incus list --format=json` + session-metadata join that `coi list` already uses (container → alias → workspace).
- **CPU% / disk-I/O / net-I/O** are rates, sampled over `--interval`:
  - CPU, memory, disk I/O come from the monitor subsystem's cgroup reader (`monitor.CollectResourceStats`).
  - Network counters come from the `incus list` state (summed over non-loopback interfaces).
  - Per-process CPU/RSS from `/proc/<pid>/stat` + `/proc/<pid>/statm`.
- **Process discovery** reuses `monitor.CollectProcessStats`, which already enumerates a container's PIDs securely via host cgroup membership (an attacker inside the container can't hide processes). Those are host PIDs — hence directly `sudo kill`-able.
- CPU% is aggregate across host cores (a container pegging 2 cores reads ~200%, same convention as `top`). Rate deltas are clamped ≥0 so a container restart never prints a negative spike.

## Tests

- Stats collection sits behind package-level `var` seams (the repo's established test pattern), so the sampling/sort/format logic is unit-tested with canned data — no live Incus or cgroups needed.
- Covers: CPU%-from-two-samples + running-only filtering, per-key sorting (cpu/mem/disk/net) with tie-breaks, loopback-excluded net summing, the `/proc/<pid>/stat` parser (including a comm field containing spaces and parens), rate clamping, and formatting helpers.
- The `/proc` readers were also verified against a live PID (non-zero jiffies + RSS).
- `go build ./...`, `go vet`, `gofmt`, and the full `go test ./...` suite pass.

## Notes / possible follow-ups

- `USER_HZ` is assumed to be 100 (fixed on all mainstream Linux; Go has no portable `sysconf(_SC_CLK_TCK)`) — documented at the constant.
- No `--watch`/TUI by design (kept to a one-shot list); easy to add later on top of `sampleContainerRows`.