### PR TITLE
refactor(monitor): ThreatEvent factory + FormatSnapshot section writers

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -42,6 +43,22 @@ func (d *Detector) WithProcessSpawnRateThreshold(threshold int) *Detector {
 }
 
 // Analyze examines a snapshot and returns detected threats
+// newThreatEvent builds a ThreatEvent with the fields every detection shares —
+// a fresh UUID, the snapshot timestamp, and the "pending" (not-yet-actioned)
+// state — so each detection block only supplies what differs.
+func newThreatEvent(ts time.Time, level ThreatLevel, category, title, description string, ev Evidence) ThreatEvent {
+	return ThreatEvent{
+		ID:          uuid.New().String(),
+		Timestamp:   ts,
+		Level:       level,
+		Category:    category,
+		Title:       title,
+		Description: description,
+		Evidence:    ev,
+		Action:      "pending",
+	}
+}
+
 func (d *Detector) Analyze(snapshot MonitorSnapshot) []ThreatEvent {
 	var threats []ThreatEvent
 
@@ -49,17 +66,8 @@ func (d *Detector) Analyze(snapshot MonitorSnapshot) []ThreatEvent {
 	if snapshot.Processes.Available {
 		reverseShells := DetectReverseShells(snapshot.Processes.Processes)
 		for _, rs := range reverseShells {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelCritical,
-				Category:  "process",
-				Title:     "Reverse shell detected",
-				Description: fmt.Sprintf("Process '%s' (PID %d) matches reverse shell pattern '%s'",
-					rs.Command, rs.PID, rs.Pattern),
-				Evidence: Evidence{Process: &rs},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelCritical, "process", "Reverse shell detected", fmt.Sprintf("Process '%s' (PID %d) matches reverse shell pattern '%s'",
+				rs.Command, rs.PID, rs.Pattern), Evidence{Process: &rs}))
 		}
 	}
 
@@ -67,17 +75,8 @@ func (d *Detector) Analyze(snapshot MonitorSnapshot) []ThreatEvent {
 	if snapshot.Processes.Available {
 		envScans := DetectEnvScanning(snapshot.Processes.Processes)
 		for _, es := range envScans {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelWarning,
-				Category:  "environment",
-				Title:     "Environment variable scanning detected",
-				Description: fmt.Sprintf("Process '%s' (PID %d) is accessing environment variables",
-					es.Command, es.PID),
-				Evidence: Evidence{Process: &es},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelWarning, "environment", "Environment variable scanning detected", fmt.Sprintf("Process '%s' (PID %d) is accessing environment variables",
+				es.Command, es.PID), Evidence{Process: &es}))
 		}
 	}
 
@@ -97,86 +96,41 @@ func (d *Detector) Analyze(snapshot MonitorSnapshot) []ThreatEvent {
 			level = ThreatLevelCritical
 		}
 
