### PR TITLE
docs(agents): document omp (Oh My Pi) tool support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - **OpenAI Codex CLI is now a supported tool (#698, thanks @breml)** — `[tool] name = "codex"` launches straight into codex like the other tools, with per-tool `model`/`reasoning_effort`. Opt it into the image with `[container.build] agents = ["claude", "codex"]`.
 
+- **Oh My Pi (`omp`) is now a supported tool (#743, thanks @VIVAAN-DHAWAN)** — `[tool] name = "omp"` launches straight into [omp](https://github.com/can1357/oh-my-pi) like the other tools. Following the `pi` integration, session data is redirected to the workspace mount (`OMP_SESSION_DIR`) to survive ephemeral container recreation, and the sandbox context is wired into omp's config dir (`~/.omp/APPEND_SYSTEM.md`). Opt it into the image with `[container.build] agents = ["claude", "omp"]`. Note: the session-dir and system-prompt mechanisms are modeled on `pi`'s and should be validated against the omp version you run.
+
 - **Per-host ports on `[[network.hosts]]`** — scope a single LAN service to specific ports (`ports = [443]`) while the rest of the internet stays open; also available at runtime via `coi hosts add … --ports`.
 
 - **`[git] readonly = true`** — lock the container's git commit identity read-only so the agent can't overwrite who commits are authored by.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Give every AI coding agent its own machine - with active defense.**
 
-`coi` runs your AI coding tool (Claude Code, Codex, opencode, pi) inside its own isolated Linux system - a full-OS container with root access, systemd, Docker, and the freedom to install anything. The agent works like it would on a real server - but it can't touch your host, can't see your credentials, and if it does something dangerous, `coi` pauses or kills the container on its own.
+`coi` runs your AI coding tool (Claude Code, Codex, opencode, pi, omp) inside its own isolated Linux system - a full-OS container with root access, systemd, Docker, and the freedom to install anything. The agent works like it would on a real server - but it can't touch your host, can't see your credentials, and if it does something dangerous, `coi` pauses or kills the container on its own.
 
 One command drops you into a coding session. Your project is mounted, file permissions just work, and your SSH keys, tokens, and environment variables never enter the container unless you explicitly say so.
 
@@ -100,12 +100,12 @@ It overrides a weaker global config (a global `mode = "open"` still becomes rest
 
 ## Supported AI tools
 
-**Claude Code** (default) · **Codex CLI** · **opencode** · **pi** - pick one in config or a profile:
+**Claude Code** (default) · **Codex CLI** · **opencode** · **pi** · **omp** (Oh My Pi) - pick one in config or a profile:
 
 ```toml
 # ~/.coi/config.toml or ./.coi/config.toml
 [tool]
-name = "claude"              # or "codex", "opencode", "pi"
+name = "claude"              # or "codex", "opencode", "pi", "omp"
 permission_mode = "bypass"   # run autonomously ("bypass") or ask first ("interactive")
 ```
 


### PR DESCRIPTION
Follow-up to #743, which added `omp` (Oh My Pi) as a supported coding agent but did not update the user-facing docs.

### Changes
- **README.md** — list `omp` in the intro tagline, the "Supported AI tools" section (`**omp** (Oh My Pi)`), and the `[tool] name` config comment.
- **CHANGELOG.md** — new entry under `0.12.0 (Unreleased)` → New Features, styled after the Codex entry: config usage, the opt-in `[container.build] agents = ["claude", "omp"]`, and credit to @VIVAAN-DHAWAN (#743).

### Note
The changelog wording for the session-dir (`OMP_SESSION_DIR`) and system-prompt (`~/.omp/APPEND_SYSTEM.md`) mechanisms is intentionally hedged ("modeled on `pi`'s, validate against the omp version you run"). Those two behaviors were copied verbatim from the `pi` integration and are **not confirmed against omp's own documentation** — omp's README documents `~/.omp/` but not an `OMP_SESSION_DIR` env var or an `APPEND_SYSTEM.md` append mechanism. Worth verifying against a live omp before treating them as guaranteed.

Docs-only; no code changes.