### PR TITLE
fix(shell): honor storage_pool config in coi shell

### DIFF
--- a/internal/cli/phases_shell.go
+++ b/internal/cli/phases_shell.go
@@ -139,6 +139,9 @@ func (a *App) validateEnvPhase(cmd *cobra.Command, s *shellState) session.Phase 
 			if warning := container.CheckKernelVersion(); warning != "" {
 				fmt.Fprintf(os.Stderr, "%s\n", warning)
 			}
+			if err := container.ValidateStoragePool(a.cfg.Container.StoragePool); err != nil {
+				return nil, err
+			}
 			return nil, nil
 		},
 	}
@@ -364,6 +367,7 @@ func (a *App) configureSessionPhase(cmd *cobra.Command, s *shellState) session.P
 				WorkspacePath:         s.absWorkspace,
 				SessionName:           a.sessionName(),
 				Image:                 img,
+				StoragePool:           a.cfg.Container.StoragePool,
 				Persistent:            a.persistent,
 				ResumeFromID:          resumeID,
 				Slot:                  slotNum,

--- a/internal/session/setup.go
+++ b/internal/session/setup.go
@@ -31,7 +31,8 @@ type SetupOptions struct {
 	WorkspacePath         string
 	SessionName           string // [container] session_name: keys the session identity instead of the workspace path when set
 	Image                 string
-	Persistent            bool // Keep container between sessions (don't delete on cleanup)
+	StoragePool           string // [container] storage_pool: Incus storage pool to launch on (empty = Incus default)
+	Persistent            bool   // Keep container between sessions (don't delete on cleanup)
 	ResumeFromID          string
 	Slot                  int
 	MountConfig           *MountConfig      // Multi-mount support
@@ -453,8 +454,14 @@ func Setup(ctx context.Context, opts SetupOptions) (*SetupResult, error) {
 	// (e.g., via 'sudo shutdown 0' from within). Cleanup will delete unless persistent mode is configured.
 	if !skipLaunch {
 		opts.Logger(fmt.Sprintf("Creating container from %s...", image))
-		// Create container without starting it (init)
-		if err := container.IncusExec("init", image, result.ContainerName); err != nil {
+		// Create container without starting it (init). An empty StoragePool
+		// falls back to Incus's default pool (whatever the `default` profile
+		// points at), matching the run/build pipeline (#726).
+		initArgs := []string{"init", image, result.ContainerName}
+		if opts.StoragePool != "" {
+			initArgs = append(initArgs, "-s", opts.StoragePool)
+		}
+		if err := container.IncusExec(initArgs...); err != nil {
 			return nil, fmt.Errorf("failed to create container: %w", err)
 		}
 

--- a/internal/session/storage_pool_integration_test.go
+++ b/internal/session/storage_pool_integration_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/container"
+)
+
+// secondStoragePoolForTest returns a storage pool other than "default" so the
+// test can prove StoragePool actually changes which pool the container lands
+// on (as opposed to a bug that silently keeps using the default pool either
+// way). Skips if none is configured locally.
+func secondStoragePoolForTest(t *testing.T) string {
+	t.Helper()
+	pools, err := container.ListStoragePools()
+	if err != nil {
+		t.Fatalf("failed to list storage pools: %v", err)
+	}
+	for _, p := range pools {
+		if p.Name != "default" {
+			return p.Name
+		}
+	}
+	t.Skip("no non-default storage pool configured; create one (e.g. `incus storage create btrfs-pool btrfs`) to run this test")
+	return ""
+}
+
+// TestSetup_HonorsStoragePool verifies that SetupOptions.StoragePool is
+// threaded through Setup() into the actual container launch (issue #726:
+// `coi shell` silently ignored [container] storage_pool while `coi
+// run`/`coi build` honored it).
+func TestSetup_HonorsStoragePool(t *testing.T) {
+	skipUnlessContextFileTestable(t)
+	pool := secondStoragePoolForTest(t)
+
+	// Match container.CodeUID to the host UID for the duration of this test so
+	// Setup()'s raw.idmap decision (host UID != code UID) doesn't kick in —
+	// that path is unrelated to storage pool selection and, combined with
+	// security.idmap.isolated on this host, hits an unrelated newuidmap/subuid
+	// limitation that would otherwise make every session.Setup() call fail
+	// here regardless of which pool is requested.
+	origUID := container.CodeUID
+	container.Configure(container.IncusProject, container.CodeUser, os.Getuid())
+	t.Cleanup(func() { container.Configure(container.IncusProject, container.CodeUser, origUID) })
+
+	opts := SetupOptions{
+		WorkspacePath: t.TempDir(),
+		Image:         "coi-default",
+		StoragePool:   pool,
+		Logger:        func(msg string) { t.Logf("[setup] %s", msg) },
+	}
+
+	result, err := Setup(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = result.Manager.Stop(true)
+		_ = result.Manager.Delete(true)
+	})
+
+	// The "root" disk device is only settable on the instance when it
+	// overrides the profile's pool (as -s does on the CLI); when a container
+	// lands on the profile's pool instead, "config device get" errors since
+	// there is no instance-level override to read. `incus list -c b` reports
+	// the effective pool either way.
+	out, err := container.IncusOutput("list", "^"+result.ContainerName+"$", "--format=csv", "--columns=nb")
+	if err != nil {
+		t.Fatalf("failed to read container's storage pool: %v", err)
+	}
+	fields := strings.SplitN(strings.TrimSpace(out), ",", 2)
+	if len(fields) != 2 {
+		t.Fatalf("unexpected `incus list` output: %q", out)
+	}
+	if got := fields[1]; got != pool {
+		t.Errorf("container launched on storage pool %q, want %q", got, pool)
+	}
+}

--- a/tests/cli/test_storage_pool_validation_shell_missing.py
+++ b/tests/cli/test_storage_pool_validation_shell_missing.py
@@ -1,0 +1,45 @@
+"""
+Test storage pool validation - non-existent pool, `coi shell` (#726).
+
+`coi shell` used to ignore [container] storage_pool entirely, only ever
+launching on whichever pool the Incus `default` profile points at. It must
+fail before any container work begins, just like `coi run`/`coi build`, with
+the same actionable `incus storage create` example.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_shell_missing_storage_pool_fails_with_actionable_error(coi_binary, workspace_dir):
+    """coi shell with a non-existent pool errors with copy-pasteable fix."""
+    profile_dir = Path(workspace_dir) / ".coi" / "profiles" / "missingpool"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "config.toml").write_text(
+        '[container]\nimage = "coi-default"\nstorage_pool = "this-pool-does-not-exist-xyz123"\n'
+    )
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "shell",
+            "--debug",
+            "--profile",
+            "missingpool",
+            "--workspace",
+            workspace_dir,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    assert result.returncode != 0, f"Should fail with non-existent pool. stdout: {result.stdout}"
+    combined = result.stdout + result.stderr
+    assert "this-pool-does-not-exist-xyz123" in combined, (
+        f"Error should reference the missing pool name. Got:\n{combined}"
+    )
+    assert "incus storage create" in combined, (
+        f"Error should include 'incus storage create' example. Got:\n{combined}"
+    )


### PR DESCRIPTION
## Summary

- Fixes #726: `coi shell` silently ignored `[container] storage_pool`, always launching on whichever pool the Incus `default` profile points at. `coi run`/`coi build` already honored it via `launchOrReuseContainer`; this brings `shell` to parity.
- Adds `StoragePool` to `session.SetupOptions` and threads it into the `incus init -s <pool>` call in `session.Setup()`.
- Wires `a.cfg.Container.StoragePool` into `SetupOptions{}` in `phases_shell.go`'s `configureSessionPhase`.
- Validates the pool up front in `validateEnvPhase` (same `container.ValidateStoragePool` check `run` already does), so a bad pool fails fast with an actionable `incus storage create` error instead of failing deep inside Incus mid-launch.

## Test plan

- [x] New Go integration test `TestSetup_HonorsStoragePool` (`internal/session/storage_pool_integration_test.go`): launches a real container via `session.Setup()` with `StoragePool` set and confirms it lands on that pool (checked via `incus list -c b`). Confirmed RED on unpatched master, GREEN with the fix.
- [x] New Python CLI test `tests/cli/test_storage_pool_validation_shell_missing.py`: mirrors the existing `run` validation test but for `shell`, confirming it fails in <0.1s for a nonexistent pool (proving validation fires before any container work). Confirmed RED on unpatched master, GREEN with the fix.
- [x] Manual end-to-end: `coi shell --debug` with `storage_pool = "btrfs-pool"` in a throwaway workspace launched the container directly on `btrfs-pool` (verified via `incus list`), not `default`.
- [x] Regression: `coi run` and `coi build` still work against the same config.
- [x] `go build ./...` / `go vet ./...` clean.
- [x] Full `internal/session` Go suite passes, aside from two pre-existing failures confirmed to reproduce identically on unmodified master (a codex-config trailing-newline seeding bug, and a UID-namespace-isolation race tied to a specific host UID) — unrelated to this change.
- [x] `tests/cli/test_storage_pool_validation_*.py` all pass.

https://claude.ai/code/session_01Qr1Ckjh7ybT7FSWjC27Jvh