### PR TITLE
refactor(monitor): rename containerRootCgroupPath -> stripSystemdScopeSuffix

### DIFF
--- a/internal/monitor/cgroup.go
+++ b/internal/monitor/cgroup.go
@@ -167,16 +167,22 @@ func findCgroupPathViaIncus(ctx context.Context, containerName string) (string, 
 	return "", fmt.Errorf("could not parse cgroup path from %s", cgroupFile)
 }
 
-// containerRootCgroupPath strips a trailing systemd scope/service segment
-// (e.g. "/init.scope") from a cgroup path so reads hit the container's
+// stripSystemdScopeSuffix removes a single trailing systemd scope/service
+// segment (e.g. "/init.scope") from a cgroup path, so reads hit the container's
 // top-level cgroup, whose cgroup v2 counters (memory.current, cpu.stat,
 // io.stat) aggregate the whole process tree. GetCgroupPath's incus-info
 // fallback returns the init process's own sub-scope, which accounts for only
 // systemd PID 1 — reading resource stats there under-reports the container by
-// orders of magnitude (#top-mem). A path that isn't a scope/service is a
-// container root already and is returned unchanged. Matches the suffix strip
-// collectProcessesViaHostProc uses so both views agree on the container root.
-func containerRootCgroupPath(cgroupPath string) string {
+// orders of magnitude (#top-mem).
+//
+// It strips exactly ONE leaf, which is all GetCgroupPath ever produces: either
+// the container root itself, or "<root>/init.scope". It is NOT a general
+// container-root resolver — a deeper path like "<root>/system.slice/foo.service"
+// yields "<root>/system.slice", not the root. Callers rely on the ≤1-level
+// contract. A path whose leaf is neither .scope nor .service is returned
+// unchanged. collectProcessesViaHostProc uses the same strip so both views
+// agree on the container root.
+func stripSystemdScopeSuffix(cgroupPath string) string {
 	base := filepath.Base(cgroupPath)
 	if strings.HasSuffix(base, ".scope") || strings.HasSuffix(base, ".service") {
 		return filepath.Dir(cgroupPath)
@@ -192,7 +198,7 @@ func CollectResourceStats(ctx context.Context, containerName string) (ResourceSt
 	}
 	// Read from the container's top-level cgroup, not init.scope, so the v2
 	// counters aggregate every process in the container (#top-mem).
-	cgroupPath := containerRootCgroupPath(rawPath)
+	cgroupPath := stripSystemdScopeSuffix(rawPath)
 
 	stats := ResourceStats{}
 

--- a/internal/monitor/cgroup_test.go
+++ b/internal/monitor/cgroup_test.go
@@ -146,26 +146,28 @@ func TestWellKnownCgroupPaths_PayloadBeforeMonitor(t *testing.T) {
 	}
 }
 
-// containerRootCgroupPath must strip the init.scope (or any systemd
+// stripSystemdScopeSuffix must strip the init.scope (or any systemd
 // scope/service) leaf that GetCgroupPath's incus-info fallback returns, so
 // resource stats read the container root whose v2 counters aggregate the whole
-// tree — not init.scope, which only accounts for systemd PID 1. A path that is
-// already a container root must be returned unchanged.
-func TestContainerRootCgroupPath(t *testing.T) {
+// tree — not init.scope, which only accounts for systemd PID 1. It strips a
+// single leaf (the ≤1-level contract), so a deeper path yields its parent, not
+// the container root; a path whose leaf is neither .scope nor .service is
+// returned unchanged.
+func TestStripSystemdScopeSuffix(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{"init.scope stripped", "/sys/fs/cgroup/incus.payload/coi-abc-1/init.scope", "/sys/fs/cgroup/incus.payload/coi-abc-1"},
-		{"service stripped", "/sys/fs/cgroup/lxc.payload/coi-abc-1/system.slice/foo.service", "/sys/fs/cgroup/lxc.payload/coi-abc-1/system.slice"},
+		{"single leaf only (deeper path not fully resolved)", "/sys/fs/cgroup/lxc.payload/coi-abc-1/system.slice/foo.service", "/sys/fs/cgroup/lxc.payload/coi-abc-1/system.slice"},
 		{"already root unchanged", "/sys/fs/cgroup/incus.payload/coi-abc-1", "/sys/fs/cgroup/incus.payload/coi-abc-1"},
 		{"monitor root unchanged", "/sys/fs/cgroup/incus.monitor/coi-abc-1", "/sys/fs/cgroup/incus.monitor/coi-abc-1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := containerRootCgroupPath(tc.in); got != tc.want {
-				t.Errorf("containerRootCgroupPath(%q) = %q, want %q", tc.in, got, tc.want)
+			if got := stripSystemdScopeSuffix(tc.in); got != tc.want {
+				t.Errorf("stripSystemdScopeSuffix(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/monitor/process.go
+++ b/internal/monitor/process.go
@@ -46,9 +46,9 @@ func collectProcessesViaHostProc(ctx context.Context, containerName string) ([]P
 
 	// GetCgroupPath may return the init process's sub-scope (e.g. /init.scope)
 	// when falling back to incus info. Strip it so the prefix match covers all
-	// processes in the container, not just init.scope — same container-root
-	// resolution CollectResourceStats uses so both views agree.
-	cgroupPath := containerRootCgroupPath(rawPath)
+	// processes in the container, not just init.scope — same strip
+	// CollectResourceStats uses so both views agree on the container root.
+	cgroupPath := stripSystemdScopeSuffix(rawPath)
 
 	// /proc/<pid>/cgroup lines use paths relative to /sys/fs/cgroup.
 	// e.g. "0::/incus.monitor/coi-abc123-1"


### PR DESCRIPTION
Addresses finding #3 (naming) from the #737 review.

## Problem

`containerRootCgroupPath` strips a **single** trailing systemd scope/service leaf, but its name implies it resolves the container root for any input. For a deeper path like `<root>/system.slice/foo.service` it returns `<root>/system.slice` — not the root — so the name over-promises and could mislead a future caller into trusting it for arbitrary depth.

## Fix

Pure rename to `stripSystemdScopeSuffix`, which describes exactly what it does, plus a doc comment that states the **≤1-level contract** explicitly: `GetCgroupPath` only ever yields `<root>` or `<root>/init.scope`, which is why single-leaf stripping is correct for all real inputs. Both call sites (`CollectResourceStats`, `collectProcessesViaHostProc`) and the unit test (now `TestStripSystemdScopeSuffix`, with a case renamed to document that a deeper path is not fully resolved) are updated.

A loop-strip was considered and rejected: it wouldn't fully resolve deeper paths anyway (`.slice` intermediates aren't scope/service), so an honest name beats a more complex helper that still can't deliver on the old name's promise.

**No behavior change.** `go build`, `go test ./internal/monitor/ ./internal/cli/`, `gofumpt -l`, `golangci-lint run` all clean. No changelog entry (internal rename, no user-facing change).