### PR TITLE
fix(shell): honor [container] storage_pool in coi shell (#726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- **`coi shell` now honors `[container] storage_pool` (#726)** — only `coi run` and `coi build` read it; `coi shell` (the primary interactive command) dropped it silently and always landed on the Incus default pool, because `session.SetupOptions` had no `StoragePool` field and `session.Setup()`'s `incus init` never passed `-s <pool>`. The pool is now threaded through the shell path (and validated up front like `coi run`), so interactive sessions land on the configured pool. Covered by an ephemeral shell integration test.
+
 - **Masked the container's `udisks2` service (#706, thanks @blegat)** — a running coi container no longer blocks host suspend / lid-close.
 
 - **`install.sh` initializes a fresh Incus correctly (#703)** — it no longer skips `incus admin init` on real hosts, which left the default profile unusable.

--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -317,6 +317,12 @@ func (a *App) configureSessionPhase(cmd *cobra.Command, s *shellState) session.P
 			if err := CheckAndReportStaleBase(a.cfg, img); err != nil {
 				return nil, err
 			}
+			// Validate the configured storage pool up front (matching coi run),
+			// so a typo fails clearly instead of the container silently landing
+			// on the default pool (#726).
+			if err := container.ValidateStoragePool(a.cfg.Container.StoragePool); err != nil {
+				return nil, err
+			}
 
 			// Build config-derived options.
 			networkConfig := a.cfg.Network
@@ -364,6 +370,7 @@ func (a *App) configureSessionPhase(cmd *cobra.Command, s *shellState) session.P
 				WorkspacePath:         s.absWorkspace,
 				SessionName:           a.sessionName(),
 				Image:                 img,
+				StoragePool:           a.cfg.Container.StoragePool,
 				Persistent:            a.persistent,
 				ResumeFromID:          resumeID,
 				Slot:                  slotNum,

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -31,7 +31,8 @@ type SetupOptions struct {
 	WorkspacePath         string
 	SessionName           string // [container] session_name: keys the session identity instead of the workspace path when set
 	Image                 string
-	Persistent            bool // Keep container between sessions (don't delete on cleanup)
+	StoragePool           string // [container] storage_pool: Incus storage pool for the container (empty = Incus default pool)
+	Persistent            bool   // Keep container between sessions (don't delete on cleanup)
 	ResumeFromID          string
 	Slot                  int
 	MountConfig           *MountConfig      // Multi-mount support
@@ -453,8 +454,15 @@ func Setup(ctx context.Context, opts SetupOptions) (*SetupResult, error) {
 	// (e.g., via 'sudo shutdown 0' from within). Cleanup will delete unless persistent mode is configured.
 	if !skipLaunch {
 		opts.Logger(fmt.Sprintf("Creating container from %s...", image))
-		// Create container without starting it (init)
-		if err := container.IncusExec("init", image, result.ContainerName); err != nil {
+		// Create container without starting it (init). Honor the configured
+		// storage pool ([container] storage_pool) the same way the run pipeline
+		// does via `-s <pool>` — otherwise `coi shell` silently lands on the
+		// Incus default pool (#726). An empty pool means "use the default".
+		initArgs := []string{"init", image, result.ContainerName}
+		if opts.StoragePool != "" {
+			initArgs = append(initArgs, "-s", opts.StoragePool)
+		}
+		if err := container.IncusExec(initArgs...); err != nil {
 			return nil, fmt.Errorf("failed to create container: %w", err)
 		}
 

--- a/tests/shell/ephemeral/storage_pool_ephemeral.py
+++ b/tests/shell/ephemeral/storage_pool_ephemeral.py
@@ -1,0 +1,105 @@
+"""
+Test that `coi shell` honours [container] storage_pool (#726).
+
+`coi run` and `coi build` honored `[container] storage_pool`, but `coi shell` -
+the primary interactive command - dropped it and always landed the container on
+the Incus default pool (session.SetupOptions had no StoragePool field, so
+phases_shell never threaded it into `incus init`).
+
+This launches an ephemeral shell session with `storage_pool` pointed at a
+freshly-created pool and asserts the container's root device lives on THAT pool,
+not the default. It fails before the fix (container on the default pool) and
+passes after.
+"""
+
+import json
+import os
+import subprocess
+import time
+
+import pytest
+from pexpect import EOF, TIMEOUT
+
+from support.helpers import (
+    calculate_container_name,
+    create_storage_pool,
+    delete_storage_pool,
+    is_incus_permission_error,
+    spawn_coi,
+    wait_for_container_ready,
+)
+
+
+def _container_pool(coi_binary, workspace_dir, container_name):
+    """Return the storage pool of container_name via `coi list --format json`."""
+    result = subprocess.run(
+        [coi_binary, "list", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=workspace_dir,
+    )
+    assert result.returncode == 0, f"coi list failed: {result.stderr}"
+    data = json.loads(result.stdout)
+    for container in data.get("active_containers", []):
+        if container.get("name") == container_name:
+            return container.get("pool")
+    return None
+
+
+def test_shell_honors_storage_pool_ephemeral(coi_binary, cleanup_containers, workspace_dir):
+    """coi shell should place the container on the configured storage_pool."""
+    pool_name = f"coi-test-shellpool-{os.urandom(4).hex()}"
+    ok, err = create_storage_pool(pool_name)
+    if not ok:
+        if is_incus_permission_error(err):
+            pytest.skip(f"No permission to create storage pool {pool_name}: {err}")
+        pytest.fail(f"Failed to create temp pool {pool_name}: {err}")
+
+    container_name = calculate_container_name(workspace_dir, 1)
+
+    # Project config pointing this workspace's containers at the temp pool.
+    coi_dir = os.path.join(workspace_dir, ".coi")
+    os.makedirs(coi_dir, exist_ok=True)
+    with open(os.path.join(coi_dir, "config.toml"), "w") as handle:
+        handle.write(f'[container]\nimage = "coi-default"\nstorage_pool = "{pool_name}"\n')
+
+    child = None
+    try:
+        child = spawn_coi(
+            coi_binary,
+            ["shell", f"--workspace={workspace_dir}"],
+            cwd=workspace_dir,
+            env={"COI_USE_DUMMY": "1"},
+            timeout=120,
+        )
+        # Container is created during setup, before the session starts.
+        wait_for_container_ready(child, timeout=90)
+        time.sleep(2)
+
+        pool = _container_pool(coi_binary, workspace_dir, container_name)
+        assert pool == pool_name, (
+            f"coi shell should place the container on '{pool_name}', "
+            f"but it landed on '{pool}' (#726)"
+        )
+    finally:
+        if child is not None:
+            try:
+                child.send("exit")
+                time.sleep(0.3)
+                child.send("\x0d")
+                child.expect(EOF, timeout=30)
+            except (TIMEOUT, Exception):
+                pass
+            try:
+                child.close(force=True)
+            except Exception:
+                pass
+        time.sleep(2)
+        subprocess.run(
+            [coi_binary, "container", "delete", container_name, "--force"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        delete_storage_pool(pool_name)


### PR DESCRIPTION
Closes #726.

## Bug

`[container] storage_pool` was honored by `coi run` and `coi build` but **silently dropped by `coi shell`** — the primary interactive command — so every interactive container landed on the Incus default pool regardless of config, with no error or warning.

Root cause (exactly as reported): `session.SetupOptions` had no `StoragePool` field, and `session.Setup()`'s container creation ran a bare `incus init image name` with no `-s <pool>`. `phases_shell.go` built the `SetupOptions` with the config in scope but had nowhere to put the pool. `coi run` threads `a.cfg.Container.StoragePool` into `launchOrReuseContainer` → `incus init ... -s <pool>`; `coi shell` did not.

## Fix

- Add `StoragePool` to `session.SetupOptions` and pass `-s <pool>` on `incus init` when set (empty = Incus default), matching the run pipeline.
- Set `StoragePool` from `a.cfg.Container.StoragePool` in `phases_shell`'s `configureSessionPhase`, and **validate it up front** (`container.ValidateStoragePool`) like `coi run` already does — so a typo fails clearly instead of silently falling back.

## Test (demonstrates the bug)

`tests/shell/ephemeral/storage_pool_ephemeral.py` creates a fresh storage pool, points `[container] storage_pool` at it, launches an **ephemeral shell session** (dummy tool), and asserts the container's root device lives on that pool via `coi list --format json`. It **fails before this fix** (container on the default pool) and **passes after**. Runs in the existing `shell-ephemeral` CI group; uses the existing `create_storage_pool`/`delete_storage_pool` helpers and skips cleanly without Incus admin rights.

## Verification

- `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/session/... ./internal/cli/...` all pass.
- New Python test is ruff-clean.

## Note

The underlying reason this bug exists is that `coi shell` (via `session.Setup()`) and `coi run` (hand-rolled in `phases_run.go`) are **two parallel container-creation paths**, so container-placement/config settings can drift between them. I'm auditing for other instances of the same class and will report separately.