### PR TITLE
test(storage-pool): add shell storage_pool coverage from #730 (#726)

### DIFF
--- a/internal/session/storage_pool_integration_test.go
+++ b/internal/session/storage_pool_integration_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mensfeld/code-on-incus/internal/container"
+)
+
+// secondStoragePoolForTest returns a storage pool other than "default" so the
+// test can prove StoragePool actually changes which pool the container lands
+// on (as opposed to a bug that silently keeps using the default pool either
+// way). Skips if none is configured locally.
+func secondStoragePoolForTest(t *testing.T) string {
+	t.Helper()
+	pools, err := container.ListStoragePools()
+	if err != nil {
+		t.Fatalf("failed to list storage pools: %v", err)
+	}
+	for _, p := range pools {
+		if p.Name != "default" {
+			return p.Name
+		}
+	}
+	t.Skip("no non-default storage pool configured; create one (e.g. `incus storage create btrfs-pool btrfs`) to run this test")
+	return ""
+}
+
+// TestSetup_HonorsStoragePool verifies that SetupOptions.StoragePool is
+// threaded through Setup() into the actual container launch (issue #726:
+// `coi shell` silently ignored [container] storage_pool while `coi
+// run`/`coi build` honored it).
+func TestSetup_HonorsStoragePool(t *testing.T) {
+	skipUnlessContextFileTestable(t)
+	pool := secondStoragePoolForTest(t)
+
+	// Match container.CodeUID to the host UID for the duration of this test so
+	// Setup()'s raw.idmap decision (host UID != code UID) doesn't kick in —
+	// that path is unrelated to storage pool selection and, combined with
+	// security.idmap.isolated on this host, hits an unrelated newuidmap/subuid
+	// limitation that would otherwise make every session.Setup() call fail
+	// here regardless of which pool is requested.
+	origUID := container.CodeUID
+	container.Configure(container.IncusProject, container.CodeUser, os.Getuid())
+	t.Cleanup(func() { container.Configure(container.IncusProject, container.CodeUser, origUID) })
+
+	opts := SetupOptions{
+		WorkspacePath: t.TempDir(),
+		Image:         "coi-default",
+		StoragePool:   pool,
+		Logger:        func(msg string) { t.Logf("[setup] %s", msg) },
+	}
+
+	result, err := Setup(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = result.Manager.Stop(true)
+		_ = result.Manager.Delete(true)
+	})
+
+	// The "root" disk device is only settable on the instance when it
+	// overrides the profile's pool (as -s does on the CLI); when a container
+	// lands on the profile's pool instead, "config device get" errors since
+	// there is no instance-level override to read. `incus list -c b` reports
+	// the effective pool either way.
+	out, err := container.IncusOutput("list", "^"+result.ContainerName+"$", "--format=csv", "--columns=nb")
+	if err != nil {
+		t.Fatalf("failed to read container's storage pool: %v", err)
+	}
+	fields := strings.SplitN(strings.TrimSpace(out), ",", 2)
+	if len(fields) != 2 {
+		t.Fatalf("unexpected `incus list` output: %q", out)
+	}
+	if got := fields[1]; got != pool {
+		t.Errorf("container launched on storage pool %q, want %q", got, pool)
+	}
+}

--- a/tests/cli/test_storage_pool_validation_shell_missing.py
+++ b/tests/cli/test_storage_pool_validation_shell_missing.py
@@ -1,0 +1,45 @@
+"""
+Test storage pool validation - non-existent pool, `coi shell` (#726).
+
+`coi shell` used to ignore [container] storage_pool entirely, only ever
+launching on whichever pool the Incus `default` profile points at. It must
+fail before any container work begins, just like `coi run`/`coi build`, with
+the same actionable `incus storage create` example.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_shell_missing_storage_pool_fails_with_actionable_error(coi_binary, workspace_dir):
+    """coi shell with a non-existent pool errors with copy-pasteable fix."""
+    profile_dir = Path(workspace_dir) / ".coi" / "profiles" / "missingpool"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "config.toml").write_text(
+        '[container]\nimage = "coi-default"\nstorage_pool = "this-pool-does-not-exist-xyz123"\n'
+    )
+
+    result = subprocess.run(
+        [
+            coi_binary,
+            "shell",
+            "--debug",
+            "--profile",
+            "missingpool",
+            "--workspace",
+            workspace_dir,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=workspace_dir,
+    )
+
+    assert result.returncode != 0, f"Should fail with non-existent pool. stdout: {result.stdout}"
+    combined = result.stdout + result.stderr
+    assert "this-pool-does-not-exist-xyz123" in combined, (
+        f"Error should reference the missing pool name. Got:\n{combined}"
+    )
+    assert "incus storage create" in combined, (
+        f"Error should include 'incus storage create' example. Got:\n{combined}"
+    )


### PR DESCRIPTION
The `storage_pool` fix for #726 already landed in **#727** (merged). **#730** (by @technicalpickles) is a duplicate of that same fix, but it carried **two tests #727 didn't have**. This cherry-picks just those tests so their coverage isn't lost when #730 is closed as a duplicate.

- **`internal/session/storage_pool_integration_test.go`** — `TestSetup_HonorsStoragePool` drives `session.Setup` with a non-default `StoragePool` and asserts the container's effective pool via `incus list -c b`. Skips when there's no non-default pool / no Incus (like the other Go integration tests).
- **`tests/cli/test_storage_pool_validation_shell_missing.py`** — asserts `coi shell` with a non-existent pool fails early with the actionable `incus storage create` hint (validation added in #727).

No production code — tests only, against the already-merged fix. `go vet`/`go test` (skips without Incus), `gofmt`, and `ruff` all clean. Credit to @technicalpickles (co-authored).

Closes #730 as duplicate.