### PR TITLE
refactor: case-insensitive status checks + shared security device prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Changed
 
+- **Consistent, case-insensitive container-status checks + a single source of truth for security device prefixes (robustness cleanup)** — Incus reports lifecycle state as `Running`/`Stopped` via the JSON API but upper-case in some `incus list` formats; call sites had drifted between exact `== "Running"` comparisons and `strings.EqualFold`, so a status read from the "wrong" surface could be silently misclassified. All checks now go through shared `container.StatusIsRunning`/`StatusIsStopped` helpers. Separately, the security disk-device prefixes (`protect-`/`mask-`/`gitc-`) were three independent string literals on the create side that had to stay in sync with the reuse-strip list by hand; they're now shared constants, with a test (`TestSecurityDeviceNamesAreStripped`) asserting every device-name generator produces a name the strip list removes — so a new family can't leak across persistent reuse (the #610 class). No behavior change.
+
 - **Trimmed the injected `SANDBOX_CONTEXT.md` ~30% to save per-session tokens (#718)** — the sandbox context prepended to the agent's instructions every session dropped from ~2,260 to ~1,570 tokens (SSH+GitHub case) by removing sections that only restated others: `What You Can Do` and `Best Practices` duplicated the autonomy, mise, and file-ownership guidance already present elsewhere. All distinct instructions are preserved (a second, deliberate autonomy reminder is kept), and the triplicated git-identity block is now a set of shared template blocks so the three auth variants no longer drift. No behavior or config changes.
 
 ### Fixed

--- a/internal/alias/resolve.go
+++ b/internal/alias/resolve.go
@@ -149,7 +149,7 @@ func FindContainersByAlias(alias string) ([]string, error) {
 		status, _ := c["status"].(string)
 
 		// Only consider running containers
-		if status != "Running" {
+		if !container.StatusIsRunning(status) {
 			continue
 		}
 

--- a/internal/cleanup/orphans.go
+++ b/internal/cleanup/orphans.go
@@ -175,7 +175,7 @@ func getRunningContainerIPs() ([]string, error) {
 
 	var ips []string
 	for _, c := range containers {
-		if c.State.Status != "Running" {
+		if !container.StatusIsRunning(c.State.Status) {
 			continue
 		}
 		if eth0, ok := c.State.Network["eth0"]; ok {

--- a/internal/cleanup/orphans.go
+++ b/internal/cleanup/orphans.go
@@ -142,7 +142,7 @@ func getRunningContainerNames() ([]string, error) {
 
 	var names []string
 	for _, c := range containers {
-		if c.State.Status == "Running" {
+		if container.StatusIsRunning(c.State.Status) {
 			names = append(names, c.Name)
 		}
 	}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -160,7 +160,7 @@ func cleanStoppedContainers() (int, bool, error) {
 
 	stoppedContainers := []string{}
 	for _, c := range containers {
-		if c.Status == "Stopped" || c.Status == "STOPPED" {
+		if container.StatusIsStopped(c.Status) {
 			stoppedContainers = append(stoppedContainers, c.Name)
 		}
 	}

--- a/internal/cli/top.go
+++ b/internal/cli/top.go
@@ -232,7 +232,7 @@ func sampleContainerRows(ctx context.Context, interval time.Duration) ([]contain
 	}
 	running := make([]incusTopEntry, 0, len(entries0))
 	for _, e := range entries0 {
-		if strings.EqualFold(e.Status, "Running") {
+		if container.StatusIsRunning(e.Status) {
 			running = append(running, e)
 		}
 	}
@@ -409,7 +409,7 @@ func resolveProcNames(only string) ([]string, error) {
 	}
 	var names []string
 	for _, e := range entries {
-		if strings.EqualFold(e.Status, "Running") {
+		if container.StatusIsRunning(e.Status) {
 			names = append(names, e.Name)
 		}
 	}

--- a/internal/cli/unfreeze.go
+++ b/internal/cli/unfreeze.go
@@ -48,7 +48,7 @@ func unfreezeContainer(name string) error {
 		return fmt.Errorf("container %s not found: %w", name, err)
 	}
 
-	if status != "Frozen" {
+	if !container.StatusIsFrozen(status) {
 		return fmt.Errorf("container %s is not frozen (status: %s)", name, status)
 	}
 
@@ -89,7 +89,7 @@ func unfreezeAllFrozen() error {
 			continue
 		}
 
-		if status == "FROZEN" {
+		if container.StatusIsFrozen(status) {
 			if err := unfreezeContainer(name); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to unfreeze %s: %v\n", name, err)
 			} else {
@@ -118,7 +118,7 @@ func getContainerStatus(name string) (string, error) {
 		return "", fmt.Errorf("container not found")
 	}
 	// Normalize status
-	if status == "FROZEN" {
+	if container.StatusIsFrozen(status) {
 		return "Frozen", nil
 	}
 	return status, nil

--- a/internal/container/commands.go
+++ b/internal/container/commands.go
@@ -953,7 +953,7 @@ func ContainerRunning(containerName string) (bool, error) {
 	}
 
 	for _, c := range containers {
-		if c.Name == containerName && c.Status == "Running" {
+		if c.Name == containerName && StatusIsRunning(c.Status) {
 			return true, nil
 		}
 	}

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -1,0 +1,18 @@
+package container
+
+import "strings"
+
+// Incus reports a container's lifecycle state as a string. The JSON API returns
+// title case ("Running", "Stopped", "Frozen"), while some `incus list` output
+// formats report upper case ("RUNNING", "STOPPED"). Comparing case-sensitively
+// therefore silently misses states depending on which surface produced the
+// value — the reason scattered call sites diverged between `== "Running"` and
+// `strings.EqualFold`. Always compare through these helpers.
+
+// StatusIsRunning reports whether an Incus status string means "running",
+// case-insensitively.
+func StatusIsRunning(status string) bool { return strings.EqualFold(status, "running") }
+
+// StatusIsStopped reports whether an Incus status string means "stopped",
+// case-insensitively.
+func StatusIsStopped(status string) bool { return strings.EqualFold(status, "stopped") }

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -16,3 +16,7 @@ func StatusIsRunning(status string) bool { return strings.EqualFold(status, "run
 // StatusIsStopped reports whether an Incus status string means "stopped",
 // case-insensitively.
 func StatusIsStopped(status string) bool { return strings.EqualFold(status, "stopped") }
+
+// StatusIsFrozen reports whether an Incus status string means "frozen" (paused),
+// case-insensitively.
+func StatusIsFrozen(status string) bool { return strings.EqualFold(status, "frozen") }

--- a/internal/container/status_test.go
+++ b/internal/container/status_test.go
@@ -1,0 +1,29 @@
+package container
+
+import "testing"
+
+func TestStatusIsRunning(t *testing.T) {
+	for _, s := range []string{"Running", "RUNNING", "running"} {
+		if !StatusIsRunning(s) {
+			t.Errorf("StatusIsRunning(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"Stopped", "STOPPED", "Frozen", "", "run"} {
+		if StatusIsRunning(s) {
+			t.Errorf("StatusIsRunning(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestStatusIsStopped(t *testing.T) {
+	for _, s := range []string{"Stopped", "STOPPED", "stopped"} {
+		if !StatusIsStopped(s) {
+			t.Errorf("StatusIsStopped(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"Running", "RUNNING", "Frozen", ""} {
+		if StatusIsStopped(s) {
+			t.Errorf("StatusIsStopped(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/container/status_test.go
+++ b/internal/container/status_test.go
@@ -27,3 +27,16 @@ func TestStatusIsStopped(t *testing.T) {
 		}
 	}
 }
+
+func TestStatusIsFrozen(t *testing.T) {
+	for _, s := range []string{"Frozen", "FROZEN", "frozen"} {
+		if !StatusIsFrozen(s) {
+			t.Errorf("StatusIsFrozen(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"Running", "Stopped", ""} {
+		if StatusIsFrozen(s) {
+			t.Errorf("StatusIsFrozen(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/health/checks_probe.go
+++ b/internal/health/checks_probe.go
@@ -610,7 +610,7 @@ func CheckProcessMonitoringCapability(imageName string) HealthCheck {
 
 	var testContainer string
 	for _, c := range containers {
-		if status, ok := c["status"].(string); ok && status == "Running" {
+		if status, ok := c["status"].(string); ok && container.StatusIsRunning(status) {
 			if name, ok := c["name"].(string); ok {
 				testContainer = name
 				break

--- a/internal/health/checks_status.go
+++ b/internal/health/checks_status.go
@@ -41,7 +41,7 @@ func CheckActiveContainers() HealthCheck {
 	// Count running containers
 	running := 0
 	for _, c := range containers {
-		if status, ok := c["status"].(string); ok && status == "Running" {
+		if status, ok := c["status"].(string); ok && container.StatusIsRunning(status) {
 			running++
 		}
 	}
@@ -221,7 +221,7 @@ func CheckOrphanedResources() HealthCheck {
 			}
 			if json.Unmarshal([]byte(output), &containers) == nil {
 				for _, c := range containers {
-					if c.State.Status == "Running" {
+					if container.StatusIsRunning(c.State.Status) {
 						containerNames[c.Name] = true
 						if eth0, ok := c.State.Network["eth0"]; ok {
 							for _, addr := range eth0.Addresses {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -728,7 +728,7 @@ func otherContainersRunning(jsonOutput, excludeName string) bool {
 		return true // conservative: can't confirm no other containers, keep rules
 	}
 	for _, c := range containers {
-		if c.Name != excludeName && c.State.Status == "Running" {
+		if c.Name != excludeName && container.StatusIsRunning(c.State.Status) {
 			return true
 		}
 	}

--- a/internal/session/naming.go
+++ b/internal/session/naming.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/mensfeld/code-on-incus/internal/container"
 )
@@ -153,7 +152,7 @@ func FindReusablePersistentSlot(workspacePath, sessionName string, maxSlots int)
 	re := regexp.MustCompile(fmt.Sprintf(`^%s(\d+)$`, regexp.QuoteMeta(prefix)))
 	best := 0
 	for _, c := range containers {
-		if !strings.EqualFold(c.Status, "stopped") {
+		if !container.StatusIsStopped(c.Status) {
 			continue
 		}
 		if m := re.FindStringSubmatch(c.Name); len(m) > 1 {

--- a/internal/session/secret_masks.go
+++ b/internal/session/secret_masks.go
@@ -109,7 +109,7 @@ func ExpandSecretPaths(workspacePath string, secretPaths []string) (masks []secr
 // second MountDisk would fail). The hash is collision-free and stable per path.
 func maskDeviceName(relPath string) string {
 	sum := sha256.Sum256([]byte(relPath))
-	return "mask-" + hex.EncodeToString(sum[:])[:16]
+	return maskDevicePrefix + hex.EncodeToString(sum[:])[:16]
 }
 
 // ensureMaskSources creates the empty file and empty directory used as read-only

--- a/internal/session/security.go
+++ b/internal/session/security.go
@@ -69,24 +69,25 @@ type securityDeviceStripper interface {
 	RemoveDevice(name string) error
 }
 
-// stripSecurityDevicePrefixes name the disk-device families whose host sources
+// Device-name prefixes for the security disk-device families whose host sources
 // are (re)established by the fresh-launch security setup: workspace-relative
 // protected paths (protect-), secret masks (mask-, sourced under ~/.coi/masks),
-// and the read-only git worktree common-dir overlays (gitc-). The read-WRITE base
-// mounts these overlay (workspace, git-worktree-common) are deliberately NOT here.
-// Device-name prefixes for the security disk-device families. Each generator
+// and the read-only git worktree common-dir overlays (gitc-). Each generator
 // (pathToDeviceName, maskDeviceName, commonDirDeviceName) builds its name from
-// the matching constant, and stripSecurityDevicePrefixes lists the same
-// constants — so the create side and the reuse-strip side share one source of
-// truth and cannot diverge (a new family added without stripping it would leak
-// across reuse, the #610 class). TestSecurityDeviceNamesAreStripped verifies the
-// coupling for every generator.
+// the matching constant here, and stripSecurityDevicePrefixes below lists the
+// same constants — so the create side and the reuse-strip side share one source
+// of truth and cannot diverge (a new family added without stripping it would
+// leak across reuse, the #610 class; TestSecurityDeviceNamesAreStripped verifies
+// the coupling for every generator). The read-WRITE base mounts these overlay
+// (workspace, git-worktree-common) are deliberately NOT here.
 const (
 	protectDevicePrefix = "protect-"
 	maskDevicePrefix    = "mask-"
 	gitcDevicePrefix    = "gitc-"
 )
 
+// stripSecurityDevicePrefixes is the reuse-strip list; it MUST list exactly the
+// prefixes above (each family created is a family stripped on reuse).
 var stripSecurityDevicePrefixes = []string{protectDevicePrefix, maskDevicePrefix, gitcDevicePrefix}
 
 // StripSecurityDevices removes the creation-time security device families (see

--- a/internal/session/security.go
+++ b/internal/session/security.go
@@ -74,7 +74,20 @@ type securityDeviceStripper interface {
 // protected paths (protect-), secret masks (mask-, sourced under ~/.coi/masks),
 // and the read-only git worktree common-dir overlays (gitc-). The read-WRITE base
 // mounts these overlay (workspace, git-worktree-common) are deliberately NOT here.
-var stripSecurityDevicePrefixes = []string{"protect-", "mask-", "gitc-"}
+// Device-name prefixes for the security disk-device families. Each generator
+// (pathToDeviceName, maskDeviceName, commonDirDeviceName) builds its name from
+// the matching constant, and stripSecurityDevicePrefixes lists the same
+// constants — so the create side and the reuse-strip side share one source of
+// truth and cannot diverge (a new family added without stripping it would leak
+// across reuse, the #610 class). TestSecurityDeviceNamesAreStripped verifies the
+// coupling for every generator.
+const (
+	protectDevicePrefix = "protect-"
+	maskDevicePrefix    = "mask-"
+	gitcDevicePrefix    = "gitc-"
+)
+
+var stripSecurityDevicePrefixes = []string{protectDevicePrefix, maskDevicePrefix, gitcDevicePrefix}
 
 // StripSecurityDevices removes the creation-time security device families (see
 // stripSecurityDevicePrefixes) from a REUSED persistent container, so the caller
@@ -502,8 +515,9 @@ func pathToDeviceName(path string) string {
 	name = strings.ReplaceAll(name, ".", "")
 	// Remove leading dash if present
 	name = strings.TrimPrefix(name, "-")
-	// Prefix with "protect-" for clarity
-	return "protect-" + name
+	// Prefix for clarity + so the reuse-strip path (stripSecurityDevicePrefixes)
+	// removes it.
+	return protectDevicePrefix + name
 }
 
 // GetProtectedPathsForLogging returns a human-readable list of protected paths

--- a/internal/session/security_device_prefix_test.go
+++ b/internal/session/security_device_prefix_test.go
@@ -1,0 +1,33 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSecurityDeviceNamesAreStripped proves the create side and the
+// reuse-strip side can't diverge: every security device-name generator produces
+// a name that stripSecurityDevicePrefixes will remove on persistent reuse. If a
+// new security device family is added, add its generator here — a name whose
+// prefix isn't in the strip list would leak the device across reuse (the #610
+// class: a stale protected/masked device outliving the config that created it).
+func TestSecurityDeviceNamesAreStripped(t *testing.T) {
+	cases := map[string]string{
+		"protect": pathToDeviceName(".git/hooks"),
+		"mask":    maskDeviceName("secrets/.env"),
+		"gitc":    commonDirDeviceName("worktree-1"),
+	}
+	for family, name := range cases {
+		stripped := false
+		for _, p := range stripSecurityDevicePrefixes {
+			if strings.HasPrefix(name, p) {
+				stripped = true
+				break
+			}
+		}
+		if !stripped {
+			t.Errorf("%s device name %q has no prefix in stripSecurityDevicePrefixes %v — "+
+				"it would leak across persistent reuse", family, name, stripSecurityDevicePrefixes)
+		}
+	}
+}

--- a/internal/session/worktree.go
+++ b/internal/session/worktree.go
@@ -318,7 +318,7 @@ func protectCommonDirSink(mgr container.ContainerDevices, commonDir string, s co
 // pathToDeviceName is not (it strips '.' and maps '/'→'-').
 func commonDirDeviceName(rel string) string {
 	sum := sha256.Sum256([]byte("gitcommon/" + rel))
-	return "gitc-" + hex.EncodeToString(sum[:])[:16]
+	return gitcDevicePrefix + hex.EncodeToString(sum[:])[:16]
 }
 
 // StripGitProtectedPaths removes workspace-relative `.git` / `.git/*` entries from a


### PR DESCRIPTION
The two cleanups flagged by the #708 audit. No behavior change; both are robustness/consistency fixes with tests.

## 1. Case-insensitive container-status checks

Incus reports lifecycle state as `Running`/`Stopped` via the JSON API but upper-case in some `incus list` output formats. Call sites had drifted:
- exact: `network/manager.go`, `cleanup/orphans.go`, `health/checks_status.go`, `health/checks_probe.go`, `container/commands.go`
- defensive: `cli/clean.go` (`== "Stopped" || == "STOPPED"`)
- already case-insensitive: `cli/top.go`, `session/naming.go`

So a status read from the "wrong" surface could be silently misclassified (e.g. a running container treated as not-running). Added `container.StatusIsRunning` / `StatusIsStopped` and routed every check through them. (`list.go`'s `EqualFold(c.Status, status)` is a user-filter match, left as-is.)

## 2. Single source of truth for security device prefixes

The security disk-device prefixes were three independent string literals on the **create** side (`pathToDeviceName` → `protect-`, `maskDeviceName` → `mask-`, `commonDirDeviceName` → `gitc-`) that had to be kept in sync **by hand** with `stripSecurityDevicePrefixes` (the reuse-strip list). A create-side family missing from the strip list would leak a stale protected/masked device across persistent reuse (the #610 class) — and the existing closed-world unit fake couldn't catch that.

Now the prefixes are shared constants used by both the generators and the strip list, and `TestSecurityDeviceNamesAreStripped` runs **every** generator and asserts the strip list covers its output — so the coupling can't silently break.

## Tests
`container.StatusIsRunning/StatusIsStopped` unit tests (mixed casing) + `TestSecurityDeviceNamesAreStripped`. Go build/vet/`-race`/`golangci-lint`(0)/gofmt green; no exact status comparison or hardcoded device prefix remains (verified by grep).