### PR TITLE
refactor(cli): share env-assembly + signal-teardown between shell and run

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/mensfeld/code-on-incus/internal/alias"
+	"github.com/mensfeld/code-on-incus/internal/session"
 )
 
 // confirmYN prints prompt and reads a line from stdin, returning true only when
@@ -42,4 +46,57 @@ func resolveNameOrAlias(nameOrAlias string) (string, error) {
 // func(string): it writes msg to stderr with a trailing newline.
 func stderrLogFn(msg string) {
 	fmt.Fprintf(os.Stderr, "%s\n", msg)
+}
+
+// applyConfigEnv overlays the three config-sourced environment layers onto env
+// in increasing-priority (last-wins) order: [defaults].environment, then
+// forward_env (host values, warning on an unset var), then env_commands
+// (freshly minted per session, fatal on error). Shared by coi shell
+// (buildContainerEnv) and coi run (appendEnvArgs) so the precedence and the
+// unset-var warning can't drift between the two launch paths.
+func (a *App) applyConfigEnv(env map[string]string) error {
+	// Static environment from config (defaults.environment + profile environment)
+	for k, v := range a.cfg.Defaults.Environment {
+		env[k] = v
+	}
+	// Resolve forward_env from config, look up host values
+	for _, name := range a.cfg.Defaults.ForwardEnv {
+		if val, ok := os.LookupEnv(name); ok {
+			env[name] = val
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: forward_env variable %q is not set on host, skipping\n", name)
+		}
+	}
+	// Command-sourced env vars (highest precedence — freshly minted per session).
+	envCommandValues, err := a.resolveEnvCommands()
+	if err != nil {
+		return err
+	}
+	for k, v := range envCommandValues {
+		env[k] = v
+	}
+	return nil
+}
+
+// runPipelineWithSignals installs a SIGINT/SIGTERM handler that triggers
+// pipeline.Teardown immediately — so cleanup runs even while a blocking incus
+// exec ignores ctx cancellation — then runs the pipeline. A dedicated sigChan
+// (not ctx.Done) avoids the non-determinism of both firing at once; Teardown is
+// idempotent so the caller's own `defer pipeline.Teardown()` stays safe. Shared
+// by coi shell and coi run.
+func runPipelineWithSignals(ctx context.Context, pipeline *session.Pipeline, phases ...session.Phase) error {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-sigChan:
+			fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
+			pipeline.Teardown()
+		case <-done:
+		}
+	}()
+	return pipeline.Run(ctx, phases...)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -144,25 +144,7 @@ func (a *App) runCommand(cmd *cobra.Command, args []string) error {
 	pipeline := &session.Pipeline{}
 	defer pipeline.Teardown()
 
-	// Signal handler: trigger cleanup immediately on SIGINT while incus exec blocks.
-	// Uses a dedicated sigChan (not ctx.Done) to avoid non-determinism when both fire
-	// simultaneously. pipeline.Teardown is idempotent so the deferred call above is safe.
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigChan)
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		select {
-		case <-sigChan:
-			fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
-			pipeline.Teardown()
-		case <-done:
-		}
-	}()
-
-	return pipeline.Run(
-		ctx,
+	return runPipelineWithSignals(ctx, pipeline,
 		a.validateEnvRunPhase(s),
 		a.launchContainerRunPhase(s),
 		a.configureContainerRunPhase(s),
@@ -350,28 +332,10 @@ func (a *App) appendEnvArgs(incusArgs []string, tz string, socketEnv map[string]
 		env[name] = path
 	}
 
-	// Static environment from config (defaults.environment + profile environment)
-	for k, v := range a.cfg.Defaults.Environment {
-		env[k] = v
-	}
-
-	// Resolve forward_env from config, look up host values
-	for _, name := range a.cfg.Defaults.ForwardEnv {
-		if val, ok := os.LookupEnv(name); ok {
-			env[name] = val
-		} else {
-			fmt.Fprintf(os.Stderr, "Warning: forward_env variable %q is not set on host, skipping\n", name)
-		}
-	}
-
-	// Command-sourced env vars (highest precedence — freshly minted per session).
-	// A failing env_command is fatal: don't launch a half-credentialed session.
-	envCommandValues, err := a.resolveEnvCommands()
-	if err != nil {
+	// Apply the config-sourced env layers (defaults.environment -> forward_env ->
+	// env_commands, last-wins), shared with coi shell's buildContainerEnv.
+	if err := a.applyConfigEnv(env); err != nil {
 		return nil, err
-	}
-	for k, v := range envCommandValues {
-		env[k] = v
 	}
 
 	// Emit each var once, in a stable (sorted) order for deterministic args.

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -87,36 +87,7 @@ func (a *App) shellCommand(cmd *cobra.Command, args []string) error {
 	pipeline := &session.Pipeline{}
 	defer pipeline.Teardown()
 
-	// Signal handler: explicitly trigger cleanup when SIGINT/SIGTERM arrives
-	// while runCLI is blocking on an interactive incus exec.
-	//
-	// We cannot use ctx.Done() as the "signal received" branch because
-	// signal.NotifyContext cancels ctx AND delivers to sigChan at the same
-	// time — a select over both is non-deterministic. If ctx.Done() is chosen,
-	// the goroutine exits without calling Teardown, leaving cleanup to the
-	// deferred call, which won't run until the blocking incus exec returns.
-	//
-	// Instead we use a dedicated `done` channel closed when shellCommand
-	// returns. On signal, cleanup is always called. On normal return, the
-	// goroutine exits via the done branch without a second cleanup attempt
-	// (pipeline.Teardown is idempotent). signal.Stop ensures no further
-	// signals are queued after shellCommand returns.
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigChan)
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		select {
-		case <-sigChan:
-			fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cleaning up...\n")
-			pipeline.Teardown()
-		case <-done:
-		}
-	}()
-
-	return pipeline.Run(
-		ctx,
+	return runPipelineWithSignals(ctx, pipeline,
 		a.resolveWorkspacePhase(cmd, s),
 		a.validateEnvPhase(cmd, s),
 		a.configureSessionPhase(cmd, s),
@@ -297,28 +268,10 @@ func (a *App) buildContainerEnv(result *session.SetupResult) (map[string]string,
 		containerEnv["TZ"] = result.Timezone
 	}
 
-	// Apply static environment from config (defaults.environment + profile environment)
-	for k, v := range a.cfg.Defaults.Environment {
-		containerEnv[k] = v
-	}
-
-	// Resolve forward_env from config, deduplicate, then look up host values
-	for _, name := range a.cfg.Defaults.ForwardEnv {
-		if val, ok := os.LookupEnv(name); ok {
-			containerEnv[name] = val
-		} else {
-			fmt.Fprintf(os.Stderr, "Warning: forward_env variable %q is not set on host, skipping\n", name)
-		}
-	}
-
-	// Command-sourced env vars (highest precedence — freshly minted per session).
-	// Applied last so a minted value wins over static environment/forward_env.
-	envCommandValues, err := a.resolveEnvCommands()
-	if err != nil {
+	// Apply the config-sourced env layers (defaults.environment -> forward_env ->
+	// env_commands, last-wins), shared with coi run's appendEnvArgs.
+	if err := a.applyConfigEnv(containerEnv); err != nil {
 		return nil, nil, err
-	}
-	for k, v := range envCommandValues {
-		containerEnv[k] = v
 	}
 
 	// Sanitize TERM if user explicitly provided it via config


### PR DESCRIPTION
Next item from the refactoring review (Tier-1 #3, safe subset). **Internal-only, behavior-preserving.**

`coi shell` and `coi run` carried two duplicated blocks (a real drift risk — cli review finding #1/#5):

- **`(*App).applyConfigEnv(env)`** — the config-env middle: `[defaults].environment` → `forward_env` (identical unset-var warning) → `env_commands` (last-wins, fatal on error). `buildContainerEnv`/`appendEnvArgs` keep their path-specific baseline + emit.
- **`runPipelineWithSignals(ctx, pipeline, phases...)`** — the byte-identical SIGINT/SIGTERM handler goroutine + `pipeline.Run(ctx, …)`. Each caller keeps its own `pipeline :=` and `defer pipeline.Teardown()` (idempotent), so semantics are unchanged.

Both live in `cli/common.go`. Same precedence, warning text, fatal-on-env-command-error, and signal handling.

## Left alone (deliberate)
The **slot-allocation** duplication — `shell` prints "Reusing **stopped** persistent container on slot %d" while `run` prints "Reusing persistent container on slot %d". A shared helper would change user-facing output, so it stays distinct (per the review caveat).

## Verification
`go build ./...`, `go vet ./...`, `go test ./...` (23 pkgs), `golangci-lint` 0 issues, `gofmt` clean.