### PR TITLE
chore(release): date CHANGELOG for 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.12.0 (Unreleased)
+## 0.12.0 (2026-09-09)
 
 ### New Features
 


### PR DESCRIPTION
Dates the `0.12.0` CHANGELOG heading (`Unreleased` → `2026-09-09`) ahead of tagging `v0.12.0`. Docs-only.