-		threats = append(threats, ThreatEvent{
-			ID:        uuid.New().String(),
-			Timestamp: snapshot.Timestamp,
-			Level:     level,
-			Category:  "network",
-			Title:     "Unexpected network connection",
-			Description: fmt.Sprintf("Connection to %s: %s",
-				conn.RemoteAddr, conn.SuspectReason),
-			Evidence: Evidence{Network: &NetworkThreat{
-				Connection: conn,
-				Reason:     conn.SuspectReason,
-				RemoteHost: extractIP(conn.RemoteAddr),
-			}},
-			Action: "pending",
-		})
+		threats = append(threats, newThreatEvent(snapshot.Timestamp, level, "network", "Unexpected network connection", fmt.Sprintf("Connection to %s: %s",
+			conn.RemoteAddr, conn.SuspectReason), Evidence{Network: &NetworkThreat{
+			Connection: conn,
+			Reason:     conn.SuspectReason,
+			RemoteHost: extractIP(conn.RemoteAddr),
+		}}))
 	}
 
 	// 4. Detect large workspace reads (possible data exfiltration)
 	if snapshot.Filesystem.Available {
 		fsExfil := DetectLargeReads(snapshot.Filesystem, d.fileReadThresholdMB, d.fileReadRateMBPerSec)
 		if fsExfil != nil {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelHigh,
-				Category:  "filesystem",
-				Title:     "Large workspace read detected",
-				Description: fmt.Sprintf("Read %.2f MB at %.2f MB/sec (threshold: %.2f MB)",
-					fsExfil.ReadBytesMB, fsExfil.ReadRate, fsExfil.Threshold),
-				Evidence: Evidence{Filesystem: fsExfil},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelHigh, "filesystem", "Large workspace read detected", fmt.Sprintf("Read %.2f MB at %.2f MB/sec (threshold: %.2f MB)",
+				fsExfil.ReadBytesMB, fsExfil.ReadRate, fsExfil.Threshold), Evidence{Filesystem: fsExfil}))
 		}
 
 		// 4b. Detect large workspace writes (possible data exfiltration via tar, dd, etc.)
 		fsWriteExfil := DetectLargeWrites(snapshot.Filesystem, d.fileWriteThresholdMB, d.fileWriteRateMBPerSec)
 		if fsWriteExfil != nil {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelHigh,
-				Category:  "filesystem",
-				Title:     "Large workspace write detected",
-				Description: fmt.Sprintf("Write %.2f MB at %.2f MB/sec (threshold: %.2f MB)",
-					fsWriteExfil.WriteBytesMB, fsWriteExfil.WriteRate, fsWriteExfil.Threshold),
-				Evidence: Evidence{FileWrite: fsWriteExfil},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelHigh, "filesystem", "Large workspace write detected", fmt.Sprintf("Write %.2f MB at %.2f MB/sec (threshold: %.2f MB)",
+				fsWriteExfil.WriteBytesMB, fsWriteExfil.WriteRate, fsWriteExfil.Threshold), Evidence{FileWrite: fsWriteExfil}))
 		}
 	}
 
 	// 5. Detect process count spike (fork bomb / runaway spawner)
 	if snapshot.Processes.Available {
 		if spike := DetectProcessCountSpike(snapshot.Processes, d.processCountThreshold); spike != nil {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelCritical,
-				Category:  "process",
-				Title:     "Process count spike detected",
-				Description: fmt.Sprintf("Container has %d processes (threshold: %d) — possible fork bomb or runaway spawner",
-					spike.Count, spike.Threshold),
-				Evidence: Evidence{ProcessCount: spike},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelCritical, "process", "Process count spike detected", fmt.Sprintf("Container has %d processes (threshold: %d) — possible fork bomb or runaway spawner",
+				spike.Count, spike.Threshold), Evidence{ProcessCount: spike}))
 		}
 
 		// 5b. Detect process spawn rate (delta-based fork-bomb detection)
 		if rate := DetectProcessSpawnRate(snapshot.Processes.TotalCount, d.previousProcessCount, d.processSpawnRateThreshold); rate != nil {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelCritical,
-				Category:  "process",
-				Title:     "Process spawn rate spike detected",
-				Description: fmt.Sprintf("Container spawned %d new processes in one poll interval (threshold: %d)",
-					rate.Delta, rate.Threshold),
-				Evidence: Evidence{ProcessCount: rate},
-				Action:   "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelCritical, "process", "Process spawn rate spike detected", fmt.Sprintf("Container spawned %d new processes in one poll interval (threshold: %d)",
+				rate.Delta, rate.Threshold), Evidence{ProcessCount: rate}))
 		}
 		d.previousProcessCount = snapshot.Processes.TotalCount
 	} else {
@@ -189,23 +143,14 @@ func (d *Detector) Analyze(snapshot MonitorSnapshot) []ThreatEvent {
 	if snapshot.Filesystem.Available && snapshot.Filesystem.TmpTotalMB > 0 {
 		// Warn if /tmp is >80% full
 		if snapshot.Filesystem.TmpUsedPercent > 80 {
-			threats = append(threats, ThreatEvent{
-				ID:        uuid.New().String(),
-				Timestamp: snapshot.Timestamp,
-				Level:     ThreatLevelWarning,
-				Category:  "filesystem",
-				Title:     "Low disk space on /tmp",
-				Description: fmt.Sprintf("/tmp is %.1f%% full (%.0fMB used of %.0fMB total). Consider increasing tmpfs_size in config.",
-					snapshot.Filesystem.TmpUsedPercent,
-					snapshot.Filesystem.TmpUsedMB,
-					snapshot.Filesystem.TmpTotalMB),
-				Evidence: Evidence{DiskSpace: &DiskSpaceInfo{
-					TmpUsedMB:      snapshot.Filesystem.TmpUsedMB,
-					TmpTotalMB:     snapshot.Filesystem.TmpTotalMB,
-					TmpUsedPercent: snapshot.Filesystem.TmpUsedPercent,
-				}},
-				Action: "pending",
-			})
+			threats = append(threats, newThreatEvent(snapshot.Timestamp, ThreatLevelWarning, "filesystem", "Low disk space on /tmp", fmt.Sprintf("/tmp is %.1f%% full (%.0fMB used of %.0fMB total). Consider increasing tmpfs_size in config.",
+				snapshot.Filesystem.TmpUsedPercent,
+				snapshot.Filesystem.TmpUsedMB,
+				snapshot.Filesystem.TmpTotalMB), Evidence{DiskSpace: &DiskSpaceInfo{
+				TmpUsedMB:      snapshot.Filesystem.TmpUsedMB,
+				TmpTotalMB:     snapshot.Filesystem.TmpTotalMB,
+				TmpUsedPercent: snapshot.Filesystem.TmpUsedPercent,
+			}}))
 		}
 	}
 

--- a/internal/monitor/formatter.go
+++ b/internal/monitor/formatter.go
@@ -9,16 +9,30 @@ import (
 // FormatSnapshot formats a monitoring snapshot as human-readable text
 func FormatSnapshot(snapshot MonitorSnapshot) string {
 	var sb strings.Builder
+	writeHeader(&sb, snapshot)
+	writeThreats(&sb, snapshot)
+	writeNetwork(&sb, snapshot)
+	writeProcesses(&sb, snapshot)
+	writeFilesystem(&sb, snapshot)
+	writeResources(&sb, snapshot)
+	writeErrors(&sb, snapshot)
+	return sb.String()
+}
 
+// writeHeader appends its section of the monitor snapshot to sb.
+func writeHeader(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Header
-	fmt.Fprintf(&sb, "Container: %s", snapshot.ContainerName)
+	fmt.Fprintf(sb, "Container: %s", snapshot.ContainerName)
 	if snapshot.ContainerIP != "" {
-		fmt.Fprintf(&sb, " (%s)", snapshot.ContainerIP)
+		fmt.Fprintf(sb, " (%s)", snapshot.ContainerIP)
 	}
 	sb.WriteString("\n")
-	fmt.Fprintf(&sb, "Timestamp: %s\n", snapshot.Timestamp.Format(time.RFC3339))
+	fmt.Fprintf(sb, "Timestamp: %s\n", snapshot.Timestamp.Format(time.RFC3339))
 	sb.WriteString(strings.Repeat("━", 70) + "\n\n")
+}
 
+// writeThreats appends its section of the monitor snapshot to sb.
+func writeThreats(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Threats summary
 	if len(snapshot.Threats) > 0 {
 		criticalCount := 0
@@ -71,22 +85,25 @@ func FormatSnapshot(snapshot MonitorSnapshot) string {
 				levelStr = "INFO    "
 			}
 
-			fmt.Fprintf(&sb, "  [%s] %s  %s\n",
+			fmt.Fprintf(sb, "  [%s] %s  %s\n",
 				threat.Timestamp.Format("15:04:05"),
 				levelStr,
 				threat.Title)
-			fmt.Fprintf(&sb, "                      %s\n", threat.Description)
+			fmt.Fprintf(sb, "                      %s\n", threat.Description)
 			if threat.Action != "" && threat.Action != "logged" {
-				fmt.Fprintf(&sb, "                      → Action: %s\n", threat.Action)
+				fmt.Fprintf(sb, "                      → Action: %s\n", threat.Action)
 			}
 			sb.WriteString("\n")
 		}
 	}
+}
 
+// writeNetwork appends its section of the monitor snapshot to sb.
+func writeNetwork(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Network stats
-	fmt.Fprintf(&sb, "NETWORK (%d active connections", snapshot.Network.ActiveConnections)
+	fmt.Fprintf(sb, "NETWORK (%d active connections", snapshot.Network.ActiveConnections)
 	if snapshot.Network.SuspiciousCount > 0 {
-		fmt.Fprintf(&sb, ", %d suspicious", snapshot.Network.SuspiciousCount)
+		fmt.Fprintf(sb, ", %d suspicious", snapshot.Network.SuspiciousCount)
 	}
 	sb.WriteString(")\n")
 
@@ -97,17 +114,20 @@ func FormatSnapshot(snapshot MonitorSnapshot) string {
 			if conn.Suspicious {
 				status = "⚠ SUSPICIOUS"
 			}
-			fmt.Fprintf(&sb, "  %-8s  %-18s  %-18s  %-11s  %s\n",
+			fmt.Fprintf(sb, "  %-8s  %-18s  %-18s  %-11s  %s\n",
 				conn.Protocol, conn.LocalAddr, conn.RemoteAddr, conn.State, status)
 		}
 	} else {
 		sb.WriteString("  No active connections\n")
 	}
 	sb.WriteString("\n")
+}
 
+// writeProcesses appends its section of the monitor snapshot to sb.
+func writeProcesses(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Process stats
 	if snapshot.Processes.Available {
-		fmt.Fprintf(&sb, "PROCESSES (%d running)\n", snapshot.Processes.TotalCount)
+		fmt.Fprintf(sb, "PROCESSES (%d running)\n", snapshot.Processes.TotalCount)
 		if len(snapshot.Processes.Processes) > 0 {
 			sb.WriteString("  PID    User   Command                                  Flags\n")
 			for _, proc := range snapshot.Processes.Processes {
@@ -122,7 +142,7 @@ func FormatSnapshot(snapshot MonitorSnapshot) string {
 					cmd = cmd[:37] + "..."
 				}
 
-				fmt.Fprintf(&sb, "  %-6d %-6s %-40s %s\n",
+				fmt.Fprintf(sb, "  %-6d %-6s %-40s %s\n",
 					proc.PID, proc.User, cmd, flags)
 			}
 		}
@@ -130,41 +150,48 @@ func FormatSnapshot(snapshot MonitorSnapshot) string {
 		sb.WriteString("PROCESSES\n  Not available\n")
 	}
 	sb.WriteString("\n")
+}
 
+// writeFilesystem appends its section of the monitor snapshot to sb.
+func writeFilesystem(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Filesystem stats
 	if snapshot.Filesystem.Available {
 		sb.WriteString("FILESYSTEM\n")
-		fmt.Fprintf(&sb, "  Workspace Reads:  %.2f MB (%.2f MB/sec)\n",
+		fmt.Fprintf(sb, "  Workspace Reads:  %.2f MB (%.2f MB/sec)\n",
 			snapshot.Filesystem.TotalReadMB, snapshot.Filesystem.ReadRateMBPerSec)
 		if snapshot.Filesystem.FilesAccessed > 0 {
-			fmt.Fprintf(&sb, "  Files Accessed:   %d\n", snapshot.Filesystem.FilesAccessed)
+			fmt.Fprintf(sb, "  Files Accessed:   %d\n", snapshot.Filesystem.FilesAccessed)
 		}
 	} else {
 		sb.WriteString("FILESYSTEM\n  Not available\n")
 	}
 	sb.WriteString("\n")
+}
 
+// writeResources appends its section of the monitor snapshot to sb.
+func writeResources(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Resource stats
 	sb.WriteString("RESOURCES\n")
-	fmt.Fprintf(&sb, "  CPU:     %.1fs total (%.1fs user, %.1fs system)\n",
+	fmt.Fprintf(sb, "  CPU:     %.1fs total (%.1fs user, %.1fs system)\n",
 		snapshot.Resources.CPUTimeSeconds, snapshot.Resources.UserCPUSeconds, snapshot.Resources.SysCPUSeconds)
 	if snapshot.Resources.MemoryLimitMB > 0 {
 		memPercent := (snapshot.Resources.MemoryMB / snapshot.Resources.MemoryLimitMB) * 100
-		fmt.Fprintf(&sb, "  Memory:  %.0f MB / %.0f MB (%.1f%%)\n",
+		fmt.Fprintf(sb, "  Memory:  %.0f MB / %.0f MB (%.1f%%)\n",
 			snapshot.Resources.MemoryMB, snapshot.Resources.MemoryLimitMB, memPercent)
 	} else {
-		fmt.Fprintf(&sb, "  Memory:  %.0f MB\n", snapshot.Resources.MemoryMB)
+		fmt.Fprintf(sb, "  Memory:  %.0f MB\n", snapshot.Resources.MemoryMB)
 	}
-	fmt.Fprintf(&sb, "  I/O:     %.0f MB read, %.0f MB write\n",
+	fmt.Fprintf(sb, "  I/O:     %.0f MB read, %.0f MB write\n",
 		snapshot.Resources.IOReadMB, snapshot.Resources.IOWriteMB)
+}
 
+// writeErrors appends its section of the monitor snapshot to sb.
+func writeErrors(sb *strings.Builder, snapshot MonitorSnapshot) {
 	// Errors
 	if len(snapshot.Errors) > 0 {
 		sb.WriteString("\nERRORS\n")
 		for _, err := range snapshot.Errors {
-			fmt.Fprintf(&sb, "  - %s\n", err)
+			fmt.Fprintf(sb, "  - %s\n", err)
 		}
 	}
-
-	return sb.String()
 }


### PR DESCRIPTION
Next item from the refactoring review (Tier-2 #8). **Internal-only, behavior-preserving.**

Two self-contained decompositions in `internal/monitor` (well-unit-tested, no integration coupling):

- **`detector.go`** — the 8 `ThreatEvent` literals in `Analyze()` each repeated `ID: uuid.New().String(), Timestamp: snapshot.Timestamp, …, Action: "pending"`. Add **`newThreatEvent(ts, level, category, title, description, ev)`** so each detection block supplies only what differs (UUID still minted once per event). `Analyze()`: **168 → 97 lines**.
- **`formatter.go`** — `FormatSnapshot()` was one ~160-line function with six independent sections sharing one `strings.Builder`. Split into `writeHeader`/`writeThreats`/`writeNetwork`/`writeProcesses`/`writeFilesystem`/`writeResources`/`writeErrors` (each appends its section verbatim). `FormatSnapshot()`: **160 → 11 lines**.

## Safety
The `newThreatEvent` conversion preserves each block's `level` var, multi-line `fmt.Sprintf`, and nested `Evidence`; the split writers are verbatim moves. **The formatter unit test pins byte-exact output** and passes unchanged.

## Verification
`go build ./...`, `go vet ./...`, `go test ./...` (23 pkgs), **`golangci-lint` 0 issues**, `gofmt`/`gofumpt` clean.